### PR TITLE
fix alembic urev

### DIFF
--- a/api/makefile
+++ b/api/makefile
@@ -49,6 +49,10 @@ run-environment:
 stop-environment:
 	docker compose down
 
+.phony: urev
+urev:
+	bash utils/urev.sh
+
 .phony: clean
 clean:
 	find . -type d -name "__pycache__" -exec rm -rf {} +

--- a/api/migrations/alembic.ini
+++ b/api/migrations/alembic.ini
@@ -12,7 +12,7 @@ file_template = %%(year)d-%%(month).2d-%%(day).2d_%%(slug)s
 
 # sys.path path, will be prepended to sys.path if present.
 # defaults to the current working directory.
-prepend_sys_path = /
+prepend_sys_path = .
 
 # timezone to use when rendering the date within the migration file
 # as well as the filename.

--- a/api/migrations/env.py
+++ b/api/migrations/env.py
@@ -5,11 +5,6 @@ from sqlalchemy import pool
 
 import alembic.context as context
 
-import sys
-import os
-
-sys.path.append(os.path.join(sys.path[1], "../../api"))
-
 from src.buckets.model import *
 from src.gdrive.model import *
 from src.s3.model import *

--- a/api/src/utils/config.py
+++ b/api/src/utils/config.py
@@ -11,11 +11,11 @@ CHUNK_SIZE = 1024 * 1024 * 100  # 100 Mb
 
 
 class DBSettings(BaseSettings):
-    name: str = ""
-    user: str = ""
-    password: str = Field(alias="db_pass")
-    host: str = ""
-    port: int = 0
+    name: str = "postgres"
+    user: str = "postgres"
+    password: str = Field(default="postgres", alias="db_pass")
+    host: str = "localhost"
+    port: int = 5432
 
     @property
     def access_str(self) -> str:


### PR DESCRIPTION
Добавил текущую директорию в pythonpath, теперь можно запустить миграции из папки api, в т.ч. через makefile

Миграции ручкой все еще накатываются