### PR TITLE
fix exp_handler

### DIFF
--- a/api/dev.requirements.txt
+++ b/api/dev.requirements.txt
@@ -4,5 +4,5 @@ mypy==1.14.1
 pytest==8.3.2
 pytest-asyncio==0.23.8
 pytest-cov==5.0.0
-httpx==0.27.0
+httpx==0.28.0
 aiobotocore==2.15.2

--- a/api/main.py
+++ b/api/main.py
@@ -6,6 +6,7 @@ from src.users.router import router as user_router
 from src.buckets.router import router as bucket_router
 from src.gdrive.router import router as gdrive_router
 from src.setup.router import router as setup_router
+from src.utils.exceptions import endpoints_exception_handler
 
 DESCRIPTION = """
 S3aaS has **S3-complatible routes** to store/retrieve/remove data and **REST API** for administrating purposes.
@@ -38,3 +39,6 @@ app.include_router(user_router, prefix="/api/v1/users", tags=["users"])
 app.include_router(bucket_router, prefix="/api/v1/buckets", tags=["buckets"])
 app.include_router(gdrive_router, prefix="/api/v1/sources/gdrive", tags=["gdrive"])
 app.include_router(setup_router)
+
+# регистрируем функцию-обработчик ошибок
+app.exception_handler(Exception)(endpoints_exception_handler)

--- a/api/src/buckets/router.py
+++ b/api/src/buckets/router.py
@@ -4,7 +4,6 @@ from src.buckets.response import PostBucketsApiResponse
 from src.buckets.schema import BucketCreate
 from src.utils.basic_auth import UserDep
 from src.utils.dependency import UOWDep, BucketServiceDep
-from src.utils.exceptions import exception_handler
 
 router = APIRouter()
 
@@ -15,7 +14,6 @@ router = APIRouter()
     summary="Create a new bucket",
     description="Create a new bucket and generate S3 credentials for it",
 )
-@exception_handler
 async def add_bucket(
     uow: UOWDep, bucket_service: BucketServiceDep, user: UserDep, bucket: BucketCreate
 ):

--- a/api/src/buckets/service.py
+++ b/api/src/buckets/service.py
@@ -63,7 +63,7 @@ class BucketService:
         async with uow:
             old_bucket = await self._bucket_repository.get(uow.session, key=bucket.key)
             if old_bucket:
-                raise BucketExistsError
+                raise BucketExistsError()
 
             await self._bucket_repository.add(uow.session, bucket_model)
             await uow.commit()

--- a/api/src/gdrive/router.py
+++ b/api/src/gdrive/router.py
@@ -4,7 +4,6 @@ from src.gdrive.response import PostGDriveApiResponse
 from src.gdrive.schema import GDriveCreate
 from src.utils.basic_auth import UserDep
 from src.utils.dependency import UOWDep, GDriveServiceDep
-from src.utils.exceptions import exception_handler
 
 router = APIRouter()
 
@@ -15,7 +14,6 @@ router = APIRouter()
     summary="Create a new Google Drive source",
     description="Create a new Google Drive source with service account authorization by provided json key",
 )
-@exception_handler
 async def add_gdrive(
     uow: UOWDep, gdrive_service: GDriveServiceDep, user: UserDep, gdrive: GDriveCreate
 ):

--- a/api/src/s3/router.py
+++ b/api/src/s3/router.py
@@ -11,7 +11,7 @@ from src.s3.schemas import (
     PutObjectResult,
 )
 from src.utils.dependency import S3ServiceDep, UOWDep
-from src.utils.exceptions import exception_handler, AuthenticationError
+from src.utils.exceptions import AuthenticationError
 from src.utils.s3_auth import S3AuthenticatedRequestDep
 
 router = APIRouter()
@@ -24,7 +24,6 @@ router = APIRouter()
     summary="List objects",
     description="Get list of objects in the bucket (S3-compatible)",
 )
-@exception_handler
 async def list_objects(
     uow: UOWDep,
     s3_service: S3ServiceDep,
@@ -59,7 +58,6 @@ async def list_objects(
     summary="Get object",
     description="Get file contents from the bucket (S3-compatible)",
 )
-@exception_handler
 async def get_object(
     uow: UOWDep, s3_service: S3ServiceDep, request: S3AuthenticatedRequestDep, name: str
 ):
@@ -84,7 +82,6 @@ async def get_object(
     summary="Put object",
     description="Put file contents to the bucket (S3-compatible)",
 )
-@exception_handler
 async def put_object(
     uow: UOWDep,
     s3_service: S3ServiceDep,
@@ -103,7 +100,6 @@ async def put_object(
     summary="Delete object",
     description="Delete file from the bucket (S3-compatible)",
 )
-@exception_handler
 async def delete_object(
     _: S3AuthenticatedRequestDep,
     name: str,

--- a/api/src/setup/router.py
+++ b/api/src/setup/router.py
@@ -13,7 +13,6 @@ from src.setup.response import (
 )
 
 # from utils.admin_auth import AdminAuthDep  # todo добавить админскую авторизацию
-from src.utils.exceptions import exception_handler
 
 router = APIRouter()
 
@@ -64,7 +63,6 @@ async def get_publication_ready_handler():
     description="Накатывает миграции вплоть до указанной ревизии на PostgreSQL с помощью alembic. Ожидается, что в основном ручка будет вызываться с `name=head`",
     response_model=PostMigrationsUpgradeResponse,
 )
-@exception_handler
 async def post_migrations_upgrade(
     name: Annotated[str, Path(description="Название ревизии", example="head")],
     # _: AdminAuthDep,

--- a/api/src/setup/router.py
+++ b/api/src/setup/router.py
@@ -64,7 +64,7 @@ async def get_publication_ready_handler():
     response_model=PostMigrationsUpgradeResponse,
 )
 async def post_migrations_upgrade(
-    name: Annotated[str, Path(description="Название ревизии", example="head")],
+    name: Annotated[str, Path(description="Название ревизии", examples="head")],
     # _: AdminAuthDep,
 ):
     try:

--- a/api/src/users/router.py
+++ b/api/src/users/router.py
@@ -4,7 +4,6 @@ from src.users.response import PostUsersApiResponse, GetUsersMeApiResponse
 from src.users.schema import UserCreate
 from src.utils.basic_auth import UserDep
 from src.utils.dependency import UOWDep, UserServiceDep
-from src.utils.exceptions import exception_handler
 
 router = APIRouter()
 
@@ -15,7 +14,6 @@ router = APIRouter()
     summary="Create a new user",
     description="Create a new user with generated password",
 )
-@exception_handler
 async def add_user(uow: UOWDep, user_service: UserServiceDep, user: UserCreate):
     created_user = await user_service.add_user(uow, user)
     return PostUsersApiResponse(data=created_user, detail="User was added.")
@@ -27,6 +25,5 @@ async def add_user(uow: UOWDep, user_service: UserServiceDep, user: UserCreate):
     summary="Get authenticated user",
     description="Validate credentials and get user details",
 )
-@exception_handler
 async def get_me(user: UserDep):
     return GetUsersMeApiResponse(data=user, detail="User was selected.")

--- a/api/src/utils/basic_auth.py
+++ b/api/src/utils/basic_auth.py
@@ -12,7 +12,7 @@ security = HTTPBasic(auto_error=True, description="User Authentication")
 BasicAuthCredentialsDep = Annotated[HTTPBasicCredentials, Depends(security)]
 
 
-@exception_handler
+# @exception_handler
 async def get_user(
     uow: UOWDep, credentials: BasicAuthCredentialsDep, user_service: UserServiceDep
 ) -> UserRead:

--- a/api/src/utils/basic_auth.py
+++ b/api/src/utils/basic_auth.py
@@ -12,7 +12,6 @@ security = HTTPBasic(auto_error=True, description="User Authentication")
 BasicAuthCredentialsDep = Annotated[HTTPBasicCredentials, Depends(security)]
 
 
-# @exception_handler
 async def get_user(
     uow: UOWDep, credentials: BasicAuthCredentialsDep, user_service: UserServiceDep
 ) -> UserRead:

--- a/api/src/utils/basic_auth.py
+++ b/api/src/utils/basic_auth.py
@@ -5,7 +5,7 @@ from fastapi.security import HTTPBasic, HTTPBasicCredentials
 
 from src.users.schema import UserRead
 from src.utils.dependency import UOWDep, UserServiceDep
-from src.utils.exceptions import AuthenticationError, exception_handler
+from src.utils.exceptions import AuthenticationError
 
 security = HTTPBasic(auto_error=True, description="User Authentication")
 

--- a/api/src/utils/exceptions.py
+++ b/api/src/utils/exceptions.py
@@ -1,4 +1,4 @@
-from fastapi import HTTPException
+from fastapi import Request, HTTPException
 from loguru import logger
 
 from typing import ParamSpec, TypeVar, Callable, Awaitable
@@ -49,3 +49,21 @@ def exception_handler(handler: Callable[P, Awaitable[R]]) -> Callable[P, Awaitab
             return res
 
     return wrapper
+
+
+async def endpoints_exception_handler(request: Request, ex: Exception):
+    if isinstance(ex, (ValueError, ExistsError)):
+        logger.error(ex)
+        raise HTTPException(400, detail=str(ex))
+    elif isinstance(ex, AuthenticationError):
+        logger.error(ex)
+        raise HTTPException(401, detail=str(ex))
+    elif isinstance(ex, PermissionError):
+        logger.error(ex)
+        raise HTTPException(403, detail=str(ex))
+    elif isinstance(ex, NotFoundError):
+        logger.error(ex)
+        raise HTTPException(404, detail=str(ex))
+    else:
+        logger.exception(ex)
+        raise HTTPException(500, detail=str(ex))

--- a/api/src/utils/exceptions.py
+++ b/api/src/utils/exceptions.py
@@ -1,7 +1,7 @@
 from fastapi import Request, HTTPException
+from fastapi.responses import JSONResponse
 from loguru import logger
 
-from typing import ParamSpec, TypeVar, Callable, Awaitable
 from functools import wraps
 
 
@@ -17,53 +17,19 @@ class ExistsError(Exception):
     pass
 
 
-P = ParamSpec("P")
-R = TypeVar("R")
-
-
-def exception_handler(handler: Callable[P, Awaitable[R]]) -> Callable[P, Awaitable[R]]:
-    """
-    Перехватывает базовые Exception и превращает их в красивые HTTPException.
-    """
-
-    @wraps(handler)
-    async def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
-        try:
-            res = await handler(*args, **kwargs)
-        except (ValueError, ExistsError) as ex:
-            logger.error(ex)
-            raise HTTPException(400, detail=str(ex))
-        except AuthenticationError as ex:
-            logger.error(ex)
-            raise HTTPException(401, detail=str(ex))
-        except PermissionError as ex:
-            logger.error(ex)
-            raise HTTPException(403, detail=str(ex))
-        except NotFoundError as ex:
-            logger.error(ex)
-            raise HTTPException(404, detail=str(ex))
-        except Exception as ex:
-            logger.exception(ex)
-            raise HTTPException(500, detail=str(ex))
-        else:
-            return res
-
-    return wrapper
-
-
 async def endpoints_exception_handler(request: Request, ex: Exception):
     if isinstance(ex, (ValueError, ExistsError)):
         logger.error(ex)
-        raise HTTPException(400, detail=str(ex))
+        return JSONResponse(status_code=400, content={"detail": str(ex)})
     elif isinstance(ex, AuthenticationError):
         logger.error(ex)
-        raise HTTPException(401, detail=str(ex))
+        return JSONResponse(status_code=401, content={"detail": str(ex)})
     elif isinstance(ex, PermissionError):
         logger.error(ex)
-        raise HTTPException(403, detail=str(ex))
+        return JSONResponse(status_code=403, content={"detail": str(ex)})
     elif isinstance(ex, NotFoundError):
         logger.error(ex)
-        raise HTTPException(404, detail=str(ex))
+        return JSONResponse(status_code=404, content={"detail": str(ex)})
     else:
         logger.exception(ex)
-        raise HTTPException(500, detail=str(ex))
+        return JSONResponse(status_code=500, content={"detail": str(ex)})

--- a/api/src/utils/exceptions.py
+++ b/api/src/utils/exceptions.py
@@ -1,6 +1,9 @@
 from fastapi import HTTPException
 from loguru import logger
 
+from typing import ParamSpec, TypeVar, Callable, Awaitable
+from functools import wraps
+
 
 class NotFoundError(Exception):
     pass
@@ -14,15 +17,17 @@ class ExistsError(Exception):
     pass
 
 
-def exception_handler(handler):
+P = ParamSpec("P")
+R = TypeVar("R")
+
+
+def exception_handler(handler: Callable[P, Awaitable[R]]) -> Callable[P, Awaitable[R]]:
     """
     Перехватывает базовые Exception и превращает их в красивые HTTPException.
-    Надо подумать над тем, как делать это средствами FastAPI, а не таким колхозом.
-    :param handler: Ручка, которую оборачиваем.
-    :return:
     """
 
-    async def wrapper(*args, **kwargs):
+    @wraps(handler)
+    async def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
         try:
             res = await handler(*args, **kwargs)
         except (ValueError, ExistsError) as ex:
@@ -43,20 +48,4 @@ def exception_handler(handler):
         else:
             return res
 
-    # Fix signature of wrapper
-    import inspect
-
-    wrapper.__signature__ = inspect.Signature(  # type: ignore
-        parameters=[
-            # Use all parameters from handler
-            *inspect.signature(handler).parameters.values(),
-            # Skip *args and **kwargs from wrapper parameters:
-            *filter(
-                lambda p: p.kind
-                not in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD),
-                inspect.signature(wrapper).parameters.values(),
-            ),
-        ],
-        return_annotation=inspect.signature(handler).return_annotation,
-    )
     return wrapper

--- a/api/src/utils/exceptions.py
+++ b/api/src/utils/exceptions.py
@@ -1,8 +1,6 @@
-from fastapi import Request, HTTPException
+from fastapi import Request
 from fastapi.responses import JSONResponse
 from loguru import logger
-
-from functools import wraps
 
 
 class NotFoundError(Exception):

--- a/api/src/utils/s3_auth.py
+++ b/api/src/utils/s3_auth.py
@@ -19,7 +19,7 @@ class S3AuthenticatedRequest(BaseModel):
 BucketKeyDep = Annotated[str, Path()]
 
 
-@exception_handler
+# @exception_handler
 async def get_s3_authenticated_request(
     uow: UOWDep,
     bucket_service: BucketServiceDep,

--- a/api/src/utils/s3_auth.py
+++ b/api/src/utils/s3_auth.py
@@ -19,7 +19,6 @@ class S3AuthenticatedRequest(BaseModel):
 BucketKeyDep = Annotated[str, Path()]
 
 
-# @exception_handler
 async def get_s3_authenticated_request(
     uow: UOWDep,
     bucket_service: BucketServiceDep,

--- a/api/src/utils/s3_auth.py
+++ b/api/src/utils/s3_auth.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel
 
 from src.buckets.schema import BucketRead
 from src.utils.dependency import UOWDep, BucketServiceDep
-from src.utils.exceptions import exception_handler, AuthenticationError
+from src.utils.exceptions import AuthenticationError
 
 
 class S3AuthenticatedRequest(BaseModel):

--- a/api/src/utils/s3_auth.py
+++ b/api/src/utils/s3_auth.py
@@ -50,7 +50,7 @@ async def get_s3_authenticated_request(
     except Exception as e:
         # снаружи мы не поймем, что именно ломается, если будут баги, поэтому добавил лог внутри
         logger.error(e)
-        raise AuthenticationError
+        raise AuthenticationError()
 
     return S3AuthenticatedRequest(
         bucket=BucketRead.model_validate(bucket),  # убираем креды

--- a/api/src/utils/unitofwork.py
+++ b/api/src/utils/unitofwork.py
@@ -7,7 +7,6 @@ from src.utils.database import get_session_maker
 
 
 class IUnitOfWork(ABC):
-
     @abstractmethod
     def __init__(self, session_factory):
         self.__session_factory = None

--- a/api/tests/test_main.py
+++ b/api/tests/test_main.py
@@ -1,39 +1,44 @@
 import pytest
 
-from httpx import AsyncClient
+from httpx import AsyncClient, ASGITransport
 from main import app
 
 
-@pytest.mark.asyncio
-async def test_get_root_handler():
-    async with AsyncClient(app=app, base_url="http://test") as ac:
-        response = await ac.get("/")
-    assert response.status_code == 200
-    assert response.json() == {
-        "data": "S3aaS API",
-        "detail": "Visit /docs or /redoc for the full documentation.",
-    }
+@pytest.fixture
+def transport():
+    return ASGITransport(app=app)
 
 
 @pytest.mark.asyncio
-async def test_get_readyz_handler():
-    async with AsyncClient(app=app, base_url="http://test") as ac:
-        response = await ac.get("/readyz")
-    assert response.status_code == 200
-    assert response.json() == {"data": "Ready", "detail": "API is ready."}
+async def test_get_root_handler(transport):
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/")
+        assert response.status_code == 200
+        assert response.json() == {
+            "data": "S3aaS API",
+            "detail": "Visit /docs or /redoc for the full documentation.",
+        }
 
 
 @pytest.mark.asyncio
-async def test_get_healthz_handler():
-    async with AsyncClient(app=app, base_url="http://test") as ac:
-        response = await ac.get("/healthz")
-    assert response.status_code == 200
-    assert response.json() == {"data": "Healthy", "detail": "API is healthy."}
+async def test_get_readyz_handler(transport):
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/readyz")
+        assert response.status_code == 200
+        assert response.json() == {"data": "Ready", "detail": "API is ready."}
 
 
 @pytest.mark.asyncio
-async def test_get_publication_ready_handler():
-    async with AsyncClient(app=app, base_url="http://test") as ac:
-        response = await ac.get("/publication/ready")
-    assert response.status_code == 200
-    assert response.json() == {"data": "Ready", "detail": "API is ready to be published."}
+async def test_get_healthz_handler(transport):
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/healthz")
+        assert response.status_code == 200
+        assert response.json() == {"data": "Healthy", "detail": "API is healthy."}
+
+
+@pytest.mark.asyncio
+async def test_get_publication_ready_handler(transport):
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/publication/ready")
+        assert response.status_code == 200
+        assert response.json() == {"data": "Ready", "detail": "API is ready to be published."}

--- a/api/tests/test_utils/test_s3_auth.py
+++ b/api/tests/test_utils/test_s3_auth.py
@@ -3,12 +3,11 @@ import aws4
 import hmac
 import uuid
 
-from fastapi import HTTPException
 from datetime import datetime
 from unittest.mock import MagicMock, AsyncMock, patch
 
 from src.buckets.schema import BucketRead, BucketReadWithCredentials
-from src.utils.exceptions import NotFoundError
+from src.utils.exceptions import NotFoundError, AuthenticationError
 from src.utils.s3_auth import get_s3_authenticated_request, S3AuthenticatedRequest
 
 
@@ -67,7 +66,7 @@ async def test_success():
 async def test_empty_access_key():
     with (
         patch("aws4.generate_challenge", return_value=MagicMock(access_key_id=None)),
-        pytest.raises(HTTPException),
+        pytest.raises(AuthenticationError),
     ):
         await get_s3_authenticated_request(AsyncMock(), AsyncMock(), "key", AsyncMock())
 
@@ -80,7 +79,7 @@ async def test_bucket_key_mismatch():
     with (
         patch("aws4.generate_challenge", return_value=MagicMock(access_key_id="access_key")),
         patch("hmac.compare_digest", return_value=False),
-        pytest.raises(HTTPException),
+        pytest.raises(AuthenticationError),
     ):
         await get_s3_authenticated_request(AsyncMock(), bucket_svc, "key", AsyncMock())
 
@@ -94,7 +93,7 @@ async def test_validation_error():
         patch("aws4.generate_challenge", return_value=MagicMock(access_key_id="access_key")),
         patch("hmac.compare_digest", return_value=True),
         patch("aws4.validate_challenge", side_effect=aws4.AWS4Exception),
-        pytest.raises(HTTPException),
+        pytest.raises(AuthenticationError),
     ):
         await get_s3_authenticated_request(AsyncMock(), bucket_svc, "key", AsyncMock())
 
@@ -106,6 +105,6 @@ async def test_get_bucket_error():
 
     with (
         patch("aws4.generate_challenge", return_value=MagicMock(access_key_id="access_key")),
-        pytest.raises(HTTPException),
+        pytest.raises(AuthenticationError),
     ):
         await get_s3_authenticated_request(AsyncMock(), bucket_svc, "key", AsyncMock())


### PR DESCRIPTION
Крч вот такой вариант нашел, чтобы сохранять типы аргс и кваргс, а также сигнатуру функции. Линтеры прошли, сам декоратор быстренько протестил вручную вроде работает. Щас надо убегать поэтому пока так запулю.

В оф. доке нашел вот такое, пока не успел разобраться опять же, но думаю тоже можно использовать

```python
from fastapi import FastAPI, HTTPException
from fastapi.exception_handlers import (
    http_exception_handler,
    request_validation_exception_handler,
)
from fastapi.exceptions import RequestValidationError
from starlette.exceptions import HTTPException as StarletteHTTPException

app = FastAPI()


@app.exception_handler(StarletteHTTPException)
async def custom_http_exception_handler(request, exc):
    print(f"OMG! An HTTP error!: {repr(exc)}")
    return await http_exception_handler(request, exc)


@app.exception_handler(RequestValidationError)
async def validation_exception_handler(request, exc):
    print(f"OMG! The client sent invalid data!: {exc}")
    return await request_validation_exception_handler(request, exc)


@app.get("/items/{item_id}")
async def read_item(item_id: int):
    if item_id == 3:
        raise HTTPException(status_code=418, detail="Nope! I don't like 3.")
    return {"item_id": item_id}
```