### PR TITLE
Add Woodpecker workflow for Go API

### DIFF
--- a/.woodpecker/api-go.yml
+++ b/.woodpecker/api-go.yml
@@ -1,0 +1,15 @@
+when:
+  - event: push
+
+steps:
+  - name: build and push
+    image: woodpeckerci/plugin-docker-buildx
+    settings:
+      repo: ghcr.io/siberianbearofficial/s3aas-api-go
+      registry: ghcr.io
+      username: siberianbearofficial
+      password:
+        from_secret: GITHUB_TOKEN
+      context: api-go
+      dockerfile: api-go/Dockerfile
+      tag: main


### PR DESCRIPTION
## Summary
- add `.woodpecker/api-go.yml` pipeline to build and push Go API Docker image to GHCR

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68725750a13483249b24fdb26164b138