### PR TITLE
Implement bucket creation in Go API

### DIFF
--- a/api-go/AGENTS.md
+++ b/api-go/AGENTS.md
@@ -1,0 +1,1 @@
+When modifying, adding, or removing API endpoints, make sure to update the swagger documentation located under internal/docs.

--- a/api-go/cmd/server/main.go
+++ b/api-go/cmd/server/main.go
@@ -3,6 +3,7 @@
 // @title S3aaS API
 // @version 1.0
 // @BasePath /
+// @securityDefinitions.basic BasicAuth
 package main
 
 import (

--- a/api-go/internal/app/router.go
+++ b/api-go/internal/app/router.go
@@ -18,8 +18,10 @@ func SetupRouter(m *db.Mongo) *gin.Engine {
 	router.GET("/publication/ready", handlers.PublicationReady)
 	router.GET("/dbz", handlers.DBProbe(m))
 	if m != nil {
-		bucketRepo, err := repository.NewBucketRepository(m.DB)
-		if err == nil {
+		if userRepo, err := repository.NewUserRepository(m.DB); err == nil {
+			router.POST("/api/v1/users", handlers.CreateUser(userRepo))
+		}
+		if bucketRepo, err := repository.NewBucketRepository(m.DB); err == nil {
 			router.POST("/api/v1/buckets", handlers.CreateBucket(bucketRepo))
 		}
 	}

--- a/api-go/internal/app/router.go
+++ b/api-go/internal/app/router.go
@@ -3,6 +3,7 @@ package app
 import (
 	"github.com/example/s3aas/api-go/internal/db"
 	"github.com/example/s3aas/api-go/internal/handlers"
+	"github.com/example/s3aas/api-go/internal/repository"
 	"github.com/gin-gonic/gin"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	swaggerFiles "github.com/swaggo/files"
@@ -16,6 +17,12 @@ func SetupRouter(m *db.Mongo) *gin.Engine {
 	router.GET("/healthz", handlers.Healthz)
 	router.GET("/publication/ready", handlers.PublicationReady)
 	router.GET("/dbz", handlers.DBProbe(m))
+	if m != nil {
+		bucketRepo, err := repository.NewBucketRepository(m.DB)
+		if err == nil {
+			router.POST("/api/v1/buckets", handlers.CreateBucket(bucketRepo))
+		}
+	}
 	router.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
 	router.GET("/metrics", gin.WrapH(promhttp.Handler()))
 	return router

--- a/api-go/internal/docs/docs.go
+++ b/api-go/internal/docs/docs.go
@@ -85,6 +85,36 @@ const docTemplate = `{
                 }
             }
         }
+        ,"/api/v1/buckets": {
+            "post": {
+                "tags": [
+                    "buckets"
+                ],
+                "summary": "Create bucket",
+                "responses": {
+                    "200": {
+                        "description": "Created",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "key": {"type": "string"},
+                                "access_key": {"type": "string"},
+                                "access_secret": {"type": "string"},
+                                "created_at": {"type": "string"}
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {"type": "string"}
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {"type": "string"}
+                    }
+                }
+            }
+        }
     }
 }`
 

--- a/api-go/internal/docs/docs.go
+++ b/api-go/internal/docs/docs.go
@@ -15,6 +15,56 @@ const docTemplate = `{
     "host": "{{.Host}}",
     "basePath": "{{.BasePath}}",
     "paths": {
+        "/api/v1/buckets": {
+            "post": {
+                "security": [
+                    {
+                        "BasicAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "buckets"
+                ],
+                "summary": "Create bucket",
+                "parameters": [
+                    {
+                        "description": "Bucket to create",
+                        "name": "bucket",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.createBucketRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.createBucketResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/dbz": {
             "get": {
                 "tags": [
@@ -85,35 +135,40 @@ const docTemplate = `{
                 }
             }
         }
-        ,"/api/v1/buckets": {
-            "post": {
-                "tags": [
-                    "buckets"
-                ],
-                "summary": "Create bucket",
-                "responses": {
-                    "200": {
-                        "description": "Created",
-                        "schema": {
-                            "type": "object",
-                            "properties": {
-                                "key": {"type": "string"},
-                                "access_key": {"type": "string"},
-                                "access_secret": {"type": "string"},
-                                "created_at": {"type": "string"}
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {"type": "string"}
-                    },
-                    "409": {
-                        "description": "Conflict",
-                        "schema": {"type": "string"}
-                    }
+    },
+    "definitions": {
+        "handlers.createBucketRequest": {
+            "type": "object",
+            "required": [
+                "key"
+            ],
+            "properties": {
+                "key": {
+                    "type": "string"
                 }
             }
+        },
+        "handlers.createBucketResponse": {
+            "type": "object",
+            "properties": {
+                "access_key": {
+                    "type": "string"
+                },
+                "access_secret": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "key": {
+                    "type": "string"
+                }
+            }
+        }
+    },
+    "securityDefinitions": {
+        "BasicAuth": {
+            "type": "basic"
         }
     }
 }`

--- a/api-go/internal/docs/docs.go
+++ b/api-go/internal/docs/docs.go
@@ -15,6 +15,51 @@ const docTemplate = `{
     "host": "{{.Host}}",
     "basePath": "{{.BasePath}}",
     "paths": {
+        "/api/v1/users": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "users"
+                ],
+                "summary": "Create user",
+                "parameters": [
+                    {
+                        "description": "User to create",
+                        "name": "user",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.createUserRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.createUserResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/buckets": {
             "post": {
                 "security": [
@@ -162,6 +207,31 @@ const docTemplate = `{
                 },
                 "key": {
                     "type": "string"
+                }
+            }
+        },
+        "handlers.createUserRequest": {
+            "type": "object",
+            "required": [
+                "username"
+            ],
+            "properties": {
+                "username": {
+                    "type": "string",
+                }
+            }
+        },
+        "handlers.createUserResponse": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string",
+                },
+                "id": {
+                    "type": "string",
+                },
+                "password": {
+                    "type": "string",
                 }
             }
         }

--- a/api-go/internal/handlers/bucket.go
+++ b/api-go/internal/handlers/bucket.go
@@ -1,0 +1,73 @@
+package handlers
+
+import (
+	"crypto/rand"
+	"math/big"
+	"net/http"
+	"time"
+
+	"github.com/example/s3aas/api-go/internal/repository"
+	"github.com/gin-gonic/gin"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+// random string generator
+const accessSecretLength = 80
+
+var alphabet = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~")
+
+func generateAccessSecret() string {
+	b := make([]rune, accessSecretLength)
+	for i := range b {
+		n, _ := rand.Int(rand.Reader, big.NewInt(int64(len(alphabet))))
+		b[i] = alphabet[n.Int64()]
+	}
+	return string(b)
+}
+
+func CreateBucket(repo *repository.BucketRepository) gin.HandlerFunc {
+	type request struct {
+		Key string `json:"key" binding:"required"`
+	}
+	type response struct {
+		Key          string    `json:"key"`
+		AccessKey    string    `json:"access_key"`
+		AccessSecret string    `json:"access_secret"`
+		CreatedAt    time.Time `json:"created_at"`
+	}
+
+	return func(c *gin.Context) {
+		var req request
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.Status(http.StatusBadRequest)
+			return
+		}
+		if repo == nil {
+			c.Status(http.StatusServiceUnavailable)
+			return
+		}
+		accessKey := req.Key
+		accessSecret := generateAccessSecret()
+		bucket := repository.Bucket{
+			Key:          req.Key,
+			AccessKey:    accessKey,
+			AccessSecret: accessSecret,
+			CreatedAt:    time.Now().UTC(),
+		}
+		created, err := repo.Create(c.Request.Context(), bucket)
+		if err != nil {
+			if mongo.IsDuplicateKeyError(err) {
+				c.Status(http.StatusConflict)
+				return
+			}
+			c.Status(http.StatusInternalServerError)
+			return
+		}
+		c.JSON(http.StatusOK, response{
+			Key:          created.Key,
+			AccessKey:    created.AccessKey,
+			AccessSecret: created.AccessSecret,
+			CreatedAt:    created.CreatedAt,
+		})
+	}
+}

--- a/api-go/internal/handlers/bucket.go
+++ b/api-go/internal/handlers/bucket.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"crypto/rand"
+	"log"
 	"math/big"
 	"net/http"
 	"time"
@@ -25,24 +26,38 @@ func generateAccessSecret() string {
 	return string(b)
 }
 
-func CreateBucket(repo *repository.BucketRepository) gin.HandlerFunc {
-	type request struct {
-		Key string `json:"key" binding:"required"`
-	}
-	type response struct {
-		Key          string    `json:"key"`
-		AccessKey    string    `json:"access_key"`
-		AccessSecret string    `json:"access_secret"`
-		CreatedAt    time.Time `json:"created_at"`
-	}
+type createBucketRequest struct {
+	Key string `json:"key" binding:"required"`
+}
 
+type createBucketResponse struct {
+	Key          string    `json:"key"`
+	AccessKey    string    `json:"access_key"`
+	AccessSecret string    `json:"access_secret"`
+	CreatedAt    time.Time `json:"created_at"`
+}
+
+// CreateBucket godoc
+// @Summary Create bucket
+// @Tags buckets
+// @Accept json
+// @Produce json
+// @Param bucket body createBucketRequest true "Bucket to create"
+// @Success 200 {object} createBucketResponse
+// @Failure 400 {string} string ""
+// @Failure 409 {string} string ""
+// @Security BasicAuth
+// @Router /api/v1/buckets [post]
+func CreateBucket(repo *repository.BucketRepository) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		var req request
+		var req createBucketRequest
 		if err := c.ShouldBindJSON(&req); err != nil {
+			log.Printf("create bucket: invalid request: %v", err)
 			c.Status(http.StatusBadRequest)
 			return
 		}
 		if repo == nil {
+			log.Print("create bucket: repository is nil")
 			c.Status(http.StatusServiceUnavailable)
 			return
 		}
@@ -57,13 +72,15 @@ func CreateBucket(repo *repository.BucketRepository) gin.HandlerFunc {
 		created, err := repo.Create(c.Request.Context(), bucket)
 		if err != nil {
 			if mongo.IsDuplicateKeyError(err) {
+				log.Printf("create bucket: key %s already exists: %v", req.Key, err)
 				c.Status(http.StatusConflict)
 				return
 			}
+			log.Printf("create bucket: failed to create bucket: %v", err)
 			c.Status(http.StatusInternalServerError)
 			return
 		}
-		c.JSON(http.StatusOK, response{
+		c.JSON(http.StatusOK, createBucketResponse{
 			Key:          created.Key,
 			AccessKey:    created.AccessKey,
 			AccessSecret: created.AccessSecret,

--- a/api-go/internal/handlers/bucket_test.go
+++ b/api-go/internal/handlers/bucket_test.go
@@ -1,0 +1,56 @@
+//go:build integration
+// +build integration
+
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/example/s3aas/api-go/internal/config"
+	"github.com/example/s3aas/api-go/internal/db"
+	"github.com/example/s3aas/api-go/internal/repository"
+	"github.com/gin-gonic/gin"
+)
+
+func TestCreateBucket(t *testing.T) {
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	mongoConn, err := db.Connect(context.Background(), cfg.Mongo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo, err := repository.NewBucketRepository(mongoConn.DB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	router := gin.New()
+	router.POST("/api/v1/buckets", CreateBucket(repo))
+	body, _ := json.Marshal(map[string]string{"key": "bucket-test"})
+	req, _ := http.NewRequest(http.MethodPost, "/api/v1/buckets", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var resp struct {
+		Key          string    `json:"key"`
+		AccessKey    string    `json:"access_key"`
+		AccessSecret string    `json:"access_secret"`
+		CreatedAt    time.Time `json:"created_at"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+	if resp.Key != "bucket-test" || resp.AccessKey == "" || resp.AccessSecret == "" {
+		t.Fatalf("unexpected response: %+v", resp)
+	}
+}

--- a/api-go/internal/handlers/user.go
+++ b/api-go/internal/handlers/user.go
@@ -1,0 +1,89 @@
+package handlers
+
+import (
+	"crypto/rand"
+	"log"
+	"math/big"
+	"net/http"
+	"time"
+
+	"github.com/example/s3aas/api-go/internal/repository"
+	"github.com/gin-gonic/gin"
+	"go.mongodb.org/mongo-driver/mongo"
+	"golang.org/x/crypto/bcrypt"
+)
+
+const passwordLength = 12
+
+func generatePassword() string {
+	b := make([]rune, passwordLength)
+	for i := range b {
+		n, _ := rand.Int(rand.Reader, big.NewInt(int64(len(alphabet))))
+		b[i] = alphabet[n.Int64()]
+	}
+	return string(b)
+}
+
+type createUserRequest struct {
+	Username string `json:"username" binding:"required"`
+}
+
+type createUserResponse struct {
+	ID        string    `json:"id"`
+	CreatedAt time.Time `json:"created_at"`
+	Password  string    `json:"password"`
+}
+
+// CreateUser godoc
+// @Summary Create user
+// @Tags users
+// @Accept json
+// @Produce json
+// @Param user body createUserRequest true "User to create"
+// @Success 200 {object} createUserResponse
+// @Failure 400 {string} string ""
+// @Failure 409 {string} string ""
+// @Router /api/v1/users [post]
+func CreateUser(repo *repository.UserRepository) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var req createUserRequest
+		if err := c.ShouldBindJSON(&req); err != nil {
+			log.Printf("create user: invalid request: %v", err)
+			c.Status(http.StatusBadRequest)
+			return
+		}
+		if repo == nil {
+			log.Print("create user: repository is nil")
+			c.Status(http.StatusServiceUnavailable)
+			return
+		}
+		password := generatePassword()
+		hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+		if err != nil {
+			log.Printf("create user: failed to hash password: %v", err)
+			c.Status(http.StatusInternalServerError)
+			return
+		}
+		user := repository.User{
+			Username:     req.Username,
+			PasswordHash: string(hash),
+			CreatedAt:    time.Now().UTC(),
+		}
+		created, err := repo.Create(c.Request.Context(), user)
+		if err != nil {
+			if mongo.IsDuplicateKeyError(err) {
+				log.Printf("create user: username %s already exists: %v", req.Username, err)
+				c.Status(http.StatusConflict)
+				return
+			}
+			log.Printf("create user: failed to create user: %v", err)
+			c.Status(http.StatusInternalServerError)
+			return
+		}
+		c.JSON(http.StatusOK, createUserResponse{
+			ID:        created.ID.Hex(),
+			CreatedAt: created.CreatedAt,
+			Password:  password,
+		})
+	}
+}

--- a/api-go/internal/handlers/user_test.go
+++ b/api-go/internal/handlers/user_test.go
@@ -1,0 +1,63 @@
+//go:build integration
+// +build integration
+
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/example/s3aas/api-go/internal/config"
+	"github.com/example/s3aas/api-go/internal/db"
+	"github.com/example/s3aas/api-go/internal/repository"
+	"github.com/gin-gonic/gin"
+	"golang.org/x/crypto/bcrypt"
+)
+
+func TestCreateUser(t *testing.T) {
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	mongoConn, err := db.Connect(context.Background(), cfg.Mongo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo, err := repository.NewUserRepository(mongoConn.DB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	router := gin.New()
+	router.POST("/api/v1/users", CreateUser(repo))
+	body, _ := json.Marshal(map[string]string{"username": "user-test"})
+	req, _ := http.NewRequest(http.MethodPost, "/api/v1/users", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var resp struct {
+		ID        string    `json:"id"`
+		CreatedAt time.Time `json:"created_at"`
+		Password  string    `json:"password"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+	if resp.ID == "" || resp.Password == "" {
+		t.Fatalf("unexpected response: %+v", resp)
+	}
+	stored, err := repo.GetByUsername(context.Background(), "user-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := bcrypt.CompareHashAndPassword([]byte(stored.PasswordHash), []byte(resp.Password)); err != nil {
+		t.Fatalf("password hash mismatch: %v", err)
+	}
+}

--- a/api-go/internal/repository/bucket.go
+++ b/api-go/internal/repository/bucket.go
@@ -1,0 +1,58 @@
+package repository
+
+import (
+	"context"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+// Bucket represents storage bucket information
+// stored in MongoDB.
+type Bucket struct {
+	ID           primitive.ObjectID `bson:"_id,omitempty"`
+	Key          string             `bson:"key"`
+	AccessKey    string             `bson:"access_key"`
+	AccessSecret string             `bson:"access_secret"`
+	CreatedAt    time.Time          `bson:"created_at"`
+}
+
+type BucketRepository struct {
+	coll *mongo.Collection
+}
+
+func NewBucketRepository(db *mongo.Database) (*BucketRepository, error) {
+	coll := db.Collection("buckets")
+	_, err := coll.Indexes().CreateOne(context.Background(), mongo.IndexModel{
+		Keys:    bson.D{{Key: "key", Value: 1}},
+		Options: options.Index().SetUnique(true),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &BucketRepository{coll: coll}, nil
+}
+
+func (r *BucketRepository) Create(ctx context.Context, b Bucket) (*Bucket, error) {
+	b.CreatedAt = b.CreatedAt.UTC()
+	res, err := r.coll.InsertOne(ctx, b)
+	if err != nil {
+		return nil, err
+	}
+	if oid, ok := res.InsertedID.(primitive.ObjectID); ok {
+		b.ID = oid
+	}
+	return &b, nil
+}
+
+func (r *BucketRepository) GetByKey(ctx context.Context, key string) (*Bucket, error) {
+	var b Bucket
+	err := r.coll.FindOne(ctx, bson.M{"key": key}).Decode(&b)
+	if err != nil {
+		return nil, err
+	}
+	return &b, nil
+}

--- a/api-go/internal/repository/bucket_test.go
+++ b/api-go/internal/repository/bucket_test.go
@@ -1,0 +1,40 @@
+//go:build integration
+// +build integration
+
+package repository
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/example/s3aas/api-go/internal/config"
+	"github.com/example/s3aas/api-go/internal/db"
+)
+
+func TestBucketRepository(t *testing.T) {
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	mongoConn, err := db.Connect(context.Background(), cfg.Mongo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo, err := NewBucketRepository(mongoConn.DB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b := Bucket{Key: "testbucket", AccessKey: "ak", AccessSecret: "secret", CreatedAt: time.Now()}
+	created, err := repo.Create(context.Background(), b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := repo.GetByKey(context.Background(), "testbucket")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ID != created.ID || got.Key != "testbucket" {
+		t.Fatalf("retrieved bucket mismatch")
+	}
+}

--- a/api-go/internal/repository/user.go
+++ b/api-go/internal/repository/user.go
@@ -2,16 +2,20 @@ package repository
 
 import (
 	"context"
+	"time"
 
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
 // User represents basic auth user
 type User struct {
-	Username     string `bson:"username"`
-	PasswordHash string `bson:"password_hash"`
+	ID           primitive.ObjectID `bson:"_id,omitempty"`
+	Username     string             `bson:"username"`
+	PasswordHash string             `bson:"password_hash"`
+	CreatedAt    time.Time          `bson:"created_at"`
 }
 
 type UserRepository struct {
@@ -30,9 +34,16 @@ func NewUserRepository(db *mongo.Database) (*UserRepository, error) {
 	return &UserRepository{coll: coll}, nil
 }
 
-func (r *UserRepository) Create(ctx context.Context, user User) error {
-	_, err := r.coll.InsertOne(ctx, user)
-	return err
+func (r *UserRepository) Create(ctx context.Context, user User) (*User, error) {
+	user.CreatedAt = user.CreatedAt.UTC()
+	res, err := r.coll.InsertOne(ctx, user)
+	if err != nil {
+		return nil, err
+	}
+	if oid, ok := res.InsertedID.(primitive.ObjectID); ok {
+		user.ID = oid
+	}
+	return &user, nil
 }
 
 func (r *UserRepository) GetByUsername(ctx context.Context, username string) (*User, error) {

--- a/api-go/internal/repository/user_test.go
+++ b/api-go/internal/repository/user_test.go
@@ -6,6 +6,7 @@ package repository
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/example/s3aas/api-go/internal/config"
 	"github.com/example/s3aas/api-go/internal/db"
@@ -27,9 +28,13 @@ func TestUserRepository(t *testing.T) {
 	}
 	password := "secret"
 	hash, _ := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
-	user := User{Username: "testuser", PasswordHash: string(hash)}
-	if err := repo.Create(context.Background(), user); err != nil {
+	user := User{Username: "testuser", PasswordHash: string(hash), CreatedAt: time.Now()}
+	created, err := repo.Create(context.Background(), user)
+	if err != nil {
 		t.Fatal(err)
+	}
+	if created.ID.IsZero() {
+		t.Fatalf("expected ID to be set")
 	}
 	u, err := repo.GetByUsername(context.Background(), "testuser")
 	if err != nil {


### PR DESCRIPTION
## Summary
- add bucket repository for Mongo
- add handler for POST `/api/v1/buckets`
- wire handler in router
- cover repository and handler with integration tests

## Testing
- `go test ./...`
- `go test -tags=integration ./...` *(fails: server selection error)*

------
https://chatgpt.com/codex/tasks/task_e_688a7c005d388324ba8ba4efc659f61a