### PR TITLE
Add gdrive source creation endpoint

### DIFF
--- a/api-go/internal/app/router.go
+++ b/api-go/internal/app/router.go
@@ -24,6 +24,9 @@ func SetupRouter(m *db.Mongo) *gin.Engine {
 		if bucketRepo, err := repository.NewBucketRepository(m.DB); err == nil {
 			router.POST("/api/v1/buckets", handlers.CreateBucket(bucketRepo))
 		}
+		if sourceRepo, err := repository.NewSourceRepository(m.DB); err == nil {
+			router.POST("/api/v1/sources/gdrive", handlers.CreateGDriveSource(sourceRepo))
+		}
 	}
 	router.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
 	router.GET("/metrics", gin.WrapH(promhttp.Handler()))

--- a/api-go/internal/app/router.go
+++ b/api-go/internal/app/router.go
@@ -19,13 +19,14 @@ func SetupRouter(m *db.Mongo) *gin.Engine {
 	router.GET("/dbz", handlers.DBProbe(m))
 	if m != nil {
 		if userRepo, err := repository.NewUserRepository(m.DB); err == nil {
+			auth := handlers.BasicAuth(userRepo)
 			router.POST("/api/v1/users", handlers.CreateUser(userRepo))
-		}
-		if bucketRepo, err := repository.NewBucketRepository(m.DB); err == nil {
-			router.POST("/api/v1/buckets", handlers.CreateBucket(bucketRepo))
-		}
-		if sourceRepo, err := repository.NewSourceRepository(m.DB); err == nil {
-			router.POST("/api/v1/sources/gdrive", handlers.CreateGDriveSource(sourceRepo))
+			if bucketRepo, err := repository.NewBucketRepository(m.DB); err == nil {
+				router.POST("/api/v1/buckets", auth, handlers.CreateBucket(bucketRepo))
+			}
+			if sourceRepo, err := repository.NewSourceRepository(m.DB); err == nil {
+				router.POST("/api/v1/sources/gdrive", auth, handlers.CreateGDriveSource(sourceRepo))
+			}
 		}
 	}
 	router.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))

--- a/api-go/internal/docs/docs.go
+++ b/api-go/internal/docs/docs.go
@@ -56,6 +56,12 @@ const docTemplate = `{
                             "type": "string"
                         }
                     },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
                     "409": {
                         "description": "Conflict",
                         "schema": {

--- a/api-go/internal/docs/docs.go
+++ b/api-go/internal/docs/docs.go
@@ -15,51 +15,6 @@ const docTemplate = `{
     "host": "{{.Host}}",
     "basePath": "{{.BasePath}}",
     "paths": {
-        "/api/v1/users": {
-            "post": {
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "users"
-                ],
-                "summary": "Create user",
-                "parameters": [
-                    {
-                        "description": "User to create",
-                        "name": "user",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/handlers.createUserRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/handlers.createUserResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "409": {
-                        "description": "Conflict",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
         "/api/v1/buckets": {
             "post": {
                 "security": [
@@ -93,6 +48,107 @@ const docTemplate = `{
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/handlers.createBucketResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/sources/gdrive": {
+            "post": {
+                "security": [
+                    {
+                        "BasicAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "sources"
+                ],
+                "summary": "Create gdrive source",
+                "parameters": [
+                    {
+                        "description": "Source to create",
+                        "name": "source",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.createGDriveSourceRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.createSourceResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/users": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "users"
+                ],
+                "summary": "Create user",
+                "parameters": [
+                    {
+                        "description": "User to create",
+                        "name": "user",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.createUserRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.createUserResponse"
                         }
                     },
                     "400": {
@@ -210,6 +266,41 @@ const docTemplate = `{
                 }
             }
         },
+        "handlers.createGDriveSourceRequest": {
+            "type": "object",
+            "required": [
+                "key",
+                "name"
+            ],
+            "properties": {
+                "key": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.createSourceResponse": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "key": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
         "handlers.createUserRequest": {
             "type": "object",
             "required": [
@@ -217,7 +308,7 @@ const docTemplate = `{
             ],
             "properties": {
                 "username": {
-                    "type": "string",
+                    "type": "string"
                 }
             }
         },
@@ -225,13 +316,13 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "created_at": {
-                    "type": "string",
+                    "type": "string"
                 },
                 "id": {
-                    "type": "string",
+                    "type": "string"
                 },
                 "password": {
-                    "type": "string",
+                    "type": "string"
                 }
             }
         }

--- a/api-go/internal/handlers/auth.go
+++ b/api-go/internal/handlers/auth.go
@@ -1,0 +1,44 @@
+package handlers
+
+import (
+	"log"
+	"net/http"
+
+	"github.com/example/s3aas/api-go/internal/repository"
+	"github.com/gin-gonic/gin"
+	"go.mongodb.org/mongo-driver/mongo"
+	"golang.org/x/crypto/bcrypt"
+)
+
+// BasicAuth is a middleware that validates HTTP Basic credentials and sets the user ID in context.
+func BasicAuth(repo *repository.UserRepository) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		username, password, ok := c.Request.BasicAuth()
+		if !ok {
+			c.Header("WWW-Authenticate", `Basic realm="restricted"`)
+			c.AbortWithStatus(http.StatusUnauthorized)
+			return
+		}
+		if repo == nil {
+			log.Print("basic auth: user repository is nil")
+			c.AbortWithStatus(http.StatusServiceUnavailable)
+			return
+		}
+		user, err := repo.GetByUsername(c.Request.Context(), username)
+		if err != nil {
+			if err == mongo.ErrNoDocuments {
+				c.AbortWithStatus(http.StatusUnauthorized)
+				return
+			}
+			log.Printf("basic auth: failed to get user: %v", err)
+			c.AbortWithStatus(http.StatusInternalServerError)
+			return
+		}
+		if bcrypt.CompareHashAndPassword([]byte(user.PasswordHash), []byte(password)) != nil {
+			c.AbortWithStatus(http.StatusUnauthorized)
+			return
+		}
+		c.Set("userID", user.ID.Hex())
+		c.Next()
+	}
+}

--- a/api-go/internal/handlers/bucket.go
+++ b/api-go/internal/handlers/bucket.go
@@ -45,6 +45,7 @@ type createBucketResponse struct {
 // @Param bucket body createBucketRequest true "Bucket to create"
 // @Success 200 {object} createBucketResponse
 // @Failure 400 {string} string ""
+// @Failure 401 {string} string ""
 // @Failure 409 {string} string ""
 // @Security BasicAuth
 // @Router /api/v1/buckets [post]

--- a/api-go/internal/handlers/bucket_test.go
+++ b/api-go/internal/handlers/bucket_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/example/s3aas/api-go/internal/db"
 	"github.com/example/s3aas/api-go/internal/repository"
 	"github.com/gin-gonic/gin"
+	"golang.org/x/crypto/bcrypt"
 )
 
 func TestCreateBucket(t *testing.T) {
@@ -27,15 +28,30 @@ func TestCreateBucket(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	userRepo, err := repository.NewUserRepository(mongoConn.DB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hash, _ := bcrypt.GenerateFromPassword([]byte("pass"), bcrypt.DefaultCost)
+	_, err = userRepo.Create(context.Background(), repository.User{
+		Username:     "tester",
+		PasswordHash: string(hash),
+		CreatedAt:    time.Now().UTC(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
 	repo, err := repository.NewBucketRepository(mongoConn.DB)
 	if err != nil {
 		t.Fatal(err)
 	}
 	router := gin.New()
-	router.POST("/api/v1/buckets", CreateBucket(repo))
+	auth := BasicAuth(userRepo)
+	router.POST("/api/v1/buckets", auth, CreateBucket(repo))
 	body, _ := json.Marshal(map[string]string{"key": "bucket-test"})
 	req, _ := http.NewRequest(http.MethodPost, "/api/v1/buckets", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
+	req.SetBasicAuth("tester", "pass")
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 	if w.Code != http.StatusOK {
@@ -52,5 +68,13 @@ func TestCreateBucket(t *testing.T) {
 	}
 	if resp.Key != "bucket-test" || resp.AccessKey == "" || resp.AccessSecret == "" {
 		t.Fatalf("unexpected response: %+v", resp)
+	}
+	badReq, _ := http.NewRequest(http.MethodPost, "/api/v1/buckets", bytes.NewReader(body))
+	badReq.Header.Set("Content-Type", "application/json")
+	badReq.SetBasicAuth("tester", "wrong")
+	w2 := httptest.NewRecorder()
+	router.ServeHTTP(w2, badReq)
+	if w2.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w2.Code)
 	}
 }

--- a/api-go/internal/handlers/source.go
+++ b/api-go/internal/handlers/source.go
@@ -1,0 +1,82 @@
+package handlers
+
+import (
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/example/s3aas/api-go/internal/repository"
+	"github.com/gin-gonic/gin"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+type createGDriveSourceRequest struct {
+	Name string `json:"name" binding:"required"`
+	Key  string `json:"key" binding:"required"`
+}
+
+type createSourceResponse struct {
+	ID        string    `json:"id"`
+	Name      string    `json:"name"`
+	Type      string    `json:"type"`
+	Key       string    `json:"key"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// CreateGDriveSource godoc
+// @Summary Create gdrive source
+// @Tags sources
+// @Accept json
+// @Produce json
+// @Param source body createGDriveSourceRequest true "Source to create"
+// @Success 200 {object} createSourceResponse
+// @Failure 400 {string} string ""
+// @Failure 401 {string} string ""
+// @Failure 500 {string} string ""
+// @Security BasicAuth
+// @Router /api/v1/sources/gdrive [post]
+func CreateGDriveSource(repo *repository.SourceRepository) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var req createGDriveSourceRequest
+		if err := c.ShouldBindJSON(&req); err != nil {
+			log.Printf("create gdrive source: invalid request: %v", err)
+			c.Status(http.StatusBadRequest)
+			return
+		}
+		if repo == nil {
+			log.Print("create gdrive source: repository is nil")
+			c.Status(http.StatusServiceUnavailable)
+			return
+		}
+		userIDHex := c.GetString("userID")
+		if userIDHex == "" {
+			c.Status(http.StatusUnauthorized)
+			return
+		}
+		userID, err := primitive.ObjectIDFromHex(userIDHex)
+		if err != nil {
+			c.Status(http.StatusUnauthorized)
+			return
+		}
+		source := repository.Source{
+			UserID:    userID,
+			Type:      repository.SourceTypeGDrive,
+			Name:      req.Name,
+			Key:       req.Key,
+			CreatedAt: time.Now().UTC(),
+		}
+		created, err := repo.Create(c.Request.Context(), source)
+		if err != nil {
+			log.Printf("create gdrive source: failed to create: %v", err)
+			c.Status(http.StatusInternalServerError)
+			return
+		}
+		c.JSON(http.StatusOK, createSourceResponse{
+			ID:        created.ID.Hex(),
+			Name:      created.Name,
+			Type:      string(created.Type),
+			Key:       created.Key,
+			CreatedAt: created.CreatedAt,
+		})
+	}
+}

--- a/api-go/internal/handlers/source_test.go
+++ b/api-go/internal/handlers/source_test.go
@@ -1,0 +1,71 @@
+//go:build integration
+// +build integration
+
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/example/s3aas/api-go/internal/config"
+	"github.com/example/s3aas/api-go/internal/db"
+	"github.com/example/s3aas/api-go/internal/repository"
+	"github.com/gin-gonic/gin"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+func TestCreateGDriveSource(t *testing.T) {
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	mongoConn, err := db.Connect(context.Background(), cfg.Mongo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo, err := repository.NewSourceRepository(mongoConn.DB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	userID := primitive.NewObjectID()
+	router := gin.New()
+	router.Use(func(c *gin.Context) { c.Set("userID", userID.Hex()) })
+	router.POST("/api/v1/sources/gdrive", CreateGDriveSource(repo))
+	body, _ := json.Marshal(map[string]string{"name": "src-test", "key": "{}"})
+	req, _ := http.NewRequest(http.MethodPost, "/api/v1/sources/gdrive", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var resp struct {
+		ID        string    `json:"id"`
+		Name      string    `json:"name"`
+		Type      string    `json:"type"`
+		Key       string    `json:"key"`
+		CreatedAt time.Time `json:"created_at"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+	if resp.Name != "src-test" || resp.Type != string(repository.SourceTypeGDrive) || resp.Key != "{}" {
+		t.Fatalf("unexpected response: %+v", resp)
+	}
+	oid, err := primitive.ObjectIDFromHex(resp.ID)
+	if err != nil {
+		t.Fatalf("invalid id: %v", err)
+	}
+	stored, err := repo.GetByID(context.Background(), oid)
+	if err != nil {
+		t.Fatalf("failed to get stored source: %v", err)
+	}
+	if stored.UserID != userID {
+		t.Fatalf("unexpected user id: %s != %s", stored.UserID.Hex(), userID.Hex())
+	}
+}

--- a/api-go/internal/handlers/source_test.go
+++ b/api-go/internal/handlers/source_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/example/s3aas/api-go/internal/repository"
 	"github.com/gin-gonic/gin"
 	"go.mongodb.org/mongo-driver/bson/primitive"
+	"golang.org/x/crypto/bcrypt"
 )
 
 func TestCreateGDriveSource(t *testing.T) {
@@ -28,17 +29,30 @@ func TestCreateGDriveSource(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	userRepo, err := repository.NewUserRepository(mongoConn.DB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hash, _ := bcrypt.GenerateFromPassword([]byte("pass"), bcrypt.DefaultCost)
+	user, err := userRepo.Create(context.Background(), repository.User{
+		Username:     "tester",
+		PasswordHash: string(hash),
+		CreatedAt:    time.Now().UTC(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
 	repo, err := repository.NewSourceRepository(mongoConn.DB)
 	if err != nil {
 		t.Fatal(err)
 	}
-	userID := primitive.NewObjectID()
 	router := gin.New()
-	router.Use(func(c *gin.Context) { c.Set("userID", userID.Hex()) })
-	router.POST("/api/v1/sources/gdrive", CreateGDriveSource(repo))
+	auth := BasicAuth(userRepo)
+	router.POST("/api/v1/sources/gdrive", auth, CreateGDriveSource(repo))
 	body, _ := json.Marshal(map[string]string{"name": "src-test", "key": "{}"})
 	req, _ := http.NewRequest(http.MethodPost, "/api/v1/sources/gdrive", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
+	req.SetBasicAuth("tester", "pass")
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 	if w.Code != http.StatusOK {
@@ -65,7 +79,7 @@ func TestCreateGDriveSource(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get stored source: %v", err)
 	}
-	if stored.UserID != userID {
-		t.Fatalf("unexpected user id: %s != %s", stored.UserID.Hex(), userID.Hex())
+	if stored.UserID != user.ID {
+		t.Fatalf("unexpected user id: %s != %s", stored.UserID.Hex(), user.ID.Hex())
 	}
 }

--- a/api-go/internal/repository/source.go
+++ b/api-go/internal/repository/source.go
@@ -1,0 +1,68 @@
+package repository
+
+import (
+	"context"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+// SourceType represents type of external source.
+type SourceType string
+
+const (
+	// SourceTypeGDrive is Google Drive source type.
+	SourceTypeGDrive SourceType = "gdrive"
+)
+
+// Source represents external data source stored in MongoDB.
+type Source struct {
+	ID        primitive.ObjectID `bson:"_id,omitempty"`
+	UserID    primitive.ObjectID `bson:"user_id"`
+	Type      SourceType         `bson:"type"`
+	Name      string             `bson:"name"`
+	Key       string             `bson:"key"`
+	CreatedAt time.Time          `bson:"created_at"`
+}
+
+// SourceRepository handles CRUD operations on sources.
+type SourceRepository struct {
+	coll *mongo.Collection
+}
+
+// NewSourceRepository creates new SourceRepository.
+func NewSourceRepository(db *mongo.Database) (*SourceRepository, error) {
+	coll := db.Collection("sources")
+	_, err := coll.Indexes().CreateOne(context.Background(), mongo.IndexModel{
+		Keys: bson.D{{Key: "user_id", Value: 1}},
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &SourceRepository{coll: coll}, nil
+}
+
+// Create stores new source in MongoDB.
+func (r *SourceRepository) Create(ctx context.Context, s Source) (*Source, error) {
+	s.CreatedAt = s.CreatedAt.UTC()
+	res, err := r.coll.InsertOne(ctx, s)
+	if err != nil {
+		return nil, err
+	}
+	if oid, ok := res.InsertedID.(primitive.ObjectID); ok {
+		s.ID = oid
+	}
+	return &s, nil
+}
+
+// GetByID returns source by its ID.
+func (r *SourceRepository) GetByID(ctx context.Context, id primitive.ObjectID) (*Source, error) {
+	var s Source
+	err := r.coll.FindOne(ctx, bson.M{"_id": id}).Decode(&s)
+	if err != nil {
+		return nil, err
+	}
+	return &s, nil
+}

--- a/api-go/internal/repository/source_test.go
+++ b/api-go/internal/repository/source_test.go
@@ -1,0 +1,50 @@
+//go:build integration
+// +build integration
+
+package repository
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/example/s3aas/api-go/internal/config"
+	"github.com/example/s3aas/api-go/internal/db"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+func TestCreateSource(t *testing.T) {
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	mongoConn, err := db.Connect(context.Background(), cfg.Mongo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo, err := NewSourceRepository(mongoConn.DB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := Source{
+		UserID:    primitive.NewObjectID(),
+		Type:      SourceTypeGDrive,
+		Name:      "gdrive-test",
+		Key:       "{}",
+		CreatedAt: time.Now().UTC(),
+	}
+	created, err := repo.Create(context.Background(), src)
+	if err != nil {
+		t.Fatalf("failed to create source: %v", err)
+	}
+	if created.ID.IsZero() {
+		t.Fatalf("expected ID to be set")
+	}
+	stored, err := repo.GetByID(context.Background(), created.ID)
+	if err != nil {
+		t.Fatalf("failed to get source: %v", err)
+	}
+	if stored.Name != src.Name || stored.Key != src.Key || stored.Type != src.Type {
+		t.Fatalf("unexpected stored source: %+v", stored)
+	}
+}


### PR DESCRIPTION
## Summary
- store external sources with user association
- add POST /api/v1/sources/gdrive handler
- document new source endpoint in swagger

## Testing
- `go test ./...`
- `go test -tags=integration ./...` *(fails: server selection timeout for mongo)*
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68aef235bcfc8324a1a1465bca83a2ec