### PR TITLE
feat: add list and delete endpoints for buckets and sources

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,3 @@
+The primary API is located in `api-go`. The `api` directory contains a deprecated Python API and should not be modified unless explicitly requested.
+
+Avoid leaving comments in code unless they clarify complex logic or are required by tools such as linters or Swagger.

--- a/api-go/.gitignore
+++ b/api-go/.gitignore
@@ -1,1 +1,3 @@
 bin/
+internal/docs/swagger.json
+internal/docs/swagger.yaml

--- a/api-go/AGENTS.md
+++ b/api-go/AGENTS.md
@@ -1,1 +1,3 @@
-When modifying, adding, or removing API endpoints, make sure to update the swagger documentation located under internal/docs.
+When modifying, adding, or removing API endpoints, update the Swagger documentation by editing Go code comments and regenerating `internal/docs/docs.go`. Do not commit generated artifacts such as `swagger.yaml` or `swagger.json`; `docs.go` is the single source of truth.
+
+Run `golangci-lint run` and `go test ./...` for this module. Skip integration tests; unit tests are sufficient.

--- a/api-go/internal/app/router.go
+++ b/api-go/internal/app/router.go
@@ -23,9 +23,13 @@ func SetupRouter(m *db.Mongo) *gin.Engine {
 			router.POST("/api/v1/users", handlers.CreateUser(userRepo))
 			if bucketRepo, err := repository.NewBucketRepository(m.DB); err == nil {
 				router.POST("/api/v1/buckets", auth, handlers.CreateBucket(bucketRepo))
+				router.GET("/api/v1/buckets", auth, handlers.ListBuckets(bucketRepo))
+				router.DELETE("/api/v1/buckets/:id", auth, handlers.DeleteBucket(bucketRepo))
 			}
 			if sourceRepo, err := repository.NewSourceRepository(m.DB); err == nil {
 				router.POST("/api/v1/sources/gdrive", auth, handlers.CreateGDriveSource(sourceRepo))
+				router.GET("/api/v1/sources", auth, handlers.ListSources(sourceRepo))
+				router.DELETE("/api/v1/sources/:id", auth, handlers.DeleteSource(sourceRepo))
 			}
 		}
 	}

--- a/api-go/internal/docs/docs.go
+++ b/api-go/internal/docs/docs.go
@@ -16,6 +16,43 @@ const docTemplate = `{
     "basePath": "{{.BasePath}}",
     "paths": {
         "/api/v1/buckets": {
+            "get": {
+                "security": [
+                    {
+                        "BasicAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "buckets"
+                ],
+                "summary": "List buckets",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/handlers.bucketResponse"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            },
             "post": {
                 "security": [
                     {
@@ -71,6 +108,99 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/buckets/{id}": {
+            "delete": {
+                "security": [
+                    {
+                        "BasicAuth": []
+                    }
+                ],
+                "tags": [
+                    "buckets"
+                ],
+                "summary": "Delete bucket",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Bucket ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/sources": {
+            "get": {
+                "security": [
+                    {
+                        "BasicAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "sources"
+                ],
+                "summary": "List sources",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/handlers.createSourceResponse"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/sources/gdrive": {
             "post": {
                 "security": [
@@ -114,6 +244,60 @@ const docTemplate = `{
                     },
                     "401": {
                         "description": "Unauthorized",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/sources/{id}": {
+            "delete": {
+                "security": [
+                    {
+                        "BasicAuth": []
+                    }
+                ],
+                "tags": [
+                    "sources"
+                ],
+                "summary": "Delete source",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Source ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
                         "schema": {
                             "type": "string"
                         }
@@ -244,6 +428,26 @@ const docTemplate = `{
         }
     },
     "definitions": {
+        "handlers.bucketResponse": {
+            "type": "object",
+            "properties": {
+                "access_key": {
+                    "type": "string"
+                },
+                "access_secret": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "key": {
+                    "type": "string"
+                }
+            }
+        },
         "handlers.createBucketRequest": {
             "type": "object",
             "required": [

--- a/api-go/internal/handlers/bucket.go
+++ b/api-go/internal/handlers/bucket.go
@@ -9,10 +9,10 @@ import (
 
 	"github.com/example/s3aas/api-go/internal/repository"
 	"github.com/gin-gonic/gin"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
-// random string generator
 const accessSecretLength = 80
 
 var alphabet = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~")
@@ -31,6 +31,14 @@ type createBucketRequest struct {
 }
 
 type createBucketResponse struct {
+	Key          string    `json:"key"`
+	AccessKey    string    `json:"access_key"`
+	AccessSecret string    `json:"access_secret"`
+	CreatedAt    time.Time `json:"created_at"`
+}
+
+type bucketResponse struct {
+	ID           string    `json:"id"`
 	Key          string    `json:"key"`
 	AccessKey    string    `json:"access_key"`
 	AccessSecret string    `json:"access_secret"`
@@ -87,5 +95,78 @@ func CreateBucket(repo *repository.BucketRepository) gin.HandlerFunc {
 			AccessSecret: created.AccessSecret,
 			CreatedAt:    created.CreatedAt,
 		})
+	}
+}
+
+// ListBuckets godoc
+// @Summary List buckets
+// @Tags buckets
+// @Produce json
+// @Success 200 {array} bucketResponse
+// @Failure 401 {string} string ""
+// @Failure 500 {string} string ""
+// @Security BasicAuth
+// @Router /api/v1/buckets [get]
+func ListBuckets(repo *repository.BucketRepository) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if repo == nil {
+			log.Print("list buckets: repository is nil")
+			c.Status(http.StatusServiceUnavailable)
+			return
+		}
+		buckets, err := repo.List(c.Request.Context())
+		if err != nil {
+			log.Printf("list buckets: failed to list buckets: %v", err)
+			c.Status(http.StatusInternalServerError)
+			return
+		}
+		resp := make([]bucketResponse, 0, len(buckets))
+		for _, b := range buckets {
+			resp = append(resp, bucketResponse{
+				ID:           b.ID.Hex(),
+				Key:          b.Key,
+				AccessKey:    b.AccessKey,
+				AccessSecret: b.AccessSecret,
+				CreatedAt:    b.CreatedAt,
+			})
+		}
+		c.JSON(http.StatusOK, resp)
+	}
+}
+
+// DeleteBucket godoc
+// @Summary Delete bucket
+// @Tags buckets
+// @Param id path string true "Bucket ID"
+// @Success 200 {string} string ""
+// @Failure 400 {string} string ""
+// @Failure 401 {string} string ""
+// @Failure 404 {string} string ""
+// @Failure 500 {string} string ""
+// @Security BasicAuth
+// @Router /api/v1/buckets/{id} [delete]
+func DeleteBucket(repo *repository.BucketRepository) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if repo == nil {
+			log.Print("delete bucket: repository is nil")
+			c.Status(http.StatusServiceUnavailable)
+			return
+		}
+		idHex := c.Param("id")
+		id, err := primitive.ObjectIDFromHex(idHex)
+		if err != nil {
+			c.Status(http.StatusBadRequest)
+			return
+		}
+		if err := repo.Delete(c.Request.Context(), id); err != nil {
+			if err == mongo.ErrNoDocuments {
+				c.Status(http.StatusNotFound)
+				return
+			}
+			log.Printf("delete bucket: failed to delete: %v", err)
+			c.Status(http.StatusInternalServerError)
+			return
+		}
+		c.Status(http.StatusOK)
 	}
 }

--- a/api-go/internal/handlers/source.go
+++ b/api-go/internal/handlers/source.go
@@ -8,6 +8,7 @@ import (
 	"github.com/example/s3aas/api-go/internal/repository"
 	"github.com/gin-gonic/gin"
 	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
 )
 
 type createGDriveSourceRequest struct {
@@ -78,5 +79,98 @@ func CreateGDriveSource(repo *repository.SourceRepository) gin.HandlerFunc {
 			Key:       created.Key,
 			CreatedAt: created.CreatedAt,
 		})
+	}
+}
+
+// ListSources godoc
+// @Summary List sources
+// @Tags sources
+// @Produce json
+// @Success 200 {array} createSourceResponse
+// @Failure 401 {string} string ""
+// @Failure 500 {string} string ""
+// @Security BasicAuth
+// @Router /api/v1/sources [get]
+func ListSources(repo *repository.SourceRepository) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if repo == nil {
+			log.Print("list sources: repository is nil")
+			c.Status(http.StatusServiceUnavailable)
+			return
+		}
+		userIDHex := c.GetString("userID")
+		if userIDHex == "" {
+			c.Status(http.StatusUnauthorized)
+			return
+		}
+		userID, err := primitive.ObjectIDFromHex(userIDHex)
+		if err != nil {
+			c.Status(http.StatusUnauthorized)
+			return
+		}
+		sources, err := repo.ListByUser(c.Request.Context(), userID)
+		if err != nil {
+			log.Printf("list sources: failed to list: %v", err)
+			c.Status(http.StatusInternalServerError)
+			return
+		}
+		resp := make([]createSourceResponse, 0, len(sources))
+		for _, s := range sources {
+			resp = append(resp, createSourceResponse{
+				ID:        s.ID.Hex(),
+				Name:      s.Name,
+				Type:      string(s.Type),
+				Key:       s.Key,
+				CreatedAt: s.CreatedAt,
+			})
+		}
+		c.JSON(http.StatusOK, resp)
+	}
+}
+
+// DeleteSource godoc
+// @Summary Delete source
+// @Tags sources
+// @Param id path string true "Source ID"
+// @Success 200 {string} string ""
+// @Failure 400 {string} string ""
+// @Failure 401 {string} string ""
+// @Failure 404 {string} string ""
+// @Failure 500 {string} string ""
+// @Security BasicAuth
+// @Router /api/v1/sources/{id} [delete]
+func DeleteSource(repo *repository.SourceRepository) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if repo == nil {
+			log.Print("delete source: repository is nil")
+			c.Status(http.StatusServiceUnavailable)
+			return
+		}
+		userIDHex := c.GetString("userID")
+		if userIDHex == "" {
+			c.Status(http.StatusUnauthorized)
+			return
+		}
+		userID, err := primitive.ObjectIDFromHex(userIDHex)
+		if err != nil {
+			c.Status(http.StatusUnauthorized)
+			return
+		}
+		idHex := c.Param("id")
+		id, err := primitive.ObjectIDFromHex(idHex)
+		if err != nil {
+			c.Status(http.StatusBadRequest)
+			return
+		}
+		if err := repo.Delete(c.Request.Context(), id, userID); err != nil {
+			if err == mongo.ErrNoDocuments {
+				c.Status(http.StatusNotFound)
+				return
+			}
+			log.Printf("delete source: failed to delete: %v", err)
+			c.Status(http.StatusInternalServerError)
+			return
+		}
+		c.Status(http.StatusOK)
 	}
 }

--- a/api-go/internal/repository/bucket.go
+++ b/api-go/internal/repository/bucket.go
@@ -10,8 +10,6 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
-// Bucket represents storage bucket information
-// stored in MongoDB.
 type Bucket struct {
 	ID           primitive.ObjectID `bson:"_id,omitempty"`
 	Key          string             `bson:"key"`
@@ -55,4 +53,35 @@ func (r *BucketRepository) GetByKey(ctx context.Context, key string) (*Bucket, e
 		return nil, err
 	}
 	return &b, nil
+}
+
+func (r *BucketRepository) List(ctx context.Context) ([]Bucket, error) {
+	cursor, err := r.coll.Find(ctx, bson.D{})
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = cursor.Close(ctx) }()
+	var buckets []Bucket
+	for cursor.Next(ctx) {
+		var b Bucket
+		if err := cursor.Decode(&b); err != nil {
+			return nil, err
+		}
+		buckets = append(buckets, b)
+	}
+	if err := cursor.Err(); err != nil {
+		return nil, err
+	}
+	return buckets, nil
+}
+
+func (r *BucketRepository) Delete(ctx context.Context, id primitive.ObjectID) error {
+	res, err := r.coll.DeleteOne(ctx, bson.M{"_id": id})
+	if err != nil {
+		return err
+	}
+	if res.DeletedCount == 0 {
+		return mongo.ErrNoDocuments
+	}
+	return nil
 }

--- a/api-go/internal/repository/source.go
+++ b/api-go/internal/repository/source.go
@@ -9,15 +9,12 @@ import (
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
-// SourceType represents type of external source.
 type SourceType string
 
 const (
-	// SourceTypeGDrive is Google Drive source type.
 	SourceTypeGDrive SourceType = "gdrive"
 )
 
-// Source represents external data source stored in MongoDB.
 type Source struct {
 	ID        primitive.ObjectID `bson:"_id,omitempty"`
 	UserID    primitive.ObjectID `bson:"user_id"`
@@ -27,12 +24,10 @@ type Source struct {
 	CreatedAt time.Time          `bson:"created_at"`
 }
 
-// SourceRepository handles CRUD operations on sources.
 type SourceRepository struct {
 	coll *mongo.Collection
 }
 
-// NewSourceRepository creates new SourceRepository.
 func NewSourceRepository(db *mongo.Database) (*SourceRepository, error) {
 	coll := db.Collection("sources")
 	_, err := coll.Indexes().CreateOne(context.Background(), mongo.IndexModel{
@@ -44,7 +39,6 @@ func NewSourceRepository(db *mongo.Database) (*SourceRepository, error) {
 	return &SourceRepository{coll: coll}, nil
 }
 
-// Create stores new source in MongoDB.
 func (r *SourceRepository) Create(ctx context.Context, s Source) (*Source, error) {
 	s.CreatedAt = s.CreatedAt.UTC()
 	res, err := r.coll.InsertOne(ctx, s)
@@ -57,7 +51,6 @@ func (r *SourceRepository) Create(ctx context.Context, s Source) (*Source, error
 	return &s, nil
 }
 
-// GetByID returns source by its ID.
 func (r *SourceRepository) GetByID(ctx context.Context, id primitive.ObjectID) (*Source, error) {
 	var s Source
 	err := r.coll.FindOne(ctx, bson.M{"_id": id}).Decode(&s)
@@ -65,4 +58,35 @@ func (r *SourceRepository) GetByID(ctx context.Context, id primitive.ObjectID) (
 		return nil, err
 	}
 	return &s, nil
+}
+
+func (r *SourceRepository) ListByUser(ctx context.Context, userID primitive.ObjectID) ([]Source, error) {
+	cursor, err := r.coll.Find(ctx, bson.M{"user_id": userID})
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = cursor.Close(ctx) }()
+	var sources []Source
+	for cursor.Next(ctx) {
+		var s Source
+		if err := cursor.Decode(&s); err != nil {
+			return nil, err
+		}
+		sources = append(sources, s)
+	}
+	if err := cursor.Err(); err != nil {
+		return nil, err
+	}
+	return sources, nil
+}
+
+func (r *SourceRepository) Delete(ctx context.Context, id, userID primitive.ObjectID) error {
+	res, err := r.coll.DeleteOne(ctx, bson.M{"_id": id, "user_id": userID})
+	if err != nil {
+		return err
+	}
+	if res.DeletedCount == 0 {
+		return mongo.ErrNoDocuments
+	}
+	return nil
 }


### PR DESCRIPTION
## Summary
- add handlers and repository methods to list and delete buckets and sources
- expose new endpoints via router with BasicAuth and Go-generated swagger docs
- add AGENTS guidelines about swagger, tests, and comment usage; clarify api-go is the primary API
- drop generated swagger.json/yaml and ignore them in git

## Testing
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68af0b6ee9748324a6b258b4ced380f3