### PR TITLE
Add source info endpoint

### DIFF
--- a/api-go/internal/app/router.go
+++ b/api-go/internal/app/router.go
@@ -53,6 +53,7 @@ func SetupRouter(m *db.Mongo, cfg *config.Config) *gin.Engine {
 	if auth != nil && sourceRepo != nil {
 		router.POST("/api/v1/sources/gdrive", auth, handlers.CreateGDriveSource(sourceRepo))
 		router.GET("/api/v1/sources", auth, handlers.ListSources(sourceRepo))
+		router.GET("/api/v1/sources/:id/info", auth, handlers.GetSourceInfo(sourceRepo))
 		router.DELETE("/api/v1/sources/:id", auth, handlers.DeleteSource(sourceRepo))
 	}
 

--- a/api-go/internal/docs/docs.go
+++ b/api-go/internal/docs/docs.go
@@ -442,6 +442,60 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/sources/{id}/info": {
+            "get": {
+                "security": [
+                    {
+                        "BasicAuth": []
+                    }
+                ],
+                "tags": [
+                    "sources"
+                ],
+                "summary": "Get source info",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Source ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.sourceInfoResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/users": {
             "post": {
                 "consumes": [
@@ -663,6 +717,49 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "password": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.sourceInfoFile": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "size": {
+                    "type": "integer"
+                }
+            }
+        },
+        "handlers.sourceInfoResponse": {
+            "type": "object",
+            "properties": {
+                "files": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/handlers.sourceInfoFile"
+                    }
+                },
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "storage_free": {
+                    "type": "integer"
+                },
+                "storage_total": {
+                    "type": "integer"
+                },
+                "storage_used": {
+                    "type": "integer"
+                },
+                "type": {
                     "type": "string"
                 }
             }

--- a/api-go/internal/gdrive/client.go
+++ b/api-go/internal/gdrive/client.go
@@ -12,6 +12,12 @@ type Client struct {
 	service *drive.Service
 }
 
+type File struct {
+	ID   string
+	Name string
+	Size int64
+}
+
 func NewClient(ctx context.Context, credsJSON []byte) (*Client, error) {
 	srv, err := drive.NewService(ctx, option.WithCredentialsJSON(credsJSON))
 	if err != nil {
@@ -35,4 +41,38 @@ func (c *Client) Download(ctx context.Context, id string) (io.ReadCloser, error)
 		return nil, err
 	}
 	return res.Body, nil
+}
+
+func (c *Client) ListFiles(ctx context.Context) ([]File, error) {
+	var all []File
+	pageToken := ""
+	for {
+		call := c.service.Files.List().Fields("nextPageToken,files(id,name,size)").PageSize(1000)
+		if pageToken != "" {
+			call = call.PageToken(pageToken)
+		}
+		res, err := call.Context(ctx).Do()
+		if err != nil {
+			return nil, err
+		}
+		for _, f := range res.Files {
+			all = append(all, File{ID: f.Id, Name: f.Name, Size: f.Size})
+		}
+		if res.NextPageToken == "" {
+			break
+		}
+		pageToken = res.NextPageToken
+	}
+	return all, nil
+}
+
+func (c *Client) StorageInfo(ctx context.Context) (total, used, free int64, err error) {
+	about, err := c.service.About.Get().Fields("storageQuota").Context(ctx).Do()
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	total = about.StorageQuota.Limit
+	used = about.StorageQuota.Usage
+	free = total - used
+	return
 }

--- a/api-go/internal/handlers/source.go
+++ b/api-go/internal/handlers/source.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/example/s3aas/api-go/internal/gdrive"
 	"github.com/example/s3aas/api-go/internal/repository"
 	"github.com/gin-gonic/gin"
 	"go.mongodb.org/mongo-driver/bson/primitive"
@@ -22,6 +23,22 @@ type createSourceResponse struct {
 	Type      string    `json:"type"`
 	Key       string    `json:"key"`
 	CreatedAt time.Time `json:"created_at"`
+}
+
+type sourceInfoFile struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	Size int64  `json:"size"`
+}
+
+type sourceInfoResponse struct {
+	ID           string           `json:"id"`
+	Name         string           `json:"name"`
+	Type         string           `json:"type"`
+	Files        []sourceInfoFile `json:"files"`
+	StorageTotal int64            `json:"storage_total"`
+	StorageUsed  int64            `json:"storage_used"`
+	StorageFree  int64            `json:"storage_free"`
 }
 
 // CreateGDriveSource godoc
@@ -172,5 +189,92 @@ func DeleteSource(repo *repository.SourceRepository) gin.HandlerFunc {
 			return
 		}
 		c.Status(http.StatusOK)
+	}
+}
+
+// GetSourceInfo godoc
+// @Summary Get source info
+// @Tags sources
+// @Param id path string true "Source ID"
+// @Success 200 {object} sourceInfoResponse
+// @Failure 400 {string} string ""
+// @Failure 401 {string} string ""
+// @Failure 404 {string} string ""
+// @Failure 500 {string} string ""
+// @Security BasicAuth
+// @Router /api/v1/sources/{id}/info [get]
+func GetSourceInfo(repo *repository.SourceRepository) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if repo == nil {
+			log.Print("get source info: repository is nil")
+			c.Status(http.StatusServiceUnavailable)
+			return
+		}
+		userIDHex := c.GetString("userID")
+		if userIDHex == "" {
+			c.Status(http.StatusUnauthorized)
+			return
+		}
+		userID, err := primitive.ObjectIDFromHex(userIDHex)
+		if err != nil {
+			c.Status(http.StatusUnauthorized)
+			return
+		}
+		idHex := c.Param("id")
+		id, err := primitive.ObjectIDFromHex(idHex)
+		if err != nil {
+			c.Status(http.StatusBadRequest)
+			return
+		}
+		src, err := repo.GetByID(c.Request.Context(), id)
+		if err != nil {
+			if err == mongo.ErrNoDocuments {
+				c.Status(http.StatusNotFound)
+				return
+			}
+			log.Printf("get source info: get source: %v", err)
+			c.Status(http.StatusInternalServerError)
+			return
+		}
+		if src.UserID != userID {
+			c.Status(http.StatusNotFound)
+			return
+		}
+		switch src.Type {
+		case repository.SourceTypeGDrive:
+			cli, err := gdrive.NewClient(c.Request.Context(), []byte(src.Key))
+			if err != nil {
+				log.Printf("get source info: create client: %v", err)
+				c.Status(http.StatusInternalServerError)
+				return
+			}
+			files, err := cli.ListFiles(c.Request.Context())
+			if err != nil {
+				log.Printf("get source info: list files: %v", err)
+				c.Status(http.StatusInternalServerError)
+				return
+			}
+			total, used, free, err := cli.StorageInfo(c.Request.Context())
+			if err != nil {
+				log.Printf("get source info: storage info: %v", err)
+				c.Status(http.StatusInternalServerError)
+				return
+			}
+			resp := sourceInfoResponse{
+				ID:           src.ID.Hex(),
+				Name:         src.Name,
+				Type:         string(src.Type),
+				Files:        make([]sourceInfoFile, len(files)),
+				StorageTotal: total,
+				StorageUsed:  used,
+				StorageFree:  free,
+			}
+			for i, f := range files {
+				resp.Files[i] = sourceInfoFile{ID: f.ID, Name: f.Name, Size: f.Size}
+			}
+			c.JSON(http.StatusOK, resp)
+		default:
+			c.Status(http.StatusNotImplemented)
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- add Google Drive client methods for listing files and storage quota
- expose GET `/api/v1/sources/:id/info` endpoint returning files and storage stats
- register route and refresh Swagger docs

## Testing
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68af401ad440832493b60aa544423693