### PR TITLE
feat(webui): add auth dialogs

### DIFF
--- a/webui/src/features/auth/ui/register-dialog.tsx
+++ b/webui/src/features/auth/ui/register-dialog.tsx
@@ -1,4 +1,4 @@
-import {Button, Input, Modal, ModalBody, ModalContent, ModalFooter, ModalHeader} from "@heroui/react";
+import {Button, Input, Modal, ModalBody, ModalContent, ModalFooter, ModalHeader, Snippet} from "@heroui/react";
 import {useState} from "react";
 import {createUser} from "../../../shared/api/users";
 import {saveAuth} from "../../../shared/lib/auth";
@@ -7,17 +7,46 @@ type Props = {isOpen: boolean; onOpenChange: (open: boolean) => void};
 
 export function RegisterDialog({isOpen, onOpenChange}: Props) {
   const [username, setUsername] = useState("");
+  const [password, setPassword] = useState<string | null>(null);
+
   return (
-    <Modal isOpen={isOpen} onOpenChange={onOpenChange}>
+    <Modal
+      isOpen={isOpen}
+      onOpenChange={(open) => {
+        if (!open) {
+          setUsername("");
+          setPassword(null);
+        }
+        onOpenChange(open);
+      }}
+    >
       <ModalContent>
         {(onClose) => (
           <>
             <ModalHeader>Sign Up</ModalHeader>
             <ModalBody>
               <Input label="Username" value={username} onChange={(e) => setUsername(e.target.value)} />
+              {password && (
+                <Snippet hideSymbol>{password}</Snippet>
+              )}
             </ModalBody>
             <ModalFooter>
-              <Button color="primary" onPress={async () => {const {password} = await createUser(username); saveAuth(username, password); onClose();}}>Sign Up</Button>
+              {password ? (
+                <Button color="primary" onPress={onClose}>
+                  Close
+                </Button>
+              ) : (
+                <Button
+                  color="primary"
+                  onPress={async () => {
+                    const {password} = await createUser(username);
+                    saveAuth(username, password);
+                    setPassword(password);
+                  }}
+                >
+                  Sign Up
+                </Button>
+              )}
             </ModalFooter>
           </>
         )}


### PR DESCRIPTION
## Summary
- add API client for user creation and auth storage helper
- implement login and sign-up dialogs using HeroUI
- display generated password in sign-up dialog with convenient copy button
- wire dialogs into landing page

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0bfa850648324bf1cac67c4654fdf