### PR TITLE
feat(webui): add buckets page

### DIFF
--- a/webui/src/app/index.tsx
+++ b/webui/src/app/index.tsx
@@ -1,6 +1,7 @@
 import {BrowserRouter, Routes, Route, Navigate} from "react-router-dom";
 import LandingPage from "../pages/landing";
 import DashboardPage from "../pages/dashboard";
+import BucketsPage from "../pages/buckets";
 
 export default function App() {
   const isAuthenticated = Boolean(localStorage.getItem("auth"));
@@ -13,6 +14,7 @@ export default function App() {
           element={isAuthenticated ? <Navigate to="/dashboard" replace /> : <LandingPage />}
         />
         <Route path="/dashboard" element={<DashboardPage />} />
+        <Route path="/buckets" element={<BucketsPage />} />
       </Routes>
     </BrowserRouter>
   );

--- a/webui/src/features/bucket/index.ts
+++ b/webui/src/features/bucket/index.ts
@@ -1,0 +1,1 @@
+export {CreateBucketDialog} from "./ui/create-bucket-dialog";

--- a/webui/src/features/bucket/ui/create-bucket-dialog.tsx
+++ b/webui/src/features/bucket/ui/create-bucket-dialog.tsx
@@ -1,0 +1,69 @@
+import {Button, Input, Modal, ModalBody, ModalContent, ModalFooter, ModalHeader, Snippet} from "@heroui/react";
+import {useState} from "react";
+import {createBucket} from "../../../shared/api/buckets";
+
+type Props = {isOpen: boolean; onOpenChange: (open: boolean) => void; onCreated: () => void};
+
+export function CreateBucketDialog({isOpen, onOpenChange, onCreated}: Props) {
+  const [key, setKey] = useState("");
+  const [creds, setCreds] = useState<{accessKey: string; accessSecret: string} | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onOpenChange={(open) => {
+        if (!open) {
+          setKey("");
+          setCreds(null);
+        }
+        onOpenChange(open);
+      }}
+    >
+      <ModalContent>
+        {(onClose) => (
+          <>
+            <ModalHeader>Create Bucket</ModalHeader>
+            <ModalBody>
+              {creds ? (
+                <>
+                  <Snippet hideSymbol>{creds.accessKey}</Snippet>
+                  <Snippet hideSymbol>{creds.accessSecret}</Snippet>
+                  <p className="text-sm text-default-500">
+                    Make sure to copy these credentials now. You won't be able to see them again.
+                  </p>
+                </>
+              ) : (
+                <Input label="Key" value={key} onChange={(e) => setKey(e.target.value)} />
+              )}
+            </ModalBody>
+            <ModalFooter>
+              {creds ? (
+                <Button color="primary" onPress={onClose}>
+                  Close
+                </Button>
+              ) : (
+                <Button
+                  color="primary"
+                  isLoading={isLoading}
+                  onPress={async () => {
+                    setIsLoading(true);
+                    try {
+                      const res = await createBucket(key);
+                      setCreds({accessKey: res.access_key, accessSecret: res.access_secret});
+                      onCreated();
+                    } finally {
+                      setIsLoading(false);
+                    }
+                  }}
+                >
+                  Create
+                </Button>
+              )}
+            </ModalFooter>
+          </>
+        )}
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/webui/src/pages/buckets/index.ts
+++ b/webui/src/pages/buckets/index.ts
@@ -1,0 +1,1 @@
+export {BucketsPage as default} from "./ui/buckets-page";

--- a/webui/src/pages/buckets/ui/buckets-page.tsx
+++ b/webui/src/pages/buckets/ui/buckets-page.tsx
@@ -1,0 +1,50 @@
+import {Button, Card, CardBody, CardHeader, useDisclosure} from "@heroui/react";
+import {useEffect, useState} from "react";
+import {CreateBucketDialog} from "../../../features/bucket";
+import {listBuckets} from "../../../shared/api/buckets";
+import type {Bucket} from "../../../shared/api/buckets";
+
+export function BucketsPage() {
+  const [buckets, setBuckets] = useState<Bucket[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const create = useDisclosure();
+
+  async function load() {
+    setIsLoading(true);
+    try {
+      setBuckets(await listBuckets());
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  return (
+    <div className="p-8 flex flex-col gap-6">
+      <div className="flex justify-between items-center">
+        <h1 className="text-3xl font-bold">Buckets</h1>
+        <Button color="primary" onPress={create.onOpen}>
+          Add Bucket
+        </Button>
+      </div>
+      {isLoading && buckets.length === 0 ? (
+        <p>Loading...</p>
+      ) : buckets.length === 0 ? (
+        <p>No buckets yet</p>
+      ) : (
+        <div className="grid gap-4 sm:grid-cols-2">
+          {buckets.map((b) => (
+            <Card key={b.id}>
+              <CardHeader className="font-bold">{b.key}</CardHeader>
+              <CardBody>{new Date(b.created_at).toLocaleString()}</CardBody>
+            </Card>
+          ))}
+        </div>
+      )}
+      <CreateBucketDialog isOpen={create.isOpen} onOpenChange={create.onOpenChange} onCreated={load} />
+    </div>
+  );
+}

--- a/webui/src/shared/api/buckets.ts
+++ b/webui/src/shared/api/buckets.ts
@@ -1,0 +1,29 @@
+const API_BASE = "https://s3aas-api.dev.nachert.art/api/v1";
+
+export type Bucket = {id: string; key: string; created_at: string};
+
+function authHeader(): Record<string, string> {
+  const auth = localStorage.getItem("auth");
+  return auth ? {Authorization: `Basic ${auth}`} : {};
+}
+
+export async function listBuckets(): Promise<Bucket[]> {
+  const res = await fetch(`${API_BASE}/buckets`, {
+    headers: authHeader(),
+  });
+  if (!res.ok) throw new Error("failed to list buckets");
+  return res.json();
+}
+
+export async function createBucket(key: string): Promise<{key: string; access_key: string; access_secret: string; created_at: string}> {
+  const res = await fetch(`${API_BASE}/buckets`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...authHeader(),
+    },
+    body: JSON.stringify({key}),
+  });
+  if (!res.ok) throw new Error("failed to create bucket");
+  return res.json();
+}


### PR DESCRIPTION
## Summary
- add API helpers for listing and creating buckets
- implement bucket creation dialog showing credentials once
- add buckets page with list and creation dialog
- register /buckets route in app router

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b236a8f4748324aa08108a63749c6d