### PR TITLE
feat: add sources page

### DIFF
--- a/webui/src/app/index.tsx
+++ b/webui/src/app/index.tsx
@@ -2,6 +2,8 @@ import {BrowserRouter, Routes, Route, Navigate} from "react-router-dom";
 import LandingPage from "../pages/landing";
 import DashboardPage from "../pages/dashboard";
 import BucketsPage from "../pages/buckets";
+import SourcesPage from "../pages/sources";
+import SourcePage from "../pages/source";
 
 export default function App() {
   const isAuthenticated = Boolean(localStorage.getItem("auth"));
@@ -15,6 +17,8 @@ export default function App() {
         />
         <Route path="/dashboard" element={<DashboardPage />} />
         <Route path="/buckets" element={<BucketsPage />} />
+        <Route path="/sources" element={<SourcesPage />} />
+        <Route path="/sources/:id" element={<SourcePage />} />
       </Routes>
     </BrowserRouter>
   );

--- a/webui/src/features/source/index.ts
+++ b/webui/src/features/source/index.ts
@@ -1,0 +1,1 @@
+export {CreateSourceDialog} from "./ui/create-source-dialog";

--- a/webui/src/features/source/ui/create-source-dialog.tsx
+++ b/webui/src/features/source/ui/create-source-dialog.tsx
@@ -1,0 +1,54 @@
+import {Button, Input, Modal, ModalBody, ModalContent, ModalFooter, ModalHeader, Textarea} from "@heroui/react";
+import {useState} from "react";
+import {createSource} from "../../../shared/api/sources";
+
+type Props = {isOpen: boolean; onOpenChange: (open: boolean) => void; onCreated: () => void};
+
+export function CreateSourceDialog({isOpen, onOpenChange, onCreated}: Props) {
+  const [name, setName] = useState("");
+  const [key, setKey] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onOpenChange={(open) => {
+        if (!open) {
+          setName("");
+          setKey("");
+        }
+        onOpenChange(open);
+      }}
+    >
+      <ModalContent>
+        {(onClose) => (
+          <>
+            <ModalHeader>Create Source</ModalHeader>
+            <ModalBody>
+              <Input label="Name" value={name} onChange={(e) => setName(e.target.value)} />
+              <Textarea label="Key" value={key} onChange={(e) => setKey(e.target.value)} />
+            </ModalBody>
+            <ModalFooter>
+              <Button
+                color="primary"
+                isLoading={isLoading}
+                onPress={async () => {
+                  setIsLoading(true);
+                  try {
+                    await createSource(name, key);
+                    onCreated();
+                    onClose();
+                  } finally {
+                    setIsLoading(false);
+                  }
+                }}
+              >
+                Create
+              </Button>
+            </ModalFooter>
+          </>
+        )}
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/webui/src/pages/source/index.ts
+++ b/webui/src/pages/source/index.ts
@@ -1,0 +1,1 @@
+export {SourcePage as default} from "./ui/source-page";

--- a/webui/src/pages/source/ui/source-page.tsx
+++ b/webui/src/pages/source/ui/source-page.tsx
@@ -1,0 +1,7 @@
+export function SourcePage() {
+  return (
+    <div className="p-8">
+      <p>Source details coming soon</p>
+    </div>
+  );
+}

--- a/webui/src/pages/sources/index.ts
+++ b/webui/src/pages/sources/index.ts
@@ -1,0 +1,1 @@
+export {SourcesPage as default} from "./ui/sources-page";

--- a/webui/src/pages/sources/ui/sources-page.tsx
+++ b/webui/src/pages/sources/ui/sources-page.tsx
@@ -1,0 +1,53 @@
+import {Button, Card, CardBody, CardHeader, useDisclosure} from "@heroui/react";
+import {Link} from "react-router-dom";
+import {useEffect, useState} from "react";
+import {CreateSourceDialog} from "../../../features/source";
+import {listSources} from "../../../shared/api/sources";
+import type {Source} from "../../../shared/api/sources";
+
+export function SourcesPage() {
+  const [sources, setSources] = useState<Source[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const create = useDisclosure();
+
+  async function load() {
+    setIsLoading(true);
+    try {
+      setSources(await listSources());
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  return (
+    <div className="p-8 flex flex-col gap-6">
+      <div className="flex justify-between items-center">
+        <h1 className="text-3xl font-bold">Sources</h1>
+        <Button color="primary" onPress={create.onOpen}>
+          Add Source
+        </Button>
+      </div>
+      {isLoading && sources.length === 0 ? (
+        <p>Loading...</p>
+      ) : sources.length === 0 ? (
+        <p>No sources yet</p>
+      ) : (
+        <div className="grid gap-4 sm:grid-cols-2">
+          {sources.map((s) => (
+            <Link key={s.id} to={`/sources/${s.id}`}>
+              <Card>
+                <CardHeader className="font-bold">{s.name}</CardHeader>
+                <CardBody>{new Date(s.created_at).toLocaleString()}</CardBody>
+              </Card>
+            </Link>
+          ))}
+        </div>
+      )}
+      <CreateSourceDialog isOpen={create.isOpen} onOpenChange={create.onOpenChange} onCreated={load} />
+    </div>
+  );
+}

--- a/webui/src/shared/api/sources.ts
+++ b/webui/src/shared/api/sources.ts
@@ -1,0 +1,29 @@
+const API_BASE = "https://s3aas-api.dev.nachert.art/api/v1";
+
+export type Source = {id: string; name: string; type: string; key: string; created_at: string};
+
+function authHeader(): Record<string, string> {
+  const auth = localStorage.getItem("auth");
+  return auth ? {Authorization: `Basic ${auth}`} : {};
+}
+
+export async function listSources(): Promise<Source[]> {
+  const res = await fetch(`${API_BASE}/sources`, {
+    headers: authHeader(),
+  });
+  if (!res.ok) throw new Error("failed to list sources");
+  return res.json();
+}
+
+export async function createSource(name: string, key: string): Promise<Source> {
+  const res = await fetch(`${API_BASE}/sources/gdrive`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...authHeader(),
+    },
+    body: JSON.stringify({name, key}),
+  });
+  if (!res.ok) throw new Error("failed to create source");
+  return res.json();
+}


### PR DESCRIPTION
## Summary
- add API utilities for sources
- add source creation dialog and listing page
- wire sources routes including placeholder for single source view

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run build` (fails: Cannot find module 'react-router-dom')

------
https://chatgpt.com/codex/tasks/task_e_68b23a7ba8388324b199c9338f901e2d