### PR TITLE
feat(webui): add bucket detail page with file upload

### DIFF
--- a/webui/src/app/index.tsx
+++ b/webui/src/app/index.tsx
@@ -2,6 +2,7 @@ import {BrowserRouter, Routes, Route, Navigate} from "react-router-dom";
 import LandingPage from "../pages/landing";
 import DashboardPage from "../pages/dashboard";
 import BucketsPage from "../pages/buckets";
+import BucketPage from "../pages/bucket";
 import SourcesPage from "../pages/sources";
 import SourcePage from "../pages/source";
 
@@ -17,6 +18,7 @@ export default function App() {
         />
         <Route path="/dashboard" element={<DashboardPage />} />
         <Route path="/buckets" element={<BucketsPage />} />
+        <Route path="/buckets/:id" element={<BucketPage />} />
         <Route path="/sources" element={<SourcesPage />} />
         <Route path="/sources/:id" element={<SourcePage />} />
       </Routes>

--- a/webui/src/pages/bucket/index.ts
+++ b/webui/src/pages/bucket/index.ts
@@ -1,0 +1,1 @@
+export {BucketPage as default} from "./ui/bucket-page";

--- a/webui/src/pages/bucket/ui/bucket-page.tsx
+++ b/webui/src/pages/bucket/ui/bucket-page.tsx
@@ -1,0 +1,95 @@
+import {Button} from "@heroui/react";
+import {useCallback, useEffect, useRef, useState} from "react";
+import {useParams} from "react-router-dom";
+import {listBuckets, listFiles, uploadFile} from "../../../shared/api/buckets";
+import type {Bucket, FileInfo} from "../../../shared/api/buckets";
+
+export function BucketPage() {
+  const {id} = useParams<{id: string}>();
+  const [bucket, setBucket] = useState<Bucket | null>(null);
+  const [files, setFiles] = useState<FileInfo[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const fileInput = useRef<HTMLInputElement>(null);
+
+  const load = useCallback(async () => {
+    if (!id) return;
+    setIsLoading(true);
+    try {
+      const [buckets, fs] = await Promise.all([listBuckets(), listFiles(id)]);
+      setBucket(buckets.find((b) => b.id === id) || null);
+      setFiles(fs);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [id]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  async function handleUpload(file: File) {
+    if (!id) return;
+    await uploadFile(id, file);
+    await load();
+  }
+
+  function onFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const f = e.target.files?.[0];
+    if (f) handleUpload(f);
+  }
+
+  function onDrop(e: React.DragEvent<HTMLDivElement>) {
+    e.preventDefault();
+    const f = e.dataTransfer.files?.[0];
+    if (f) handleUpload(f);
+  }
+
+  if (isLoading) return <div className="p-8">Loading...</div>;
+  if (!bucket) return <div className="p-8">Bucket not found</div>;
+
+  return (
+    <div className="p-8 flex flex-col gap-6">
+      <div className="flex flex-col gap-1">
+        <h1 className="text-3xl font-bold">{bucket.key}</h1>
+        <p>ID: {bucket.id}</p>
+        <p>Access Key: {bucket.access_key}</p>
+        <p>Access Secret: {bucket.access_secret}</p>
+        <p>Created: {new Date(bucket.created_at).toLocaleString()}</p>
+      </div>
+      <div className="flex justify-end">
+        <input type="file" ref={fileInput} className="hidden" onChange={onFileChange} />
+        <Button color="primary" onPress={() => fileInput.current?.click()}>
+          Upload File
+        </Button>
+      </div>
+      <div
+        className="border-2 border-dashed rounded p-4"
+        onDragOver={(e) => e.preventDefault()}
+        onDrop={onDrop}
+      >
+        {files.length === 0 ? (
+          <p>No files</p>
+        ) : (
+          <table className="w-full text-left">
+            <thead>
+              <tr>
+                <th className="pb-2">Name</th>
+                <th className="pb-2">Size</th>
+                <th className="pb-2">Created</th>
+              </tr>
+            </thead>
+            <tbody>
+              {files.map((f) => (
+                <tr key={f.id} className="border-t">
+                  <td className="py-2">{f.name}</td>
+                  <td className="py-2">{f.size}</td>
+                  <td className="py-2">{new Date(f.created_at).toLocaleString()}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/webui/src/pages/buckets/ui/buckets-page.tsx
+++ b/webui/src/pages/buckets/ui/buckets-page.tsx
@@ -1,5 +1,6 @@
 import {Button, Card, CardBody, CardHeader, useDisclosure} from "@heroui/react";
 import {useEffect, useState} from "react";
+import {Link} from "react-router-dom";
 import {CreateBucketDialog} from "../../../features/bucket";
 import {listBuckets} from "../../../shared/api/buckets";
 import type {Bucket} from "../../../shared/api/buckets";
@@ -39,7 +40,12 @@ export function BucketsPage() {
           {buckets.map((b) => (
             <Card key={b.id}>
               <CardHeader className="font-bold">{b.key}</CardHeader>
-              <CardBody>{new Date(b.created_at).toLocaleString()}</CardBody>
+              <CardBody className="flex justify-between items-center">
+                {new Date(b.created_at).toLocaleString()}
+                <Button as={Link} to={`/buckets/${b.id}`} color="primary" variant="flat">
+                  Open
+                </Button>
+              </CardBody>
             </Card>
           ))}
         </div>

--- a/webui/src/shared/api/buckets.ts
+++ b/webui/src/shared/api/buckets.ts
@@ -1,6 +1,19 @@
 const API_BASE = "https://s3aas-api.dev.nachert.art/api/v1";
 
-export type Bucket = {id: string; key: string; created_at: string};
+export type Bucket = {
+  id: string;
+  key: string;
+  access_key: string;
+  access_secret: string;
+  created_at: string;
+};
+
+export type FileInfo = {
+  id: string;
+  name: string;
+  created_at: string;
+  size: number;
+};
 
 function authHeader(): Record<string, string> {
   const auth = localStorage.getItem("auth");
@@ -25,5 +38,25 @@ export async function createBucket(key: string): Promise<{key: string; access_ke
     body: JSON.stringify({key}),
   });
   if (!res.ok) throw new Error("failed to create bucket");
+  return res.json();
+}
+
+export async function listFiles(bucketId: string): Promise<FileInfo[]> {
+  const res = await fetch(`${API_BASE}/buckets/${bucketId}/files`, {
+    headers: authHeader(),
+  });
+  if (!res.ok) throw new Error("failed to list files");
+  return res.json();
+}
+
+export async function uploadFile(bucketId: string, file: File): Promise<FileInfo> {
+  const form = new FormData();
+  form.append("file", file);
+  const res = await fetch(`${API_BASE}/buckets/${bucketId}/upload`, {
+    method: "POST",
+    headers: authHeader(),
+    body: form,
+  });
+  if (!res.ok) throw new Error("failed to upload file");
   return res.json();
 }


### PR DESCRIPTION
## Summary
- add bucket detail view listing files
- support file upload via button or drag-and-drop
- link bucket list entries to detail page

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b339c2e7548324b7a5184e2e373f68