### PR TITLE
Secure buckets by user and hide access secrets

### DIFF
--- a/api-go/internal/docs/docs.go
+++ b/api-go/internal/docs/docs.go
@@ -913,16 +913,21 @@ const docTemplate = `{
                 }
             }
         }
+    },
+    "securityDefinitions": {
+        "BasicAuth": {
+            "type": "basic"
+        }
     }
 }`
 
 // SwaggerInfo holds exported Swagger Info so clients can modify it
 var SwaggerInfo = &swag.Spec{
-	Version:          "",
+	Version:          "1.0",
 	Host:             "",
-	BasePath:         "",
+	BasePath:         "/",
 	Schemes:          []string{},
-	Title:            "",
+	Title:            "S3aaS API",
 	Description:      "",
 	InfoInstanceName: "swagger",
 	SwaggerTemplate:  docTemplate,

--- a/api-go/internal/docs/docs.go
+++ b/api-go/internal/docs/docs.go
@@ -740,9 +740,6 @@ const docTemplate = `{
                 "access_key": {
                     "type": "string"
                 },
-                "access_secret": {
-                    "type": "string"
-                },
                 "created_at": {
                     "type": "string"
                 },
@@ -916,21 +913,16 @@ const docTemplate = `{
                 }
             }
         }
-    },
-    "securityDefinitions": {
-        "BasicAuth": {
-            "type": "basic"
-        }
     }
 }`
 
 // SwaggerInfo holds exported Swagger Info so clients can modify it
 var SwaggerInfo = &swag.Spec{
-	Version:          "1.0",
+	Version:          "",
 	Host:             "",
-	BasePath:         "/",
+	BasePath:         "",
 	Schemes:          []string{},
-	Title:            "S3aaS API",
+	Title:            "",
 	Description:      "",
 	InfoInstanceName: "swagger",
 	SwaggerTemplate:  docTemplate,

--- a/api-go/internal/handlers/bucket.go
+++ b/api-go/internal/handlers/bucket.go
@@ -16,11 +16,12 @@ import (
 	"github.com/gin-gonic/gin"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
+	"golang.org/x/crypto/bcrypt"
 )
 
-const accessSecretLength = 80
+const accessSecretLength = 35
 
-var alphabet = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~")
+var alphabet = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
 
 func generateAccessSecret() string {
 	b := make([]rune, accessSecretLength)
@@ -43,11 +44,10 @@ type createBucketResponse struct {
 }
 
 type bucketResponse struct {
-	ID           string    `json:"id"`
-	Key          string    `json:"key"`
-	AccessKey    string    `json:"access_key"`
-	AccessSecret string    `json:"access_secret"`
-	CreatedAt    time.Time `json:"created_at"`
+	ID        string    `json:"id"`
+	Key       string    `json:"key"`
+	AccessKey string    `json:"access_key"`
+	CreatedAt time.Time `json:"created_at"`
 }
 
 type fileResponse struct {
@@ -82,13 +82,30 @@ func CreateBucket(repo *repository.BucketRepository) gin.HandlerFunc {
 			c.Status(http.StatusServiceUnavailable)
 			return
 		}
+		userIDHex := c.GetString("userID")
+		if userIDHex == "" {
+			c.Status(http.StatusUnauthorized)
+			return
+		}
+		userID, err := primitive.ObjectIDFromHex(userIDHex)
+		if err != nil {
+			c.Status(http.StatusUnauthorized)
+			return
+		}
 		accessKey := req.Key
 		accessSecret := generateAccessSecret()
+		hash, err := bcrypt.GenerateFromPassword([]byte(accessSecret), bcrypt.DefaultCost)
+		if err != nil {
+			log.Printf("create bucket: hash secret: %v", err)
+			c.Status(http.StatusInternalServerError)
+			return
+		}
 		bucket := repository.Bucket{
-			Key:          req.Key,
-			AccessKey:    accessKey,
-			AccessSecret: accessSecret,
-			CreatedAt:    time.Now().UTC(),
+			UserID:           userID,
+			Key:              req.Key,
+			AccessKey:        accessKey,
+			AccessSecretHash: string(hash),
+			CreatedAt:        time.Now().UTC(),
 		}
 		created, err := repo.Create(c.Request.Context(), bucket)
 		if err != nil {
@@ -104,7 +121,7 @@ func CreateBucket(repo *repository.BucketRepository) gin.HandlerFunc {
 		c.JSON(http.StatusOK, createBucketResponse{
 			Key:          created.Key,
 			AccessKey:    created.AccessKey,
-			AccessSecret: created.AccessSecret,
+			AccessSecret: accessSecret,
 			CreatedAt:    created.CreatedAt,
 		})
 	}
@@ -126,7 +143,17 @@ func ListBuckets(repo *repository.BucketRepository) gin.HandlerFunc {
 			c.Status(http.StatusServiceUnavailable)
 			return
 		}
-		buckets, err := repo.List(c.Request.Context())
+		userIDHex := c.GetString("userID")
+		if userIDHex == "" {
+			c.Status(http.StatusUnauthorized)
+			return
+		}
+		userID, err := primitive.ObjectIDFromHex(userIDHex)
+		if err != nil {
+			c.Status(http.StatusUnauthorized)
+			return
+		}
+		buckets, err := repo.ListByUser(c.Request.Context(), userID)
 		if err != nil {
 			log.Printf("list buckets: failed to list buckets: %v", err)
 			c.Status(http.StatusInternalServerError)
@@ -135,11 +162,10 @@ func ListBuckets(repo *repository.BucketRepository) gin.HandlerFunc {
 		resp := make([]bucketResponse, 0, len(buckets))
 		for _, b := range buckets {
 			resp = append(resp, bucketResponse{
-				ID:           b.ID.Hex(),
-				Key:          b.Key,
-				AccessKey:    b.AccessKey,
-				AccessSecret: b.AccessSecret,
-				CreatedAt:    b.CreatedAt,
+				ID:        b.ID.Hex(),
+				Key:       b.Key,
+				AccessKey: b.AccessKey,
+				CreatedAt: b.CreatedAt,
 			})
 		}
 		c.JSON(http.StatusOK, resp)
@@ -164,13 +190,23 @@ func DeleteBucket(repo *repository.BucketRepository) gin.HandlerFunc {
 			c.Status(http.StatusServiceUnavailable)
 			return
 		}
+		userIDHex := c.GetString("userID")
+		if userIDHex == "" {
+			c.Status(http.StatusUnauthorized)
+			return
+		}
+		userID, err := primitive.ObjectIDFromHex(userIDHex)
+		if err != nil {
+			c.Status(http.StatusUnauthorized)
+			return
+		}
 		idHex := c.Param("id")
 		id, err := primitive.ObjectIDFromHex(idHex)
 		if err != nil {
 			c.Status(http.StatusBadRequest)
 			return
 		}
-		if err := repo.Delete(c.Request.Context(), id); err != nil {
+		if err := repo.Delete(c.Request.Context(), id, userID); err != nil {
 			if err == mongo.ErrNoDocuments {
 				c.Status(http.StatusNotFound)
 				return
@@ -216,15 +252,6 @@ func UploadFile(bucketRepo *repository.BucketRepository, sourceRepo *repository.
 			c.Status(http.StatusBadRequest)
 			return
 		}
-		if _, err := bucketRepo.GetByID(c.Request.Context(), bucketID); err != nil {
-			if err == mongo.ErrNoDocuments {
-				c.Status(http.StatusNotFound)
-				return
-			}
-			log.Printf("upload file: get bucket: %v", err)
-			c.Status(http.StatusInternalServerError)
-			return
-		}
 		userIDHex := c.GetString("userID")
 		if userIDHex == "" {
 			c.Status(http.StatusUnauthorized)
@@ -233,6 +260,20 @@ func UploadFile(bucketRepo *repository.BucketRepository, sourceRepo *repository.
 		userID, err := primitive.ObjectIDFromHex(userIDHex)
 		if err != nil {
 			c.Status(http.StatusUnauthorized)
+			return
+		}
+		bucketDoc, err := bucketRepo.GetByID(c.Request.Context(), bucketID)
+		if err != nil {
+			if err == mongo.ErrNoDocuments {
+				c.Status(http.StatusNotFound)
+				return
+			}
+			log.Printf("upload file: get bucket: %v", err)
+			c.Status(http.StatusInternalServerError)
+			return
+		}
+		if bucketDoc.UserID != userID {
+			c.Status(http.StatusNotFound)
 			return
 		}
 		sources, err := sourceRepo.ListByUser(c.Request.Context(), userID)
@@ -348,13 +389,28 @@ func ListFiles(bucketRepo *repository.BucketRepository, fileRepo *repository.Fil
 			c.Status(http.StatusBadRequest)
 			return
 		}
-		if _, err := bucketRepo.GetByID(c.Request.Context(), bucketID); err != nil {
+		userIDHex := c.GetString("userID")
+		if userIDHex == "" {
+			c.Status(http.StatusUnauthorized)
+			return
+		}
+		userID, err := primitive.ObjectIDFromHex(userIDHex)
+		if err != nil {
+			c.Status(http.StatusUnauthorized)
+			return
+		}
+		bucketDoc, err := bucketRepo.GetByID(c.Request.Context(), bucketID)
+		if err != nil {
 			if err == mongo.ErrNoDocuments {
 				c.Status(http.StatusNotFound)
 				return
 			}
 			log.Printf("list files: get bucket: %v", err)
 			c.Status(http.StatusInternalServerError)
+			return
+		}
+		if bucketDoc.UserID != userID {
+			c.Status(http.StatusNotFound)
 			return
 		}
 		files, err := fileRepo.ListByBucket(c.Request.Context(), bucketID)
@@ -412,13 +468,28 @@ func DownloadFile(bucketRepo *repository.BucketRepository, sourceRepo *repositor
 			c.Status(http.StatusBadRequest)
 			return
 		}
-		if _, err := bucketRepo.GetByID(c.Request.Context(), bucketID); err != nil {
+		userIDHex := c.GetString("userID")
+		if userIDHex == "" {
+			c.Status(http.StatusUnauthorized)
+			return
+		}
+		userID, err := primitive.ObjectIDFromHex(userIDHex)
+		if err != nil {
+			c.Status(http.StatusUnauthorized)
+			return
+		}
+		bucketDoc, err := bucketRepo.GetByID(c.Request.Context(), bucketID)
+		if err != nil {
 			if err == mongo.ErrNoDocuments {
 				c.Status(http.StatusNotFound)
 				return
 			}
 			log.Printf("download file: get bucket: %v", err)
 			c.Status(http.StatusInternalServerError)
+			return
+		}
+		if bucketDoc.UserID != userID {
+			c.Status(http.StatusNotFound)
 			return
 		}
 		fileDoc, err := fileRepo.GetByID(c.Request.Context(), fileID)
@@ -506,13 +577,28 @@ func DeleteFile(bucketRepo *repository.BucketRepository, sourceRepo *repository.
 			c.Status(http.StatusBadRequest)
 			return
 		}
-		if _, err := bucketRepo.GetByID(c.Request.Context(), bucketID); err != nil {
+		userIDHex := c.GetString("userID")
+		if userIDHex == "" {
+			c.Status(http.StatusUnauthorized)
+			return
+		}
+		userID, err := primitive.ObjectIDFromHex(userIDHex)
+		if err != nil {
+			c.Status(http.StatusUnauthorized)
+			return
+		}
+		bucketDoc, err := bucketRepo.GetByID(c.Request.Context(), bucketID)
+		if err != nil {
 			if err == mongo.ErrNoDocuments {
 				c.Status(http.StatusNotFound)
 				return
 			}
 			log.Printf("delete file: get bucket: %v", err)
 			c.Status(http.StatusInternalServerError)
+			return
+		}
+		if bucketDoc.UserID != userID {
+			c.Status(http.StatusNotFound)
 			return
 		}
 		fileDoc, err := fileRepo.GetByID(c.Request.Context(), fileID)

--- a/api-go/internal/repository/bucket.go
+++ b/api-go/internal/repository/bucket.go
@@ -11,11 +11,12 @@ import (
 )
 
 type Bucket struct {
-	ID           primitive.ObjectID `bson:"_id,omitempty"`
-	Key          string             `bson:"key"`
-	AccessKey    string             `bson:"access_key"`
-	AccessSecret string             `bson:"access_secret"`
-	CreatedAt    time.Time          `bson:"created_at"`
+	ID               primitive.ObjectID `bson:"_id,omitempty"`
+	UserID           primitive.ObjectID `bson:"user_id"`
+	Key              string             `bson:"key"`
+	AccessKey        string             `bson:"access_key"`
+	AccessSecretHash string             `bson:"access_secret"`
+	CreatedAt        time.Time          `bson:"created_at"`
 }
 
 type BucketRepository struct {
@@ -24,9 +25,14 @@ type BucketRepository struct {
 
 func NewBucketRepository(db *mongo.Database) (*BucketRepository, error) {
 	coll := db.Collection("buckets")
-	_, err := coll.Indexes().CreateOne(context.Background(), mongo.IndexModel{
-		Keys:    bson.D{{Key: "key", Value: 1}},
-		Options: options.Index().SetUnique(true),
+	_, err := coll.Indexes().CreateMany(context.Background(), []mongo.IndexModel{
+		{
+			Keys:    bson.D{{Key: "key", Value: 1}},
+			Options: options.Index().SetUnique(true),
+		},
+		{
+			Keys: bson.D{{Key: "user_id", Value: 1}},
+		},
 	})
 	if err != nil {
 		return nil, err
@@ -64,8 +70,8 @@ func (r *BucketRepository) GetByKey(ctx context.Context, key string) (*Bucket, e
 	return &b, nil
 }
 
-func (r *BucketRepository) List(ctx context.Context) ([]Bucket, error) {
-	cursor, err := r.coll.Find(ctx, bson.D{})
+func (r *BucketRepository) ListByUser(ctx context.Context, userID primitive.ObjectID) ([]Bucket, error) {
+	cursor, err := r.coll.Find(ctx, bson.M{"user_id": userID})
 	if err != nil {
 		return nil, err
 	}
@@ -84,8 +90,8 @@ func (r *BucketRepository) List(ctx context.Context) ([]Bucket, error) {
 	return buckets, nil
 }
 
-func (r *BucketRepository) Delete(ctx context.Context, id primitive.ObjectID) error {
-	res, err := r.coll.DeleteOne(ctx, bson.M{"_id": id})
+func (r *BucketRepository) Delete(ctx context.Context, id, userID primitive.ObjectID) error {
+	res, err := r.coll.DeleteOne(ctx, bson.M{"_id": id, "user_id": userID})
 	if err != nil {
 		return err
 	}

--- a/api-go/internal/repository/bucket_test.go
+++ b/api-go/internal/repository/bucket_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/example/s3aas/api-go/internal/config"
 	"github.com/example/s3aas/api-go/internal/db"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
 func TestBucketRepository(t *testing.T) {
@@ -25,7 +26,7 @@ func TestBucketRepository(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	b := Bucket{Key: "testbucket", AccessKey: "ak", AccessSecret: "secret", CreatedAt: time.Now()}
+	b := Bucket{UserID: primitive.NewObjectID(), Key: "testbucket", AccessKey: "ak", AccessSecretHash: "secret", CreatedAt: time.Now()}
 	created, err := repo.Create(context.Background(), b)
 	if err != nil {
 		t.Fatal(err)

--- a/webui/src/pages/bucket/ui/bucket-page.tsx
+++ b/webui/src/pages/bucket/ui/bucket-page.tsx
@@ -82,7 +82,6 @@ export function BucketPage() {
         <h1 className="text-3xl font-bold">{bucket.key}</h1>
         <p>ID: {bucket.id}</p>
         <p>Access Key: {bucket.access_key}</p>
-        <p>Access Secret: {bucket.access_secret}</p>
         <p>Created: {new Date(bucket.created_at).toLocaleString()}</p>
       </div>
       <div className="flex justify-end">

--- a/webui/src/shared/api/buckets.ts
+++ b/webui/src/shared/api/buckets.ts
@@ -4,7 +4,6 @@ export type Bucket = {
   id: string;
   key: string;
   access_key: string;
-  access_secret: string;
   created_at: string;
 };
 
@@ -28,9 +27,7 @@ export async function listBuckets(): Promise<Bucket[]> {
   return res.json();
 }
 
-export async function createBucket(
-  key: string,
-): Promise<{
+export async function createBucket(key: string): Promise<{
   key: string;
   access_key: string;
   access_secret: string;


### PR DESCRIPTION
## Summary
- associate buckets with user and restrict list/delete to owner
- generate 35-char alphanumeric access secrets, store hash only, return secret only on creation
- remove access secret from web UI bucket listings

## Testing
- `golangci-lint run`
- `go test ./...`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b46f72f4c883248212e40053219d99