### PR TITLE
Encrypt access secrets with runtime key

### DIFF
--- a/api-go/internal/app/router.go
+++ b/api-go/internal/app/router.go
@@ -44,7 +44,11 @@ func SetupRouter(m *db.Mongo, cfg *config.Config) *gin.Engine {
 	}
 
 	if auth != nil && bucketRepo != nil {
-		router.POST("/api/v1/buckets", auth, handlers.CreateBucket(bucketRepo))
+		secretKey := ""
+		if cfg != nil {
+			secretKey = cfg.AccessSecretKey
+		}
+		router.POST("/api/v1/buckets", auth, handlers.CreateBucket(bucketRepo, secretKey))
 		router.GET("/api/v1/buckets", auth, handlers.ListBuckets(bucketRepo))
 		router.DELETE("/api/v1/buckets/:id", auth, handlers.DeleteBucket(bucketRepo))
 		if sourceRepo != nil && fileRepo != nil {

--- a/api-go/internal/config/config.go
+++ b/api-go/internal/config/config.go
@@ -23,8 +23,9 @@ type UploadConfig struct {
 }
 
 type Config struct {
-	Mongo  MongoConfig  `yaml:"mongo"`
-	Upload UploadConfig `yaml:"upload"`
+	Mongo           MongoConfig  `yaml:"mongo"`
+	Upload          UploadConfig `yaml:"upload"`
+	AccessSecretKey string       `yaml:"-"`
 }
 
 func Load() (*Config, error) {
@@ -69,5 +70,8 @@ func overrideEnv(cfg *Config) {
 		if s, err := strconv.Atoi(v); err == nil {
 			cfg.Upload.ChunkSize = s
 		}
+	}
+	if v := os.Getenv("ACCESS_SECRET_KEY"); v != "" {
+		cfg.AccessSecretKey = v
 	}
 }

--- a/api-go/internal/cryptoutil/cryptoutil.go
+++ b/api-go/internal/cryptoutil/cryptoutil.go
@@ -1,0 +1,79 @@
+package cryptoutil
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+	"io"
+	"math/big"
+)
+
+const accessSecretLength = 35
+
+var alphabet = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
+
+func RandomString(n int) (string, error) {
+	b := make([]rune, n)
+	for i := range b {
+		nBig, err := rand.Int(rand.Reader, big.NewInt(int64(len(alphabet))))
+		if err != nil {
+			return "", err
+		}
+		b[i] = alphabet[nBig.Int64()]
+	}
+	return string(b), nil
+}
+
+func GenerateSecret() (string, error) {
+	return RandomString(accessSecretLength)
+}
+
+func Encrypt(plainText, key string) (string, error) {
+	block, err := aes.NewCipher(deriveKey(key))
+	if err != nil {
+		return "", err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", err
+	}
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return "", err
+	}
+	cipherText := gcm.Seal(nonce, nonce, []byte(plainText), nil)
+	return base64.StdEncoding.EncodeToString(cipherText), nil
+}
+
+func Decrypt(cipherText, key string) (string, error) {
+	data, err := base64.StdEncoding.DecodeString(cipherText)
+	if err != nil {
+		return "", err
+	}
+	block, err := aes.NewCipher(deriveKey(key))
+	if err != nil {
+		return "", err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", err
+	}
+	nonceSize := gcm.NonceSize()
+	if len(data) < nonceSize {
+		return "", errors.New("ciphertext too short")
+	}
+	nonce, ct := data[:nonceSize], data[nonceSize:]
+	plain, err := gcm.Open(nil, nonce, ct, nil)
+	if err != nil {
+		return "", err
+	}
+	return string(plain), nil
+}
+
+func deriveKey(key string) []byte {
+	sum := sha256.Sum256([]byte(key))
+	return sum[:]
+}

--- a/api-go/internal/cryptoutil/cryptoutil_test.go
+++ b/api-go/internal/cryptoutil/cryptoutil_test.go
@@ -1,0 +1,22 @@
+package cryptoutil
+
+import "testing"
+
+func TestEncryptDecrypt(t *testing.T) {
+	key := "testkey"
+	s, err := GenerateSecret()
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	enc, err := Encrypt(s, key)
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	dec, err := Decrypt(enc, key)
+	if err != nil {
+		t.Fatalf("decrypt: %v", err)
+	}
+	if dec != s {
+		t.Fatalf("expected %s, got %s", s, dec)
+	}
+}

--- a/api-go/internal/handlers/bucket.go
+++ b/api-go/internal/handlers/bucket.go
@@ -2,35 +2,20 @@ package handlers
 
 import (
 	"bytes"
-	"crypto/rand"
 	"fmt"
 	"io"
 	"log"
-	"math/big"
 	"net/http"
 	"strconv"
 	"time"
 
+	"github.com/example/s3aas/api-go/internal/cryptoutil"
 	"github.com/example/s3aas/api-go/internal/gdrive"
 	"github.com/example/s3aas/api-go/internal/repository"
 	"github.com/gin-gonic/gin"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
-	"golang.org/x/crypto/bcrypt"
 )
-
-const accessSecretLength = 35
-
-var alphabet = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
-
-func generateAccessSecret() string {
-	b := make([]rune, accessSecretLength)
-	for i := range b {
-		n, _ := rand.Int(rand.Reader, big.NewInt(int64(len(alphabet))))
-		b[i] = alphabet[n.Int64()]
-	}
-	return string(b)
-}
 
 type createBucketRequest struct {
 	Key string `json:"key" binding:"required"`
@@ -69,7 +54,7 @@ type fileResponse struct {
 // @Failure 409 {string} string ""
 // @Security BasicAuth
 // @Router /api/v1/buckets [post]
-func CreateBucket(repo *repository.BucketRepository) gin.HandlerFunc {
+func CreateBucket(repo *repository.BucketRepository, secretKey string) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var req createBucketRequest
 		if err := c.ShouldBindJSON(&req); err != nil {
@@ -92,20 +77,30 @@ func CreateBucket(repo *repository.BucketRepository) gin.HandlerFunc {
 			c.Status(http.StatusUnauthorized)
 			return
 		}
+		if secretKey == "" {
+			log.Print("create bucket: secret key is empty")
+			c.Status(http.StatusInternalServerError)
+			return
+		}
 		accessKey := req.Key
-		accessSecret := generateAccessSecret()
-		hash, err := bcrypt.GenerateFromPassword([]byte(accessSecret), bcrypt.DefaultCost)
+		accessSecret, err := cryptoutil.GenerateSecret()
 		if err != nil {
-			log.Printf("create bucket: hash secret: %v", err)
+			log.Printf("create bucket: generate secret: %v", err)
+			c.Status(http.StatusInternalServerError)
+			return
+		}
+		encrypted, err := cryptoutil.Encrypt(accessSecret, secretKey)
+		if err != nil {
+			log.Printf("create bucket: encrypt secret: %v", err)
 			c.Status(http.StatusInternalServerError)
 			return
 		}
 		bucket := repository.Bucket{
-			UserID:           userID,
-			Key:              req.Key,
-			AccessKey:        accessKey,
-			AccessSecretHash: string(hash),
-			CreatedAt:        time.Now().UTC(),
+			UserID:          userID,
+			Key:             req.Key,
+			AccessKey:       accessKey,
+			AccessSecretEnc: encrypted,
+			CreatedAt:       time.Now().UTC(),
 		}
 		created, err := repo.Create(c.Request.Context(), bucket)
 		if err != nil {

--- a/api-go/internal/handlers/bucket_test.go
+++ b/api-go/internal/handlers/bucket_test.go
@@ -47,7 +47,7 @@ func TestCreateBucket(t *testing.T) {
 	}
 	router := gin.New()
 	auth := BasicAuth(userRepo)
-	router.POST("/api/v1/buckets", auth, CreateBucket(repo))
+	router.POST("/api/v1/buckets", auth, CreateBucket(repo, "testkey"))
 	body, _ := json.Marshal(map[string]string{"key": "bucket-test"})
 	req, _ := http.NewRequest(http.MethodPost, "/api/v1/buckets", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")

--- a/api-go/internal/handlers/user.go
+++ b/api-go/internal/handlers/user.go
@@ -1,12 +1,11 @@
 package handlers
 
 import (
-	"crypto/rand"
 	"log"
-	"math/big"
 	"net/http"
 	"time"
 
+	"github.com/example/s3aas/api-go/internal/cryptoutil"
 	"github.com/example/s3aas/api-go/internal/repository"
 	"github.com/gin-gonic/gin"
 	"go.mongodb.org/mongo-driver/mongo"
@@ -15,13 +14,8 @@ import (
 
 const passwordLength = 12
 
-func generatePassword() string {
-	b := make([]rune, passwordLength)
-	for i := range b {
-		n, _ := rand.Int(rand.Reader, big.NewInt(int64(len(alphabet))))
-		b[i] = alphabet[n.Int64()]
-	}
-	return string(b)
+func generatePassword() (string, error) {
+	return cryptoutil.RandomString(passwordLength)
 }
 
 type createUserRequest struct {
@@ -57,7 +51,12 @@ func CreateUser(repo *repository.UserRepository) gin.HandlerFunc {
 			c.Status(http.StatusServiceUnavailable)
 			return
 		}
-		password := generatePassword()
+		password, err := generatePassword()
+		if err != nil {
+			log.Printf("create user: generate password: %v", err)
+			c.Status(http.StatusInternalServerError)
+			return
+		}
 		hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
 		if err != nil {
 			log.Printf("create user: failed to hash password: %v", err)

--- a/api-go/internal/repository/bucket.go
+++ b/api-go/internal/repository/bucket.go
@@ -11,12 +11,12 @@ import (
 )
 
 type Bucket struct {
-	ID               primitive.ObjectID `bson:"_id,omitempty"`
-	UserID           primitive.ObjectID `bson:"user_id"`
-	Key              string             `bson:"key"`
-	AccessKey        string             `bson:"access_key"`
-	AccessSecretHash string             `bson:"access_secret"`
-	CreatedAt        time.Time          `bson:"created_at"`
+	ID              primitive.ObjectID `bson:"_id,omitempty"`
+	UserID          primitive.ObjectID `bson:"user_id"`
+	Key             string             `bson:"key"`
+	AccessKey       string             `bson:"access_key"`
+	AccessSecretEnc string             `bson:"access_secret"`
+	CreatedAt       time.Time          `bson:"created_at"`
 }
 
 type BucketRepository struct {
@@ -28,6 +28,10 @@ func NewBucketRepository(db *mongo.Database) (*BucketRepository, error) {
 	_, err := coll.Indexes().CreateMany(context.Background(), []mongo.IndexModel{
 		{
 			Keys:    bson.D{{Key: "key", Value: 1}},
+			Options: options.Index().SetUnique(true),
+		},
+		{
+			Keys:    bson.D{{Key: "access_key", Value: 1}},
 			Options: options.Index().SetUnique(true),
 		},
 		{
@@ -68,6 +72,15 @@ func (r *BucketRepository) GetByKey(ctx context.Context, key string) (*Bucket, e
 		return nil, err
 	}
 	return &b, nil
+}
+
+func (r *BucketRepository) GetSecretByAccessKey(ctx context.Context, accessKey string) (string, error) {
+	var b Bucket
+	err := r.coll.FindOne(ctx, bson.M{"access_key": accessKey}).Decode(&b)
+	if err != nil {
+		return "", err
+	}
+	return b.AccessSecretEnc, nil
 }
 
 func (r *BucketRepository) ListByUser(ctx context.Context, userID primitive.ObjectID) ([]Bucket, error) {

--- a/api-go/internal/repository/bucket_test.go
+++ b/api-go/internal/repository/bucket_test.go
@@ -26,7 +26,7 @@ func TestBucketRepository(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	b := Bucket{UserID: primitive.NewObjectID(), Key: "testbucket", AccessKey: "ak", AccessSecretHash: "secret", CreatedAt: time.Now()}
+	b := Bucket{UserID: primitive.NewObjectID(), Key: "testbucket", AccessKey: "ak", AccessSecretEnc: "secret", CreatedAt: time.Now()}
 	created, err := repo.Create(context.Background(), b)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Summary
- encrypt bucket access secrets using AES with a runtime key
- enforce unique access keys and expose repository method for secret lookup
- add helper package for random generation and encryption

## Testing
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b865e3bcd883248b8f161dff9b1ce6