### PR TITLE
feat: add S3 object retrieval

### DIFF
--- a/api-go/Makefile
+++ b/api-go/Makefile
@@ -22,6 +22,10 @@ test-e2e:
 	ENV=test go test -tags=e2e ./...
 
 
+simple-test-e2e:
+	cd ../api && venv/bin/python client.py
+
+
 lint:
 	golangci-lint run
 

--- a/api-go/config/local.yaml
+++ b/api-go/config/local.yaml
@@ -6,3 +6,4 @@ mongo:
   database: s3aas
 upload:
   chunk_size: 5242880
+access_secret_key: examplesecret

--- a/api-go/config/test.yaml
+++ b/api-go/config/test.yaml
@@ -6,3 +6,4 @@ mongo:
   database: s3aas_test
 upload:
   chunk_size: 5242880
+access_secret_key: examplesecret

--- a/api-go/docker-compose.ci.yml
+++ b/api-go/docker-compose.ci.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   api-go:
     build: .

--- a/api-go/docker-compose.yml
+++ b/api-go/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   mongo:
     image: mongo:7

--- a/api-go/go.mod
+++ b/api-go/go.mod
@@ -3,7 +3,6 @@ module github.com/example/s3aas/api-go
 go 1.24.3
 
 require (
-	github.com/allaboutapps/aws4 v0.0.0-20200604111205-3c45f7eabfb9
 	github.com/gin-contrib/cors v1.5.0
 	github.com/gin-gonic/gin v1.10.1
 	github.com/prometheus/client_golang v1.22.0

--- a/api-go/go.sum
+++ b/api-go/go.sum
@@ -10,8 +10,6 @@ github.com/PuerkitoBio/purell v1.1.1 h1:WEQqlqaGbrPkxLJWfBwQmfEAE1Z7ONdDLqrN38tN
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV/sSk/8dngufqelfh6jnri85riMAaF/M=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
-github.com/allaboutapps/aws4 v0.0.0-20200604111205-3c45f7eabfb9 h1:A85rTFVEuDjChFl29Cpjr1w5Gsb0eAIHlDcGsIdcbwM=
-github.com/allaboutapps/aws4 v0.0.0-20200604111205-3c45f7eabfb9/go.mod h1:oYR5/MHKFU69bNYk5Q9LBRTDr6Y4UEwa9Qw3h6bkNAs=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bytedance/sonic v1.11.6 h1:oUp34TzMlL+OY1OUWxHqsdkgC/Zfc85zGqw9siXjrc0=

--- a/api-go/internal/app/router.go
+++ b/api-go/internal/app/router.go
@@ -72,5 +72,12 @@ func SetupRouter(m *db.Mongo, cfg *config.Config) *gin.Engine {
 
 	router.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
 	router.GET("/metrics", gin.WrapH(promhttp.Handler()))
+	if bucketRepo != nil && sourceRepo != nil && fileRepo != nil {
+		secretKey := ""
+		if cfg != nil {
+			secretKey = cfg.AccessSecretKey
+		}
+		router.GET("/api/s3/:bucket/*object", handlers.AWS4Auth(bucketRepo, secretKey), handlers.GetObject(bucketRepo, sourceRepo, fileRepo))
+	}
 	return router
 }

--- a/api-go/internal/config/config.go
+++ b/api-go/internal/config/config.go
@@ -25,7 +25,7 @@ type UploadConfig struct {
 type Config struct {
 	Mongo           MongoConfig  `yaml:"mongo"`
 	Upload          UploadConfig `yaml:"upload"`
-	AccessSecretKey string       `yaml:"-"`
+	AccessSecretKey string       `yaml:"access_secret_key"`
 }
 
 func Load() (*Config, error) {

--- a/api-go/internal/docs/docs.go
+++ b/api-go/internal/docs/docs.go
@@ -15,6 +15,53 @@ const docTemplate = `{
     "host": "{{.Host}}",
     "basePath": "{{.BasePath}}",
     "paths": {
+        "/api/s3/{bucket}/{object}": {
+            "get": {
+                "produces": [
+                    "application/octet-stream"
+                ],
+                "tags": [
+                    "s3"
+                ],
+                "summary": "Get object",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Bucket key",
+                        "name": "bucket",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Object key",
+                        "name": "object",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "file"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/buckets": {
             "get": {
                 "security": [
@@ -35,7 +82,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/handlers.bucketResponse"
+                                "$ref": "#/definitions/internal_handlers.bucketResponse"
                             }
                         }
                     },
@@ -76,7 +123,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/handlers.createBucketRequest"
+                            "$ref": "#/definitions/internal_handlers.createBucketRequest"
                         }
                     }
                 ],
@@ -84,7 +131,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/handlers.createBucketResponse"
+                            "$ref": "#/definitions/internal_handlers.createBucketResponse"
                         }
                     },
                     "400": {
@@ -191,7 +238,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/handlers.fileResponse"
+                                "$ref": "#/definitions/internal_handlers.fileResponse"
                             }
                         }
                     },
@@ -384,7 +431,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/handlers.uploadFileResponse"
+                            "$ref": "#/definitions/internal_handlers.uploadFileResponse"
                         }
                     },
                     "400": {
@@ -434,7 +481,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/handlers.createSourceResponse"
+                                "$ref": "#/definitions/internal_handlers.createSourceResponse"
                             }
                         }
                     },
@@ -477,7 +524,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/handlers.createGDriveSourceRequest"
+                            "$ref": "#/definitions/internal_handlers.createGDriveSourceRequest"
                         }
                     }
                 ],
@@ -485,7 +532,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/handlers.createSourceResponse"
+                            "$ref": "#/definitions/internal_handlers.createSourceResponse"
                         }
                     },
                     "400": {
@@ -587,7 +634,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/handlers.sourceInfoResponse"
+                            "$ref": "#/definitions/internal_handlers.sourceInfoResponse"
                         }
                     },
                     "400": {
@@ -636,7 +683,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/handlers.createUserRequest"
+                            "$ref": "#/definitions/internal_handlers.createUserRequest"
                         }
                     }
                 ],
@@ -644,7 +691,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/handlers.createUserResponse"
+                            "$ref": "#/definitions/internal_handlers.createUserResponse"
                         }
                     },
                     "400": {
@@ -734,7 +781,7 @@ const docTemplate = `{
         }
     },
     "definitions": {
-        "handlers.bucketResponse": {
+        "internal_handlers.bucketResponse": {
             "type": "object",
             "properties": {
                 "access_key": {
@@ -751,7 +798,7 @@ const docTemplate = `{
                 }
             }
         },
-        "handlers.createBucketRequest": {
+        "internal_handlers.createBucketRequest": {
             "type": "object",
             "required": [
                 "key"
@@ -762,7 +809,7 @@ const docTemplate = `{
                 }
             }
         },
-        "handlers.createBucketResponse": {
+        "internal_handlers.createBucketResponse": {
             "type": "object",
             "properties": {
                 "access_key": {
@@ -779,7 +826,7 @@ const docTemplate = `{
                 }
             }
         },
-        "handlers.createGDriveSourceRequest": {
+        "internal_handlers.createGDriveSourceRequest": {
             "type": "object",
             "required": [
                 "key",
@@ -794,7 +841,7 @@ const docTemplate = `{
                 }
             }
         },
-        "handlers.createSourceResponse": {
+        "internal_handlers.createSourceResponse": {
             "type": "object",
             "properties": {
                 "created_at": {
@@ -814,7 +861,7 @@ const docTemplate = `{
                 }
             }
         },
-        "handlers.createUserRequest": {
+        "internal_handlers.createUserRequest": {
             "type": "object",
             "required": [
                 "username"
@@ -825,7 +872,7 @@ const docTemplate = `{
                 }
             }
         },
-        "handlers.createUserResponse": {
+        "internal_handlers.createUserResponse": {
             "type": "object",
             "properties": {
                 "created_at": {
@@ -839,7 +886,7 @@ const docTemplate = `{
                 }
             }
         },
-        "handlers.fileResponse": {
+        "internal_handlers.fileResponse": {
             "type": "object",
             "properties": {
                 "created_at": {
@@ -856,7 +903,7 @@ const docTemplate = `{
                 }
             }
         },
-        "handlers.sourceInfoFile": {
+        "internal_handlers.sourceInfoFile": {
             "type": "object",
             "properties": {
                 "id": {
@@ -870,13 +917,13 @@ const docTemplate = `{
                 }
             }
         },
-        "handlers.sourceInfoResponse": {
+        "internal_handlers.sourceInfoResponse": {
             "type": "object",
             "properties": {
                 "files": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/handlers.sourceInfoFile"
+                        "$ref": "#/definitions/internal_handlers.sourceInfoFile"
                     }
                 },
                 "id": {
@@ -899,7 +946,7 @@ const docTemplate = `{
                 }
             }
         },
-        "handlers.uploadFileResponse": {
+        "internal_handlers.uploadFileResponse": {
             "type": "object",
             "properties": {
                 "created_at": {

--- a/api-go/internal/handlers/aws4.go
+++ b/api-go/internal/handlers/aws4.go
@@ -4,21 +4,18 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/allaboutapps/aws4"
 	"github.com/example/s3aas/api-go/internal/cryptoutil"
 	"github.com/example/s3aas/api-go/internal/repository"
+	"github.com/example/s3aas/api-go/internal/s3sigv4"
 	"github.com/gin-gonic/gin"
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
 // AWS4Auth validates AWS Signature V4 signed requests using bucket access keys.
 func AWS4Auth(repo *repository.BucketRepository, secretKey string) gin.HandlerFunc {
+	validator := &s3sigv4.Validator{}
+
 	return func(c *gin.Context) {
-		accessKey := aws4.AccessKeyIDFromRequest(c.Request)
-		if accessKey == "" {
-			c.AbortWithStatus(http.StatusUnauthorized)
-			return
-		}
 		if repo == nil {
 			log.Print("aws4 auth: bucket repository is nil")
 			c.AbortWithStatus(http.StatusServiceUnavailable)
@@ -29,9 +26,18 @@ func AWS4Auth(repo *repository.BucketRepository, secretKey string) gin.HandlerFu
 			c.AbortWithStatus(http.StatusInternalServerError)
 			return
 		}
+
+		accessKey, err := s3sigv4.AccessKeyFromRequest(c.Request)
+		if err != nil || accessKey == "" {
+			log.Printf("aws4 auth: failed to extract access key: %v", err)
+			c.AbortWithStatus(http.StatusUnauthorized)
+			return
+		}
+
 		encSecret, err := repo.GetSecretByAccessKey(c.Request.Context(), accessKey)
 		if err != nil {
 			if err == mongo.ErrNoDocuments {
+				log.Print("aws4 auth: get secret by access key lead to ErrNoDocuments")
 				c.AbortWithStatus(http.StatusUnauthorized)
 				return
 			}
@@ -45,11 +51,14 @@ func AWS4Auth(repo *repository.BucketRepository, secretKey string) gin.HandlerFu
 			c.AbortWithStatus(http.StatusInternalServerError)
 			return
 		}
-		signer := aws4.NewSignerWithStaticCredentials(accessKey, secret, "")
-		if _, err = signer.Validate(c.Request); err != nil {
+
+		if _, err = validator.Validate(c.Request.Context(), c.Request, accessKey, secret); err != nil {
+			log.Printf("aws4 auth: signature validation failed: %v", err)
 			c.AbortWithStatus(http.StatusUnauthorized)
 			return
 		}
+
+		log.Print("aws4 auth success")
 		c.Set("accessKey", accessKey)
 		c.Next()
 	}

--- a/api-go/internal/handlers/bucket.go
+++ b/api-go/internal/handlers/bucket.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/example/s3aas/api-go/internal/cryptoutil"
 	"github.com/example/s3aas/api-go/internal/gdrive"
+	"github.com/example/s3aas/api-go/internal/manager"
 	"github.com/example/s3aas/api-go/internal/repository"
 	"github.com/gin-gonic/gin"
 	"go.mongodb.org/mongo-driver/bson/primitive"
@@ -509,34 +510,8 @@ func DownloadFile(bucketRepo *repository.BucketRepository, sourceRepo *repositor
 		c.Header("Content-Type", "application/octet-stream")
 		c.Header("Content-Length", strconv.FormatInt(total, 10))
 		c.Status(http.StatusOK)
-		ctx := c.Request.Context()
-		clients := make(map[primitive.ObjectID]*gdrive.Client)
-		for _, ch := range fileDoc.Chunks {
-			cli, ok := clients[ch.SourceID]
-			if !ok {
-				src, err := sourceRepo.GetByID(ctx, ch.SourceID)
-				if err != nil {
-					log.Printf("download file: get source: %v", err)
-					return
-				}
-				cli, err = gdrive.NewClient(ctx, []byte(src.Key))
-				if err != nil {
-					log.Printf("download file: create client: %v", err)
-					return
-				}
-				clients[ch.SourceID] = cli
-			}
-			rc, err := cli.Download(ctx, ch.Name)
-			if err != nil {
-				log.Printf("download file: download chunk: %v", err)
-				return
-			}
-			_, err = io.Copy(c.Writer, rc)
-			_ = rc.Close()
-			if err != nil {
-				log.Printf("download file: write chunk: %v", err)
-				return
-			}
+		if err := manager.StreamFile(c.Request.Context(), sourceRepo, fileDoc, c.Writer); err != nil {
+			log.Printf("download file: %v", err)
 		}
 	}
 }

--- a/api-go/internal/handlers/s3.go
+++ b/api-go/internal/handlers/s3.go
@@ -1,0 +1,81 @@
+package handlers
+
+import (
+	"encoding/xml"
+	"log"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/example/s3aas/api-go/internal/manager"
+	"github.com/example/s3aas/api-go/internal/repository"
+	"github.com/gin-gonic/gin"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+type s3Error struct {
+	XMLName xml.Name `xml:"Error"`
+	Code    string   `xml:"Code"`
+	Message string   `xml:"Message"`
+}
+
+func writeS3Error(c *gin.Context, status int, code, message string) {
+	c.XML(status, s3Error{Code: code, Message: message})
+}
+
+// GetObject godoc
+// @Summary Get object
+// @Tags s3
+// @Produce octet-stream
+// @Param bucket path string true "Bucket key"
+// @Param object path string true "Object key"
+// @Success 200 {file} file
+// @Failure 404 {string} string ""
+// @Failure 500 {string} string ""
+// @Router /api/s3/{bucket}/{object} [get]
+func GetObject(bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if bucketRepo == nil || sourceRepo == nil || fileRepo == nil {
+			c.Status(http.StatusServiceUnavailable)
+			return
+		}
+		bucketKey := c.Param("bucket")
+		name := strings.TrimPrefix(c.Param("object"), "/")
+		ctx := c.Request.Context()
+		bucketDoc, err := bucketRepo.GetByKey(ctx, bucketKey)
+		if err != nil {
+			if err == mongo.ErrNoDocuments {
+				writeS3Error(c, http.StatusNotFound, "NoSuchBucket", "")
+				return
+			}
+			log.Printf("get object: get bucket: %v", err)
+			writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
+			return
+		}
+		accessKey := c.GetString("accessKey")
+		if accessKey == "" || bucketDoc.AccessKey != accessKey {
+			writeS3Error(c, http.StatusNotFound, "NoSuchBucket", "")
+			return
+		}
+		fileDoc, err := fileRepo.GetByName(ctx, bucketDoc.ID, name)
+		if err != nil {
+			if err == mongo.ErrNoDocuments {
+				writeS3Error(c, http.StatusNotFound, "NoSuchKey", "")
+				return
+			}
+			log.Printf("get object: get file: %v", err)
+			writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
+			return
+		}
+		var total int64
+		for _, ch := range fileDoc.Chunks {
+			total += ch.Size
+		}
+		c.Header("Content-Type", "application/octet-stream")
+		c.Header("Content-Length", strconv.FormatInt(total, 10))
+		c.Status(http.StatusOK)
+		if err := manager.StreamFile(c.Request.Context(), sourceRepo, fileDoc, c.Writer); err != nil {
+			log.Printf("get object: %v", err)
+		}
+	}
+}

--- a/api-go/internal/manager/file.go
+++ b/api-go/internal/manager/file.go
@@ -1,0 +1,40 @@
+package manager
+
+import (
+	"context"
+	"io"
+
+	"github.com/example/s3aas/api-go/internal/gdrive"
+	"github.com/example/s3aas/api-go/internal/repository"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+// StreamFile downloads file chunks from sources and writes them to w.
+// It returns an error if any chunk cannot be downloaded or written.
+func StreamFile(ctx context.Context, srcRepo *repository.SourceRepository, f *repository.File, w io.Writer) error {
+	clients := make(map[primitive.ObjectID]*gdrive.Client)
+	for _, ch := range f.Chunks {
+		cli, ok := clients[ch.SourceID]
+		if !ok {
+			src, err := srcRepo.GetByID(ctx, ch.SourceID)
+			if err != nil {
+				return err
+			}
+			cli, err = gdrive.NewClient(ctx, []byte(src.Key))
+			if err != nil {
+				return err
+			}
+			clients[ch.SourceID] = cli
+		}
+		rc, err := cli.Download(ctx, ch.Name)
+		if err != nil {
+			return err
+		}
+		if _, err := io.Copy(w, rc); err != nil {
+			_ = rc.Close()
+			return err
+		}
+		_ = rc.Close()
+	}
+	return nil
+}

--- a/api-go/internal/repository/file.go
+++ b/api-go/internal/repository/file.go
@@ -60,6 +60,15 @@ func (r *FileRepository) GetByID(ctx context.Context, id primitive.ObjectID) (*F
 	return &f, nil
 }
 
+func (r *FileRepository) GetByName(ctx context.Context, bucketID primitive.ObjectID, name string) (*File, error) {
+	var f File
+	err := r.coll.FindOne(ctx, bson.M{"bucket_id": bucketID, "name": name}).Decode(&f)
+	if err != nil {
+		return nil, err
+	}
+	return &f, nil
+}
+
 func (r *FileRepository) ListByBucket(ctx context.Context, bucketID primitive.ObjectID) ([]File, error) {
 	cursor, err := r.coll.Find(ctx, bson.M{"bucket_id": bucketID})
 	if err != nil {

--- a/api-go/internal/s3sigv4/validator.go
+++ b/api-go/internal/s3sigv4/validator.go
@@ -1,0 +1,762 @@
+package s3sigv4
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var (
+	ErrMissingAuth          = errors.New("sigv4: missing Authorization header or presign query parameters")
+	ErrUnsupportedAlgorithm = errors.New("sigv4: unsupported algorithm")
+	ErrInvalidAuthorization = errors.New("sigv4: invalid Authorization header format")
+	ErrInvalidPresign       = errors.New("sigv4: invalid presign query")
+	ErrInvalidCredential    = errors.New("sigv4: invalid credential scope")
+	ErrInvalidSignedHeaders = errors.New("sigv4: invalid SignedHeaders")
+	ErrMissingSignedHeader  = errors.New("sigv4: request missing a header listed in SignedHeaders")
+	ErrSignatureMismatch    = errors.New("sigv4: signature mismatch")
+	ErrExpired              = errors.New("sigv4: request expired")
+	ErrClockSkew            = errors.New("sigv4: request time outside allowed skew")
+)
+
+type Validator struct {
+	Now           func() time.Time
+	MaxSkew       time.Duration
+	MaxPresignTTL time.Duration
+}
+
+type ValidatedRequest struct {
+	Mode             string
+	Algorithm        string
+	AccessKey        string
+	Date             string
+	Region           string
+	Service          string
+	AmzDate          time.Time
+	Scope            string
+	SignedHeaders    []string
+	Signature        string
+	CanonicalRequest string
+	StringToSign     string
+	PayloadHash      string
+	Request          *http.Request
+}
+
+func (v *Validator) nowUTC() time.Time {
+	if v.Now != nil {
+		return v.Now().UTC()
+	}
+	return time.Now().UTC()
+}
+
+func (v *Validator) skew() time.Duration {
+	if v.MaxSkew <= 0 {
+		return 15 * time.Minute
+	}
+	return v.MaxSkew
+}
+
+func (v *Validator) maxPresignTTL() time.Duration {
+	if v.MaxPresignTTL <= 0 {
+		return 7 * 24 * time.Hour
+	}
+	return v.MaxPresignTTL
+}
+
+func AccessKeyFromRequest(r *http.Request) (string, error) {
+	if r == nil {
+		return "", ErrMissingAuth
+	}
+	if isPresign(r.URL) {
+		return parseAccessKey(r.URL.Query().Get("X-Amz-Credential"))
+	}
+
+	auth := strings.TrimSpace(r.Header.Get("Authorization"))
+	if auth == "" {
+		return "", ErrMissingAuth
+	}
+
+	algo, params, err := parseAuthorizationHeader(auth)
+	if err != nil {
+		return "", err
+	}
+	if algo != "AWS4-HMAC-SHA256" {
+		return "", ErrUnsupportedAlgorithm
+	}
+
+	cred := params["Credential"]
+	if cred == "" {
+		return "", ErrInvalidAuthorization
+	}
+
+	return parseAccessKey(cred)
+}
+
+func parseAccessKey(credential string) (string, error) {
+	ak, _, _, _, _, err := parseCredential(credential)
+	return ak, err
+}
+
+func (v *Validator) Validate(ctx context.Context, r *http.Request, accessKey, secretKey string) (*ValidatedRequest, error) {
+	if ctx != nil {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+	}
+
+	if r == nil {
+		return nil, errors.New("sigv4: nil request")
+	}
+	if accessKey == "" || secretKey == "" {
+		return nil, errors.New("sigv4: accessKey/secretKey required")
+	}
+
+	if isPresign(r.URL) {
+		return v.validatePresign(ctx, r, accessKey, secretKey)
+	}
+	if strings.TrimSpace(r.Header.Get("Authorization")) != "" {
+		return v.validateHeaderAuth(ctx, r, accessKey, secretKey)
+	}
+	return nil, ErrMissingAuth
+}
+
+func isPresign(u *url.URL) bool {
+	if u == nil {
+		return false
+	}
+	q := u.Query()
+	return strings.EqualFold(q.Get("X-Amz-Algorithm"), "AWS4-HMAC-SHA256") &&
+		q.Get("X-Amz-Credential") != "" &&
+		q.Get("X-Amz-SignedHeaders") != "" &&
+		q.Get("X-Amz-Date") != "" &&
+		q.Get("X-Amz-Signature") != ""
+}
+
+func (v *Validator) validateHeaderAuth(ctx context.Context, r *http.Request, accessKey, secretKey string) (*ValidatedRequest, error) {
+	if ctx != nil {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+	}
+
+	auth := strings.TrimSpace(r.Header.Get("Authorization"))
+	algo, params, err := parseAuthorizationHeader(auth)
+	if err != nil {
+		return nil, err
+	}
+	if algo != "AWS4-HMAC-SHA256" {
+		return nil, ErrUnsupportedAlgorithm
+	}
+
+	cred := params["Credential"]
+	signedHeadersStr := params["SignedHeaders"]
+	signature := params["Signature"]
+	if cred == "" || signedHeadersStr == "" || signature == "" {
+		return nil, ErrInvalidAuthorization
+	}
+
+	ak, scope, date, region, service, err := parseCredential(cred)
+	if err != nil {
+		return nil, err
+	}
+	if ak != accessKey {
+		return nil, fmt.Errorf("sigv4: access key mismatch: got %q", ak)
+	}
+
+	amzDate, err := parseAmzDateFromRequest(r, "")
+	if err != nil {
+		return nil, err
+	}
+	if amzDate.Format("20060102") != date {
+		return nil, ErrInvalidCredential
+	}
+
+	now := v.nowUTC()
+	if amzDate.Before(now.Add(-v.skew())) || amzDate.After(now.Add(v.skew())) {
+		return nil, ErrClockSkew
+	}
+
+	signedHeaders, err := normalizeAndValidateSignedHeaders(signedHeadersStr)
+	if err != nil {
+		return nil, err
+	}
+	if !contains(signedHeaders, "host") {
+		return nil, fmt.Errorf("%w: SignedHeaders must include host", ErrInvalidSignedHeaders)
+	}
+
+	payloadHash, bodyBytes, err := payloadHashForHeaderAuth(r)
+	if err != nil {
+		return nil, err
+	}
+	restoreBody(r, bodyBytes)
+
+	canonReq, canonHeaders, err := buildCanonicalRequest(r, signedHeaders, payloadHash, false)
+	if err != nil {
+		return nil, err
+	}
+
+	stringToSign := buildStringToSign(algo, amzDate, scope, canonReq)
+	expectedSig := computeSignature(secretKey, date, region, service, stringToSign)
+
+	if !constantTimeHexEquals(expectedSig, signature) {
+		return nil, fmt.Errorf("%w: expected %s got %s; canonicalHeaders=%q", ErrSignatureMismatch, expectedSig, signature, canonHeaders)
+	}
+
+	return &ValidatedRequest{
+		Mode:             "header",
+		Algorithm:        algo,
+		AccessKey:        ak,
+		Date:             date,
+		Region:           region,
+		Service:          service,
+		AmzDate:          amzDate,
+		Scope:            scope,
+		SignedHeaders:    signedHeaders,
+		Signature:        strings.ToLower(signature),
+		CanonicalRequest: canonReq,
+		StringToSign:     stringToSign,
+		PayloadHash:      payloadHash,
+		Request:          r,
+	}, nil
+}
+
+func parseAuthorizationHeader(h string) (string, map[string]string, error) {
+	if h == "" {
+		return "", nil, ErrMissingAuth
+	}
+	parts := strings.SplitN(h, " ", 2)
+	if len(parts) != 2 {
+		return "", nil, ErrInvalidAuthorization
+	}
+	algo := strings.TrimSpace(parts[0])
+	rest := strings.TrimSpace(parts[1])
+
+	params := map[string]string{}
+	for _, p := range splitCommaParams(rest) {
+		kv := strings.SplitN(strings.TrimSpace(p), "=", 2)
+		if len(kv) != 2 {
+			return "", nil, ErrInvalidAuthorization
+		}
+		k := strings.TrimSpace(kv[0])
+		v := strings.TrimSpace(kv[1])
+		params[k] = v
+	}
+	return algo, params, nil
+}
+
+func splitCommaParams(s string) []string {
+	raw := strings.Split(s, ",")
+	out := make([]string, 0, len(raw))
+	for _, r := range raw {
+		t := strings.TrimSpace(r)
+		if t != "" {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
+func (v *Validator) validatePresign(ctx context.Context, r *http.Request, accessKey, secretKey string) (*ValidatedRequest, error) {
+	if ctx != nil {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+	}
+
+	q := r.URL.Query()
+
+	algo := q.Get("X-Amz-Algorithm")
+	if algo != "AWS4-HMAC-SHA256" {
+		return nil, ErrUnsupportedAlgorithm
+	}
+
+	cred := q.Get("X-Amz-Credential")
+	signedHeadersStr := q.Get("X-Amz-SignedHeaders")
+	signature := q.Get("X-Amz-Signature")
+	amzDateStr := q.Get("X-Amz-Date")
+	expiresStr := q.Get("X-Amz-Expires")
+
+	if cred == "" || signedHeadersStr == "" || signature == "" || amzDateStr == "" || expiresStr == "" {
+		return nil, ErrInvalidPresign
+	}
+
+	ak, scope, date, region, service, err := parseCredential(cred)
+	if err != nil {
+		return nil, err
+	}
+	if ak != accessKey {
+		return nil, fmt.Errorf("sigv4: access key mismatch: got %q", ak)
+	}
+
+	amzDate, err := parseAmzDate(amzDateStr)
+	if err != nil {
+		return nil, err
+	}
+	if amzDate.Format("20060102") != date {
+		return nil, ErrInvalidCredential
+	}
+
+	expiresSec, err := strconv.Atoi(expiresStr)
+	if err != nil || expiresSec <= 0 {
+		return nil, fmt.Errorf("%w: invalid X-Amz-Expires", ErrInvalidPresign)
+	}
+	ttl := time.Duration(expiresSec) * time.Second
+	if ttl > v.maxPresignTTL() {
+		return nil, fmt.Errorf("%w: presign ttl exceeds max (%s)", ErrInvalidPresign, v.maxPresignTTL())
+	}
+
+	now := v.nowUTC()
+	if now.Before(amzDate.Add(-v.skew())) {
+		return nil, ErrClockSkew
+	}
+	if now.After(amzDate.Add(ttl).Add(v.skew())) {
+		return nil, ErrExpired
+	}
+
+	signedHeaders, err := normalizeAndValidateSignedHeaders(signedHeadersStr)
+	if err != nil {
+		return nil, err
+	}
+	if !contains(signedHeaders, "host") {
+		return nil, fmt.Errorf("%w: SignedHeaders must include host", ErrInvalidSignedHeaders)
+	}
+
+	payloadHash := q.Get("X-Amz-Content-Sha256")
+	var bodyBytes []byte
+	if payloadHash == "" {
+		if h := strings.TrimSpace(r.Header.Get("X-Amz-Content-Sha256")); h != "" {
+			payloadHash = h
+		} else if strings.EqualFold(service, "s3") {
+			payloadHash = "UNSIGNED-PAYLOAD"
+		} else {
+			payloadHash, bodyBytes, err = payloadHashForHeaderAuth(r)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+	if bodyBytes != nil {
+		restoreBody(r, bodyBytes)
+	}
+
+	canonReq, canonHeaders, err := buildCanonicalRequest(r, signedHeaders, payloadHash, true)
+	if err != nil {
+		return nil, err
+	}
+
+	stringToSign := buildStringToSign(algo, amzDate, scope, canonReq)
+	expectedSig := computeSignature(secretKey, date, region, service, stringToSign)
+
+	if !constantTimeHexEquals(expectedSig, signature) {
+		return nil, fmt.Errorf("%w: expected %s got %s; canonicalHeaders=%q", ErrSignatureMismatch, expectedSig, signature, canonHeaders)
+	}
+
+	return &ValidatedRequest{
+		Mode:             "presign",
+		Algorithm:        algo,
+		AccessKey:        ak,
+		Date:             date,
+		Region:           region,
+		Service:          service,
+		AmzDate:          amzDate,
+		Scope:            scope,
+		SignedHeaders:    signedHeaders,
+		Signature:        strings.ToLower(signature),
+		CanonicalRequest: canonReq,
+		StringToSign:     stringToSign,
+		PayloadHash:      payloadHash,
+		Request:          r,
+	}, nil
+}
+
+func buildCanonicalRequest(r *http.Request, signedHeaders []string, payloadHash string, presign bool) (string, string, error) {
+	method := r.Method
+	if method == "" {
+		method = "GET"
+	}
+
+	canonicalURI := canonicalizeURI(r.URL)
+	canonicalQuery := canonicalizeQuery(r.URL, presign)
+
+	canonicalHeaders, signedHeadersStr, err := canonicalizeHeaders(r, signedHeaders)
+	if err != nil {
+		return "", "", err
+	}
+
+	var sb strings.Builder
+	sb.WriteString(method)
+	sb.WriteByte('\n')
+	sb.WriteString(canonicalURI)
+	sb.WriteByte('\n')
+	sb.WriteString(canonicalQuery)
+	sb.WriteByte('\n')
+	sb.WriteString(canonicalHeaders)
+	sb.WriteByte('\n')
+	sb.WriteString(signedHeadersStr)
+	sb.WriteByte('\n')
+	sb.WriteString(payloadHash)
+
+	return sb.String(), canonicalHeaders, nil
+}
+
+func canonicalizeURI(u *url.URL) string {
+	if u == nil {
+		return "/"
+	}
+
+	path := u.EscapedPath()
+	if u.Opaque != "" {
+		parts := strings.Split(u.Opaque, "/")
+		if len(parts) >= 4 {
+			path = "/" + strings.Join(parts[3:], "/")
+		}
+	}
+	if path == "" {
+		path = "/"
+	}
+
+	decoded, err := url.PathUnescape(path)
+	if err != nil {
+		return awsPercentEncodePath(path)
+	}
+	return awsPercentEncodePath(decoded)
+}
+
+func awsPercentEncodePath(path string) string {
+	var b strings.Builder
+	for i := 0; i < len(path); i++ {
+		c := path[i]
+		if isUnreserved(c) || c == '/' {
+			b.WriteByte(c)
+		} else {
+			b.WriteString(fmt.Sprintf("%%%02X", c))
+		}
+	}
+	return b.String()
+}
+
+func canonicalizeQuery(u *url.URL, presign bool) string {
+	if u == nil {
+		return ""
+	}
+	values, _ := url.ParseQuery(u.RawQuery)
+
+	type kv struct {
+		k string
+		v string
+	}
+	var items []kv
+	for k, vs := range values {
+		if presign && strings.EqualFold(k, "X-Amz-Signature") {
+			continue
+		}
+		if len(vs) == 0 {
+			items = append(items, kv{k: k, v: ""})
+			continue
+		}
+		for _, v := range vs {
+			items = append(items, kv{k: k, v: v})
+		}
+	}
+
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].k == items[j].k {
+			return items[i].v < items[j].v
+		}
+		return items[i].k < items[j].k
+	})
+
+	var sb strings.Builder
+	for i, it := range items {
+		if i > 0 {
+			sb.WriteByte('&')
+		}
+		sb.WriteString(awsPercentEncodeQuery(it.k))
+		sb.WriteByte('=')
+		sb.WriteString(awsPercentEncodeQuery(it.v))
+	}
+	return sb.String()
+}
+
+func awsPercentEncodeQuery(s string) string {
+	var b strings.Builder
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if isUnreserved(c) {
+			b.WriteByte(c)
+		} else {
+			b.WriteString(fmt.Sprintf("%%%02X", c))
+		}
+	}
+	return b.String()
+}
+
+func canonicalizeHeaders(r *http.Request, signedHeaders []string) (string, string, error) {
+	var sb strings.Builder
+	for _, h := range signedHeaders {
+		sb.WriteString(h)
+		sb.WriteByte(':')
+
+		if h == "host" {
+			host, err := canonicalHost(r)
+			if err != nil {
+				return "", "", err
+			}
+			sb.WriteString(canonicalizeHeaderValue(host))
+			sb.WriteByte('\n')
+			continue
+		}
+
+		values := r.Header.Values(h)
+		if len(values) == 0 {
+			v := r.Header.Get(h)
+			if strings.TrimSpace(v) == "" {
+				return "", "", fmt.Errorf("%w: %s", ErrMissingSignedHeader, h)
+			}
+			values = []string{v}
+		}
+
+		for i, v := range values {
+			if i > 0 {
+				sb.WriteByte(',')
+			}
+			sb.WriteString(canonicalizeHeaderValue(v))
+		}
+		sb.WriteByte('\n')
+	}
+
+	return sb.String(), strings.Join(signedHeaders, ";"), nil
+}
+
+func canonicalHost(r *http.Request) (string, error) {
+	host := r.Host
+	if host == "" && r.URL != nil {
+		host = r.URL.Host
+	}
+	if host == "" {
+		host = r.Header.Get("Host")
+	}
+	host = strings.TrimSpace(host)
+	if host == "" {
+		return "", fmt.Errorf("%w: host", ErrMissingSignedHeader)
+	}
+
+	scheme := strings.ToLower(r.URL.Scheme)
+	if scheme == "" {
+		if r.TLS != nil {
+			scheme = "https"
+		} else {
+			scheme = "http"
+		}
+	}
+
+	if h, p, err := net.SplitHostPort(host); err == nil {
+		if (p == "80" && scheme == "http") || (p == "443" && scheme == "https") {
+			return h, nil
+		}
+		return net.JoinHostPort(h, p), nil
+	}
+
+	return host, nil
+}
+
+func canonicalizeHeaderValue(v string) string {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return ""
+	}
+	var b strings.Builder
+	b.Grow(len(v))
+	inWS := false
+	for i := 0; i < len(v); i++ {
+		c := v[i]
+		isWS := c == ' ' || c == '\t' || c == '\n' || c == '\r'
+		if isWS {
+			inWS = true
+			continue
+		}
+		if inWS {
+			b.WriteByte(' ')
+			inWS = false
+		}
+		b.WriteByte(c)
+	}
+	return b.String()
+}
+
+func parseCredential(cred string) (accessKey, scope, date, region, service string, err error) {
+	parts := strings.Split(cred, "/")
+	if len(parts) != 5 {
+		return "", "", "", "", "", ErrInvalidCredential
+	}
+	accessKey = parts[0]
+	date = parts[1]
+	region = parts[2]
+	service = parts[3]
+	term := parts[4]
+	if accessKey == "" || date == "" || region == "" || service == "" || term != "aws4_request" {
+		return "", "", "", "", "", ErrInvalidCredential
+	}
+	if len(date) != 8 {
+		return "", "", "", "", "", ErrInvalidCredential
+	}
+	scope = strings.Join(parts[1:], "/")
+	return accessKey, scope, date, region, service, nil
+}
+
+func parseAmzDateFromRequest(r *http.Request, fallback string) (time.Time, error) {
+	s := strings.TrimSpace(r.Header.Get("X-Amz-Date"))
+	if s == "" {
+		s = strings.TrimSpace(r.Header.Get("Date"))
+	}
+	if s == "" && fallback != "" {
+		s = fallback
+	}
+	if s == "" {
+		return time.Time{}, errors.New("sigv4: missing X-Amz-Date/Date")
+	}
+
+	if t, err := parseAmzDate(s); err == nil {
+		return t, nil
+	}
+	if t, err := http.ParseTime(s); err == nil {
+		return t.UTC(), nil
+	}
+	return time.Time{}, errors.New("sigv4: invalid date format")
+}
+
+func parseAmzDate(s string) (time.Time, error) {
+	t, err := time.Parse("20060102T150405Z", s)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("sigv4: invalid X-Amz-Date: %w", err)
+	}
+	return t.UTC(), nil
+}
+
+func normalizeAndValidateSignedHeaders(s string) ([]string, error) {
+	if strings.TrimSpace(s) == "" {
+		return nil, ErrInvalidSignedHeaders
+	}
+	parts := strings.Split(s, ";")
+	out := make([]string, 0, len(parts))
+	seen := map[string]struct{}{}
+
+	for _, p := range parts {
+		h := strings.ToLower(strings.TrimSpace(p))
+		if h == "" {
+			return nil, ErrInvalidSignedHeaders
+		}
+		if h == "authorization" {
+			return nil, fmt.Errorf("%w: authorization cannot be signed", ErrInvalidSignedHeaders)
+		}
+		for i := 0; i < len(h); i++ {
+			c := h[i]
+			if !(c >= 'a' && c <= 'z') && !(c >= '0' && c <= '9') && c != '-' {
+				return nil, fmt.Errorf("%w: invalid header name %q", ErrInvalidSignedHeaders, h)
+			}
+		}
+		if _, ok := seen[h]; ok {
+			return nil, fmt.Errorf("%w: duplicate header %q", ErrInvalidSignedHeaders, h)
+		}
+		seen[h] = struct{}{}
+		out = append(out, h)
+	}
+
+	sorted := append([]string(nil), out...)
+	sort.Strings(sorted)
+	if strings.Join(sorted, ";") != strings.Join(out, ";") {
+		return nil, fmt.Errorf("%w: SignedHeaders must be sorted", ErrInvalidSignedHeaders)
+	}
+	return out, nil
+}
+
+func payloadHashForHeaderAuth(r *http.Request) (payloadHash string, bodyBytes []byte, err error) {
+	if h := strings.TrimSpace(r.Header.Get("X-Amz-Content-Sha256")); h != "" {
+		return h, nil, nil
+	}
+
+	if r.Body == nil {
+		empty := sha256.Sum256(nil)
+		return hex.EncodeToString(empty[:]), nil, nil
+	}
+	b, err := io.ReadAll(r.Body)
+	if err != nil {
+		return "", nil, fmt.Errorf("sigv4: read body: %w", err)
+	}
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:]), b, nil
+}
+
+func restoreBody(r *http.Request, body []byte) {
+	if body == nil {
+		return
+	}
+	r.Body = io.NopCloser(bytes.NewReader(body))
+	r.ContentLength = int64(len(body))
+}
+
+func buildStringToSign(algorithm string, amzDate time.Time, scope string, canonicalRequest string) string {
+	crHash := sha256.Sum256([]byte(canonicalRequest))
+	var sb strings.Builder
+	sb.WriteString(algorithm)
+	sb.WriteByte('\n')
+	sb.WriteString(amzDate.UTC().Format("20060102T150405Z"))
+	sb.WriteByte('\n')
+	sb.WriteString(scope)
+	sb.WriteByte('\n')
+	sb.WriteString(hex.EncodeToString(crHash[:]))
+	return sb.String()
+}
+
+func computeSignature(secretKey, dateYYYYMMDD, region, service, stringToSign string) string {
+	kDate := hmacSHA256([]byte("AWS4"+secretKey), []byte(dateYYYYMMDD))
+	kRegion := hmacSHA256(kDate, []byte(region))
+	kService := hmacSHA256(kRegion, []byte(service))
+	kSigning := hmacSHA256(kService, []byte("aws4_request"))
+	sig := hmacSHA256(kSigning, []byte(stringToSign))
+	return hex.EncodeToString(sig)
+}
+
+func hmacSHA256(key, data []byte) []byte {
+	h := hmac.New(sha256.New, key)
+	h.Write(data)
+	return h.Sum(nil)
+}
+
+func constantTimeHexEquals(aHex, bHex string) bool {
+	a := strings.ToLower(strings.TrimSpace(aHex))
+	b := strings.ToLower(strings.TrimSpace(bHex))
+	if len(a) != len(b) {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(a), []byte(b)) == 1
+}
+
+func isUnreserved(c byte) bool {
+	return (c >= 'A' && c <= 'Z') ||
+		(c >= 'a' && c <= 'z') ||
+		(c >= '0' && c <= '9') ||
+		c == '-' || c == '_' || c == '.' || c == '~'
+}
+
+func contains(ss []string, s string) bool {
+	for _, x := range ss {
+		if x == s {
+			return true
+		}
+	}
+	return false
+}

--- a/api-go/internal/s3sigv4/validator_test.go
+++ b/api-go/internal/s3sigv4/validator_test.go
@@ -1,0 +1,140 @@
+package s3sigv4
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestValidatorHeaderAuthMatchesAWSExample(t *testing.T) {
+	req, err := http.NewRequest("GET", "https://iam.amazonaws.com/?Action=ListUsers&Version=2010-05-08", nil)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded; charset=utf-8")
+	req.Header.Set("X-Amz-Date", "20150830T123600Z")
+	req.Header.Set("Authorization", "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/iam/aws4_request, SignedHeaders=content-type;host;x-amz-date, Signature=5d672d79c15b13162d9279b0855cfba6789a8edb4c82c400e06b5924a6f2b5d7")
+
+	v := Validator{Now: func() time.Time { return time.Date(2015, 8, 30, 12, 36, 0, 0, time.UTC) }}
+
+	res, err := v.Validate(context.Background(), req, "AKIDEXAMPLE", "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY")
+	if err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	if res.Mode != "header" {
+		t.Fatalf("mode: expected header got %s", res.Mode)
+	}
+
+	expectedCanonical := `GET
+/
+Action=ListUsers&Version=2010-05-08
+content-type:application/x-www-form-urlencoded; charset=utf-8
+host:iam.amazonaws.com
+x-amz-date:20150830T123600Z
+
+content-type;host;x-amz-date
+e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855`
+	if res.CanonicalRequest != expectedCanonical {
+		t.Fatalf("canonical request mismatch:\nexpected:\n%s\n\nactual:\n%s", expectedCanonical, res.CanonicalRequest)
+	}
+
+	expectedStringToSign := `AWS4-HMAC-SHA256
+20150830T123600Z
+20150830/us-east-1/iam/aws4_request
+f536975d06c0309214f805bb90ccff089219ecd68b2577efef23edd43b7e1a59`
+	if res.StringToSign != expectedStringToSign {
+		t.Fatalf("string to sign mismatch:\nexpected:\n%s\n\nactual:\n%s", expectedStringToSign, res.StringToSign)
+	}
+
+	expectedSig := "5d672d79c15b13162d9279b0855cfba6789a8edb4c82c400e06b5924a6f2b5d7"
+	if res.Signature != expectedSig {
+		t.Fatalf("signature mismatch: expected %s got %s", expectedSig, res.Signature)
+	}
+}
+
+func TestValidatorPresignMatchesAWSExample(t *testing.T) {
+	req, err := http.NewRequest("GET", "https://iam.amazonaws.com/?Action=ListUsers&Version=2010-05-08&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIDEXAMPLE%2F20150830%2Fus-east-1%2Fiam%2Faws4_request&X-Amz-Date=20150830T123600Z&X-Amz-Expires=60&X-Amz-SignedHeaders=content-type%3Bhost%3Bx-amz-date&X-Amz-Signature=63613d9c6a68b0e499ed9beeeabe0c4f3295742554209d6f109fe3c9563f56c3", nil)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded; charset=utf-8")
+	req.Header.Set("X-Amz-Date", "20150830T123600Z")
+
+	v := Validator{Now: func() time.Time { return time.Date(2015, 8, 30, 12, 36, 0, 0, time.UTC) }}
+
+	res, err := v.Validate(context.Background(), req, "AKIDEXAMPLE", "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY")
+	if err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	if res.Mode != "presign" {
+		t.Fatalf("mode: expected presign got %s", res.Mode)
+	}
+
+	expectedCanonical := `GET
+/
+Action=ListUsers&Version=2010-05-08&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIDEXAMPLE%2F20150830%2Fus-east-1%2Fiam%2Faws4_request&X-Amz-Date=20150830T123600Z&X-Amz-Expires=60&X-Amz-SignedHeaders=content-type%3Bhost%3Bx-amz-date
+content-type:application/x-www-form-urlencoded; charset=utf-8
+host:iam.amazonaws.com
+x-amz-date:20150830T123600Z
+
+content-type;host;x-amz-date
+e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855`
+	if res.CanonicalRequest != expectedCanonical {
+		t.Fatalf("canonical request mismatch:\nexpected:\n%s\n\nactual:\n%s", expectedCanonical, res.CanonicalRequest)
+	}
+
+	expectedStringToSign := `AWS4-HMAC-SHA256
+20150830T123600Z
+20150830/us-east-1/iam/aws4_request
+829d0ec8859c4877fb1709979fe8ef44a082303f2517ff2a1f335b6b0b1392fa`
+	if res.StringToSign != expectedStringToSign {
+		t.Fatalf("string to sign mismatch:\nexpected:\n%s\n\nactual:\n%s", expectedStringToSign, res.StringToSign)
+	}
+
+	expectedSig := "63613d9c6a68b0e499ed9beeeabe0c4f3295742554209d6f109fe3c9563f56c3"
+	if res.Signature != expectedSig {
+		t.Fatalf("signature mismatch: expected %s got %s", expectedSig, res.Signature)
+	}
+}
+
+func TestValidatorCanonicalizesDefaultPort(t *testing.T) {
+	req, err := http.NewRequest("GET", "https://estest.us-east-1.es.amazonaws.com:443/_search", nil)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+
+	req.Header.Set("X-Amz-Date", "19700101T000000Z")
+	req.Header.Set("X-Amz-Security-Token", "SESSION")
+	req.Header.Set("Authorization", "AWS4-HMAC-SHA256 Credential=AKID/19700101/us-east-1/es/aws4_request, SignedHeaders=host;x-amz-date;x-amz-security-token, Signature=e573fc9aa3a156b720976419319be98fb2824a3abc2ddd895ecb1d1611c6a82d")
+
+	v := Validator{
+		Now:     func() time.Time { return time.Unix(0, 0) },
+		MaxSkew: time.Hour,
+	}
+
+	res, err := v.Validate(context.Background(), req, "AKID", "SECRET")
+	if err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+
+	expectedCanonical := `GET
+/_search
+
+host:estest.us-east-1.es.amazonaws.com
+x-amz-date:19700101T000000Z
+x-amz-security-token:SESSION
+
+host;x-amz-date;x-amz-security-token
+e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855`
+	if res.CanonicalRequest != expectedCanonical {
+		t.Fatalf("canonical request mismatch:\nexpected:\n%s\n\nactual:\n%s", expectedCanonical, res.CanonicalRequest)
+	}
+
+	expectedSig := "e573fc9aa3a156b720976419319be98fb2824a3abc2ddd895ecb1d1611c6a82d"
+	if res.Signature != expectedSig {
+		t.Fatalf("signature mismatch: expected %s got %s", expectedSig, res.Signature)
+	}
+}

--- a/api/client.py
+++ b/api/client.py
@@ -1,17 +1,18 @@
 import asyncio
 import sys
+from typing import Any, Dict, List, Optional
 
-from loguru import logger
-from aiohttp import ClientSession, BasicAuth
 from aiobotocore.session import get_session
+from aiohttp import BasicAuth, ClientSession, FormData
+from loguru import logger
 from pydantic_settings import BaseSettings
 
 
 class Settings(BaseSettings):
-    base_api_url: str = "http://localhost:8000"
+    base_api_url: str = "https://s3aas-api.dev.nachert.art"
     gdrive_key: str  # Секретный ключ для Google Drive
-    username: str = "testuser"
-    bucket_key: str = "test-bucket"
+    username: str = "testuser4"
+    bucket_key: str = "test-bucket2"
 
     @property
     def user_endpoint(self) -> str:
@@ -23,37 +24,62 @@ class Settings(BaseSettings):
 
     @property
     def s3_endpoint(self) -> str:
-        return f"{self.base_api_url}/api/v1/s3"
+        return f"{self.base_api_url}/api/s3"
 
     @property
     def gdrive_endpoint(self) -> str:
         return f"{self.base_api_url}/api/v1/sources/gdrive"
 
+    def bucket_upload_endpoint(self, bucket_id: str) -> str:
+        return f"{self.base_api_url}/api/v1/buckets/{bucket_id}/upload"
+
 
 async def create_user(session: ClientSession, settings: Settings) -> dict:
-    async with session.post(settings.user_endpoint, json={"username": settings.username}) as resp:
+    async with session.post(settings.user_endpoint, json={"username": settings.username}, ssl=False) as resp:
         data = await resp.json()
         logger.info("User created: {}", data)
-        return data["data"]
+        return data
 
 
 async def create_bucket(session: ClientSession, auth: BasicAuth, settings: Settings) -> dict:
+    # 1) создаём бакет
     async with session.post(
-        settings.bucket_endpoint, json={"key": settings.bucket_key}, auth=auth
+        settings.bucket_endpoint,
+        json={"key": settings.bucket_key},
+        auth=auth,
+        ssl=False,
     ) as resp:
-        data = await resp.json()
-        logger.info("Bucket created: {}", data)
-        return data["data"]
+        created = await resp.json()
+
+    # 2) получаем список бакетов и находим id по key
+    async with session.get(settings.bucket_endpoint, auth=auth, ssl=False) as resp:
+        buckets: List[Dict[str, Any]] = await resp.json()
+
+    matched: Optional[Dict[str, Any]] = next(
+        (b for b in buckets if b.get("key") == settings.bucket_key),
+        None,
+    )
+    if not matched or not matched.get("id"):
+        raise Exception(f"Created bucket not found in list by key={settings.bucket_key}")
+
+    # 3) возвращаем данные создания + id
+    result = dict[Any, Any](created)
+    result["id"] = matched["id"]
+    result.setdefault("key", matched.get("key"))
+    result.setdefault("created_at", matched.get("created_at"))
+
+    logger.info("Bucket created: {}", result)
+    return result
 
 
 async def add_gdrive_source(
     session: ClientSession, auth: BasicAuth, settings: Settings, name: str = "Test GDrive Source"
 ) -> dict:
     payload = {"key": settings.gdrive_key, "name": name}
-    async with session.post(settings.gdrive_endpoint, json=payload, auth=auth) as resp:
+    async with session.post(settings.gdrive_endpoint, json=payload, auth=auth, ssl=False) as resp:
         data = await resp.json()
         logger.info("GDrive source added")
-        return data["data"]
+        return data
 
 
 async def upload_file_s3(client, bucket_key: str, file_key: str, content: bytes) -> None:
@@ -66,6 +92,34 @@ async def download_file_s3(client, bucket_key: str, file_key: str) -> bytes:
     content = await response["Body"].read()
     logger.info("Downloaded file from S3")
     return content
+
+
+async def upload_file_http(
+    session: ClientSession,
+    auth: BasicAuth,
+    settings: Settings,
+    bucket_id: str,
+    file_name: str,
+    content: bytes,
+    field_name: str = "file",
+) -> dict:
+    form = FormData()
+    form.add_field(
+        name=field_name,
+        value=content,
+        filename=file_name,
+        content_type="application/octet-stream",
+    )
+
+    async with session.post(
+        settings.bucket_upload_endpoint(bucket_id),
+        data=form,
+        auth=auth,
+        ssl=False,
+    ) as resp:
+        data = await resp.json()
+        logger.info("Uploaded file via HTTP: {}", data)
+        return data
 
 
 async def run_e2e_test(settings: Settings) -> None:
@@ -85,10 +139,24 @@ async def run_e2e_test(settings: Settings) -> None:
         if "access_key" not in bucket_data or "access_secret" not in bucket_data:
             raise Exception("Bucket credentials missing")
 
+        bucket_id = bucket_data.get("id")
+        if not bucket_id:
+            raise Exception("Bucket id missing")
+
         # Шаг 3: Добавление Google Drive Source
         await add_gdrive_source(http_session, auth, settings)
 
-        # Шаг 4: Загрузка и скачивание файла через S3
+        # Шаг 4: Загрузка файла через HTTP (НОВАЯ РУЧКА)
+        await upload_file_http(
+            session=http_session,
+            auth=auth,
+            settings=settings,
+            bucket_id=bucket_id,
+            file_name=test_file_key,
+            content=test_file_content,
+        )
+
+        # Шаг 5: Скачивание файла через S3-like как и было
         s3_session = get_session()
         async with s3_session.create_client(
             "s3",
@@ -98,15 +166,14 @@ async def run_e2e_test(settings: Settings) -> None:
             aws_access_key_id=bucket_data["access_key"],
             verify=False,
         ) as s3_client:
-            await upload_file_s3(
+            downloaded_content = await download_file_s3(
                 s3_client,
                 bucket_data.get("key", settings.bucket_key),
                 test_file_key,
-                test_file_content,
             )
-            downloaded_content = await download_file_s3(
-                s3_client, bucket_data.get("key", settings.bucket_key), test_file_key
-            )
+            with open(f"downloaded-{test_file_key}", "wb") as f:
+                f.write(downloaded_content)
+
             if downloaded_content != test_file_content:
                 raise Exception("File content mismatch")
 


### PR DESCRIPTION
## Summary
- move chunk streaming to shared manager
- reuse manager in bucket download and S3 handlers
- serve S3 object retrieval under `/api/s3`
- restore Swagger metadata and Basic Auth

## Testing
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bc35ec153c8324a302592bb415c763