### PR TITLE
Add scalable e2e tests for api-go and run them in Woodpecker

### DIFF
--- a/.woodpecker/api-go.yml
+++ b/.woodpecker/api-go.yml
@@ -4,6 +4,17 @@ when:
       include: [ '.woodpecker/api-go.yml', 'api-go/**' ]
 
 steps:
+  - name: e2e tests
+    image: docker:27-cli
+    environment:
+      DOCKER_HOST: tcp://docker:2375
+      E2E_GDRIVE_KEY:
+        from_secret: E2E_GDRIVE_KEY
+    commands:
+      - cd api-go
+      - docker compose -f docker-compose.e2e.yml up --build --abort-on-container-exit --exit-code-from e2e-tests
+      - docker compose -f docker-compose.e2e.yml down -v
+
   - name: build and push
     image: woodpeckerci/plugin-docker-buildx
     settings:
@@ -15,3 +26,11 @@ steps:
       context: api-go
       dockerfile: api-go/Dockerfile
       tag: main
+
+services:
+  - name: docker
+    image: docker:27-dind
+    privileged: true
+    command:
+      - --host=tcp://0.0.0.0:2375
+      - --tls=false

--- a/.woodpecker/api-go.yml
+++ b/.woodpecker/api-go.yml
@@ -17,6 +17,7 @@ steps:
     image: docker:27-cli
     environment:
       DOCKER_HOST: tcp://docker:2375
+      DOCKER_TLS_CERTDIR: ""
       E2E_GDRIVE_KEY:
         from_secret: E2E_GDRIVE_KEY
     commands:
@@ -43,6 +44,8 @@ services:
   - name: docker
     image: docker:27-dind
     privileged: true
+    environment:
+      DOCKER_TLS_CERTDIR: ""
     command:
       - --host=tcp://0.0.0.0:2375
       - --tls=false

--- a/.woodpecker/api-go.yml
+++ b/.woodpecker/api-go.yml
@@ -21,6 +21,9 @@ steps:
       E2E_GDRIVE_KEY:
         from_secret: E2E_GDRIVE_KEY
     commands:
+      - echo "Waiting for Docker daemon..."
+      - for i in $(seq 1 60); do docker info >/dev/null 2>&1 && break; echo "still waiting ($i)"; sleep 1; done
+      - docker info
       - cd api-go
       - docker compose -f docker-compose.e2e.yml up --build --abort-on-container-exit --exit-code-from e2e-tests
       - docker compose -f docker-compose.e2e.yml down -v

--- a/.woodpecker/api-go.yml
+++ b/.woodpecker/api-go.yml
@@ -1,7 +1,16 @@
 when:
-  - event: push
+  - event: pull_request
     path:
-      include: [ '.woodpecker/api-go.yml', 'api-go/**' ]
+      include:
+        - .woodpecker/api-go.yml
+        - api-go/**
+
+  - event: push
+    branch: main
+    path:
+      include:
+        - .woodpecker/api-go.yml
+        - api-go/**
 
 steps:
   - name: e2e tests
@@ -17,6 +26,9 @@ steps:
 
   - name: build and push
     image: woodpeckerci/plugin-docker-buildx
+    when:
+      - event: push
+        branch: main
     settings:
       repo: ghcr.io/siberianbearofficial/s3aas-api-go
       registry: ghcr.io

--- a/api-go/Makefile
+++ b/api-go/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build run test test-unit test-integration test-e2e lint docker-build
+.PHONY: build run test test-unit test-integration test-e2e lint docker-build test-e2e-local test-e2e-python
 
 build:
 	go build -o bin/server ./cmd/server
@@ -22,8 +22,12 @@ test-e2e:
 	ENV=test go test -tags=e2e ./...
 
 
-simple-test-e2e:
-	cd ../api && venv/bin/python client.py
+test-e2e-python:
+	cd .. && python3 -m venv .venv-e2e && . .venv-e2e/bin/activate && pip install -r api-go/e2e/requirements.txt && PYTHONPATH=api-go pytest -q api-go/e2e/test_api_e2e.py
+
+
+test-e2e-local:
+	docker compose -f docker-compose.e2e.yml up --build --abort-on-container-exit --exit-code-from e2e-tests
 
 
 lint:

--- a/api-go/Makefile
+++ b/api-go/Makefile
@@ -23,7 +23,9 @@ test-e2e:
 
 
 test-e2e-python:
-	cd .. && python3 -m venv .venv-e2e && . .venv-e2e/bin/activate && pip install -r api-go/e2e/requirements.txt && PYTHONPATH=api-go pytest -q api-go/e2e/test_api_e2e.py
+	cd .. && python3 -m venv .venv-e2e && . .venv-e2e/bin/activate && \
+	pip install -r api-go/e2e/requirements.txt && \
+	cd api-go/e2e && PYTHONPATH=.. pytest -q test_api_e2e.py
 
 
 test-e2e-local:

--- a/api-go/docker-compose.e2e.yml
+++ b/api-go/docker-compose.e2e.yml
@@ -1,0 +1,28 @@
+services:
+  mongo:
+    image: mongo:7
+    environment:
+      - MONGO_INITDB_ROOT_USERNAME=root
+      - MONGO_INITDB_ROOT_PASSWORD=example
+
+  api-go:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      - ENV=test
+      - GIN_MODE=release
+    depends_on:
+      - mongo
+    ports:
+      - "8080:8080"
+
+  e2e-tests:
+    build:
+      context: .
+      dockerfile: e2e/Dockerfile
+    environment:
+      - E2E_BASE_API_URL=http://api-go:8080
+      - E2E_GDRIVE_KEY=${E2E_GDRIVE_KEY}
+    depends_on:
+      - api-go

--- a/api-go/e2e/Dockerfile
+++ b/api-go/e2e/Dockerfile
@@ -4,5 +4,6 @@ WORKDIR /work
 COPY e2e/requirements.txt /tmp/requirements.txt
 RUN pip install --no-cache-dir -r /tmp/requirements.txt
 COPY e2e /work/e2e
+COPY e2e/pytest.ini /work
 ENV PYTHONPATH=/work
 CMD ["pytest", "-q", "e2e/test_api_e2e.py"]

--- a/api-go/e2e/Dockerfile
+++ b/api-go/e2e/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.12-slim
+
+WORKDIR /work
+COPY e2e/requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
+COPY e2e /work/e2e
+ENV PYTHONPATH=/work
+CMD ["pytest", "-q", "e2e/test_api_e2e.py"]

--- a/api-go/e2e/README.md
+++ b/api-go/e2e/README.md
@@ -1,0 +1,46 @@
+# API Go E2E
+
+E2E-тесты проверяют HTTP и S3-эндпоинты `api-go` через реальный клиент на `aiobotocore`.
+
+## Что покрывается
+
+- `POST /api/v1/users`
+- `POST /api/v1/buckets`
+- `GET /api/v1/buckets`
+- `DELETE /api/v1/buckets/:id`
+- `POST /api/v1/sources/gdrive`
+- `GET /api/v1/sources`
+- `GET /api/v1/sources/:id/info`
+- `DELETE /api/v1/sources/:id`
+- `POST /api/v1/buckets/:id/upload`
+- `GET /api/v1/buckets/:id/files`
+- `GET /api/v1/buckets/:id/files/:file_id/download`
+- `DELETE /api/v1/buckets/:id/files/:file_id`
+- `GET /api/s3/:bucket/*object`
+
+## Локальный запуск
+
+```bash
+cd api-go
+export E2E_GDRIVE_KEY='<json_service_account_or_token>'
+make test-e2e-local
+```
+
+## Запуск без Docker Compose
+
+```bash
+cd api-go
+export E2E_BASE_API_URL='http://localhost:8080'
+export E2E_GDRIVE_KEY='<json_service_account_or_token>'
+make test-e2e-python
+```
+
+## CI (Woodpecker)
+
+Pipeline `.woodpecker/api-go.yml` запускает `docker-compose.e2e.yml` через DinD.
+
+Нужно добавить секрет:
+
+- `E2E_GDRIVE_KEY` — ключ для Google Drive source.
+
+Нужно убедиться, что у агента разрешены privileged service-контейнеры (для `docker:dind`).

--- a/api-go/e2e/conftest.py
+++ b/api-go/e2e/conftest.py
@@ -1,0 +1,25 @@
+import os
+
+import pytest
+import pytest_asyncio
+
+from e2e.s3aas_client import E2EConfig, S3AASClient
+
+
+@pytest.fixture(scope="session")
+def e2e_config() -> E2EConfig:
+    base_api_url = os.getenv("E2E_BASE_API_URL", "http://localhost:8080")
+    gdrive_key = os.getenv("E2E_GDRIVE_KEY", "")
+    if not gdrive_key:
+        raise RuntimeError("E2E_GDRIVE_KEY is required for e2e tests")
+    return E2EConfig(base_api_url=base_api_url.rstrip("/"), gdrive_key=gdrive_key)
+
+
+@pytest_asyncio.fixture
+async def client(e2e_config: E2EConfig) -> S3AASClient:
+    client = S3AASClient(e2e_config)
+    await client.wait_ready()
+    try:
+        yield client
+    finally:
+        await client.close()

--- a/api-go/e2e/pytest.ini
+++ b/api-go/e2e/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+asyncio_mode = auto
+asyncio_default_fixture_loop_scope = function

--- a/api-go/e2e/requirements.txt
+++ b/api-go/e2e/requirements.txt
@@ -1,0 +1,4 @@
+aiohttp==3.11.14
+aiobotocore==2.21.1
+pytest==8.3.5
+pytest-asyncio==0.25.3

--- a/api-go/e2e/s3aas_client.py
+++ b/api-go/e2e/s3aas_client.py
@@ -1,0 +1,119 @@
+import asyncio
+from dataclasses import dataclass
+from typing import Any
+
+from aiobotocore.session import get_session
+from aiohttp import BasicAuth, ClientSession, FormData
+
+
+@dataclass(slots=True)
+class E2EConfig:
+    base_api_url: str
+    gdrive_key: str
+
+    @property
+    def users_url(self) -> str:
+        return f"{self.base_api_url}/api/v1/users"
+
+    @property
+    def buckets_url(self) -> str:
+        return f"{self.base_api_url}/api/v1/buckets"
+
+    @property
+    def sources_url(self) -> str:
+        return f"{self.base_api_url}/api/v1/sources"
+
+    @property
+    def gdrive_sources_url(self) -> str:
+        return f"{self.sources_url}/gdrive"
+
+    @property
+    def s3_url(self) -> str:
+        return f"{self.base_api_url}/api/s3"
+
+
+class S3AASClient:
+    def __init__(self, config: E2EConfig) -> None:
+        self.config = config
+        self._http = ClientSession(raise_for_status=True)
+
+    async def close(self) -> None:
+        await self._http.close()
+
+    async def wait_ready(self, timeout_s: int = 60) -> None:
+        deadline = asyncio.get_event_loop().time() + timeout_s
+        last_err: Exception | None = None
+        while asyncio.get_event_loop().time() < deadline:
+            try:
+                async with self._http.get(f"{self.config.base_api_url}/readyz") as response:
+                    if response.status == 200:
+                        return
+            except Exception as exc:  # noqa: BLE001
+                last_err = exc
+            await asyncio.sleep(1)
+        if last_err is not None:
+            raise TimeoutError("API is not ready") from last_err
+        raise TimeoutError("API is not ready")
+
+    async def create_user(self, username: str) -> dict[str, Any]:
+        async with self._http.post(self.config.users_url, json={"username": username}) as response:
+            return await response.json()
+
+    async def create_bucket(self, auth: BasicAuth, key: str) -> dict[str, Any]:
+        async with self._http.post(self.config.buckets_url, auth=auth, json={"key": key}) as response:
+            return await response.json()
+
+    async def list_buckets(self, auth: BasicAuth) -> list[dict[str, Any]]:
+        async with self._http.get(self.config.buckets_url, auth=auth) as response:
+            return await response.json()
+
+    async def delete_bucket(self, auth: BasicAuth, bucket_id: str) -> None:
+        async with self._http.delete(f"{self.config.buckets_url}/{bucket_id}", auth=auth):
+            return
+
+    async def create_gdrive_source(self, auth: BasicAuth, name: str) -> dict[str, Any]:
+        payload = {"name": name, "key": self.config.gdrive_key}
+        async with self._http.post(self.config.gdrive_sources_url, auth=auth, json=payload) as response:
+            return await response.json()
+
+    async def list_sources(self, auth: BasicAuth) -> list[dict[str, Any]]:
+        async with self._http.get(self.config.sources_url, auth=auth) as response:
+            return await response.json()
+
+    async def get_source_info(self, auth: BasicAuth, source_id: str) -> dict[str, Any]:
+        async with self._http.get(f"{self.config.sources_url}/{source_id}/info", auth=auth) as response:
+            return await response.json()
+
+    async def delete_source(self, auth: BasicAuth, source_id: str) -> None:
+        async with self._http.delete(f"{self.config.sources_url}/{source_id}", auth=auth):
+            return
+
+    async def upload_file_http(self, auth: BasicAuth, bucket_id: str, filename: str, content: bytes) -> dict[str, Any]:
+        form = FormData()
+        form.add_field("file", content, filename=filename, content_type="application/octet-stream")
+        async with self._http.post(f"{self.config.buckets_url}/{bucket_id}/upload", auth=auth, data=form) as response:
+            return await response.json()
+
+    async def list_files(self, auth: BasicAuth, bucket_id: str) -> list[dict[str, Any]]:
+        async with self._http.get(f"{self.config.buckets_url}/{bucket_id}/files", auth=auth) as response:
+            return await response.json()
+
+    async def download_file_http(self, auth: BasicAuth, bucket_id: str, file_id: str) -> bytes:
+        async with self._http.get(f"{self.config.buckets_url}/{bucket_id}/files/{file_id}/download", auth=auth) as response:
+            return await response.read()
+
+    async def delete_file(self, auth: BasicAuth, bucket_id: str, file_id: str) -> None:
+        async with self._http.delete(f"{self.config.buckets_url}/{bucket_id}/files/{file_id}", auth=auth):
+            return
+
+    async def download_file_s3(self, access_key: str, access_secret: str, bucket_key: str, object_key: str) -> bytes:
+        session = get_session()
+        async with session.create_client(
+            "s3",
+            region_name="us-east-1",
+            endpoint_url=self.config.s3_url,
+            aws_access_key_id=access_key,
+            aws_secret_access_key=access_secret,
+        ) as s3_client:
+            response = await s3_client.get_object(Bucket=bucket_key, Key=object_key)
+            return await response["Body"].read()

--- a/api-go/e2e/test_api_e2e.py
+++ b/api-go/e2e/test_api_e2e.py
@@ -1,0 +1,62 @@
+from uuid import uuid4
+
+from aiohttp import BasicAuth
+
+
+async def test_http_and_s3_endpoints(client):
+    username = f"e2e-user-{uuid4().hex[:10]}"
+    bucket_key = f"e2e-bucket-{uuid4().hex[:10]}"
+    source_name = f"e2e-source-{uuid4().hex[:10]}"
+    filename = f"e2e-object-{uuid4().hex[:8]}.txt"
+    payload = b"s3aas e2e payload"
+
+    user = await client.create_user(username)
+    assert user["id"]
+    assert user["password"]
+    auth = BasicAuth(login=username, password=user["password"])
+
+    bucket = await client.create_bucket(auth=auth, key=bucket_key)
+    assert bucket["key"] == bucket_key
+    assert bucket["access_key"]
+    assert bucket["access_secret"]
+
+    buckets = await client.list_buckets(auth)
+    bucket_from_list = next(item for item in buckets if item["key"] == bucket_key)
+    bucket_id = bucket_from_list["id"]
+
+    source = await client.create_gdrive_source(auth, source_name)
+    assert source["name"] == source_name
+    source_id = source["id"]
+
+    sources = await client.list_sources(auth)
+    assert any(item["id"] == source_id for item in sources)
+
+    source_info = await client.get_source_info(auth, source_id)
+    assert source_info["id"] == source_id
+    assert source_info["type"] == "gdrive"
+
+    uploaded = await client.upload_file_http(auth, bucket_id, filename, payload)
+    file_id = uploaded["id"]
+
+    files = await client.list_files(auth, bucket_id)
+    assert any(item["id"] == file_id and item["name"] == filename for item in files)
+
+    downloaded_http = await client.download_file_http(auth, bucket_id, file_id)
+    assert downloaded_http == payload
+
+    downloaded_s3 = await client.download_file_s3(
+        access_key=bucket["access_key"],
+        access_secret=bucket["access_secret"],
+        bucket_key=bucket_key,
+        object_key=filename,
+    )
+    assert downloaded_s3 == payload
+
+    await client.delete_file(auth, bucket_id, file_id)
+    assert not await client.list_files(auth, bucket_id)
+
+    await client.delete_source(auth, source_id)
+    assert not await client.list_sources(auth)
+
+    await client.delete_bucket(auth, bucket_id)
+    assert not await client.list_buckets(auth)

--- a/api-go/pytest.ini
+++ b/api-go/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+asyncio_mode = auto
+asyncio_default_fixture_loop_scope = function

--- a/api-go/pytest.ini
+++ b/api-go/pytest.ini
@@ -1,3 +1,0 @@
-[pytest]
-asyncio_mode = auto
-asyncio_default_fixture_loop_scope = function


### PR DESCRIPTION
### Motivation
- Добавить надёжный e2e-контур, который покрывает HTTP- и S3-эндпоинты `api-go` через реальный клиент на `aiobotocore` и можно запускать в CI и локально.
- Обеспечить удобную основу для будущего расширения тестов (переиспользуемый async-клиент, фикстуры и compose-сценарий).

### Description
- Добавлен Python e2e-пакет в `api-go/e2e` с реиспользуемым async-клиентом `S3AASClient` (`aiohttp` + `aiobotocore`) в `e2e/s3aas_client.py` и тестом `e2e/test_api_e2e.py` для полного сценария (users, buckets, sources, upload/list/download/delete, S3 `GetObject`).
- Добавлены инфраструктурные файлы: `api-go/e2e/requirements.txt`, `api-go/e2e/Dockerfile`, `api-go/pytest.ini` и `api-go/e2e/README.md` с инструкциями по локальному и CI запуску.
- Добавлен `docker-compose.e2e.yml` для запуска Mongo + api-go + e2e-runner, и обновлён `api-go/Makefile` с целями `test-e2e-local` и `test-e2e-python` для удобного запуска локально и в CI.
- Обновлён CI-конфиг `.woodpecker/api-go.yml` для запуска e2e перед сборкой образа через DinD и передачи секрета `E2E_GDRIVE_KEY`, добавлен сервис `docker:27-dind`.

### Testing
- Ran `cd api-go && go test ./...`, which passed for the module packages that include tests.
- Ran `cd api-go && golangci-lint run`, which failed on a pre-existing `staticcheck` issue in `internal/s3sigv4/validator.go` and is unrelated to the e2e additions.
- Attempted `cd api-go && . .venv-e2e/bin/activate && PYTHONPATH=. pytest -q e2e/test_api_e2e.py`, which correctly errored because the required environment variable `E2E_GDRIVE_KEY` was not set.
- Attempted local compose run via `make test-e2e-local`, which could not run in this environment because Docker is unavailable (`make: docker: No such file or directory`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989fe3b42848324bb2c93d2dc437ef7)