### PR TITLE
S3-compatible object listing

### DIFF
--- a/api-go/e2e/s3aas_client.py
+++ b/api-go/e2e/s3aas_client.py
@@ -128,3 +128,15 @@ class S3AASClient:
         ) as s3_client:
             response = await s3_client.get_object(Bucket=bucket_key, Key=object_key)
             return await response["Body"].read()
+
+    async def list_objects_s3(self, access_key: str, access_secret: str, bucket_key: str) -> list[dict[str, Any]]:
+        session = get_session()
+        async with session.create_client(
+            "s3",
+            region_name="us-east-1",
+            endpoint_url=self.config.s3_url,
+            aws_access_key_id=access_key,
+            aws_secret_access_key=access_secret,
+        ) as s3_client:
+            response = await s3_client.list_objects_v2(Bucket=bucket_key)
+            return response.get("Contents", [])

--- a/api-go/e2e/test_api_e2e.py
+++ b/api-go/e2e/test_api_e2e.py
@@ -81,3 +81,35 @@ async def test_http_upload_works(client, e2e_context):
     uploaded = await client.upload_file_http(e2e_context.auth, e2e_context.bucket_id, filename, payload)
     downloaded = await client.download_file_http(e2e_context.auth, e2e_context.bucket_id, uploaded["id"])
     assert downloaded == payload
+
+
+async def test_s3_list_objects_v2_returns_uploaded_files(client, e2e_context):
+    name_1 = f"e2e-list-{uuid4().hex[:8]}-1.txt"
+    name_2 = f"e2e-list-{uuid4().hex[:8]}-2.txt"
+
+    await client.upload_file_s3(
+        access_key=e2e_context.access_key,
+        access_secret=e2e_context.access_secret,
+        bucket_key=e2e_context.bucket_key,
+        object_key=name_1,
+        content=b"one",
+    )
+    await client.upload_file_s3(
+        access_key=e2e_context.access_key,
+        access_secret=e2e_context.access_secret,
+        bucket_key=e2e_context.bucket_key,
+        object_key=name_2,
+        content=b"two-two",
+    )
+
+    objects = await client.list_objects_s3(
+        access_key=e2e_context.access_key,
+        access_secret=e2e_context.access_secret,
+        bucket_key=e2e_context.bucket_key,
+    )
+
+    by_key = {item["Key"]: item for item in objects}
+    assert name_1 in by_key
+    assert name_2 in by_key
+    assert by_key[name_1]["Size"] == 3
+    assert by_key[name_2]["Size"] == 7

--- a/api-go/e2e/test_api_e2e.py
+++ b/api-go/e2e/test_api_e2e.py
@@ -49,6 +49,13 @@ async def test_s3_put_overwrites_existing_object(client, e2e_context):
         object_key=filename,
         content=payload_v1,
     )
+    first_list = await client.list_objects_s3(
+        access_key=e2e_context.access_key,
+        access_secret=e2e_context.access_secret,
+        bucket_key=e2e_context.bucket_key,
+    )
+    etag_before = next(item for item in first_list if item["Key"] == filename)["ETag"]
+
     await client.upload_file_s3(
         access_key=e2e_context.access_key,
         access_secret=e2e_context.access_secret,
@@ -56,6 +63,13 @@ async def test_s3_put_overwrites_existing_object(client, e2e_context):
         object_key=filename,
         content=payload_v2,
     )
+    second_list = await client.list_objects_s3(
+        access_key=e2e_context.access_key,
+        access_secret=e2e_context.access_secret,
+        bucket_key=e2e_context.bucket_key,
+    )
+    etag_after = next(item for item in second_list if item["Key"] == filename)["ETag"]
+    assert etag_after != etag_before
 
     files = await client.list_files(e2e_context.auth, e2e_context.bucket_id)
     matched = [item for item in files if item["name"] == filename]

--- a/api-go/internal/app/router.go
+++ b/api-go/internal/app/router.go
@@ -82,6 +82,7 @@ func SetupRouter(m *db.Mongo, cfg *config.Config) *gin.Engine {
 			chunkSize = cfg.Upload.ChunkSize
 		}
 		router.GET("/api/s3/:bucket/*object", handlers.AWS4Auth(bucketRepo, secretKey), handlers.GetObject(bucketRepo, sourceRepo, fileRepo))
+		router.GET("/api/s3/:bucket", handlers.AWS4Auth(bucketRepo, secretKey), handlers.ListObjects(bucketRepo, fileRepo))
 		router.PUT("/api/s3/:bucket/*object", handlers.AWS4Auth(bucketRepo, secretKey), handlers.PutObject(bucketRepo, sourceRepo, fileRepo, chunkSize))
 	}
 	return router

--- a/api-go/internal/docs/docs.go
+++ b/api-go/internal/docs/docs.go
@@ -15,6 +15,46 @@ const docTemplate = `{
     "host": "{{.Host}}",
     "basePath": "{{.BasePath}}",
     "paths": {
+        "/api/s3/{bucket}": {
+            "get": {
+                "produces": [
+                    "text/xml"
+                ],
+                "tags": [
+                    "s3"
+                ],
+                "summary": "List objects",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Bucket key",
+                        "name": "bucket",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/api/s3/{bucket}/{object}": {
             "get": {
                 "produces": [

--- a/api-go/internal/handlers/s3.go
+++ b/api-go/internal/handlers/s3.go
@@ -1,6 +1,8 @@
 package handlers
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/xml"
 	"log"
 	"net/http"
@@ -42,6 +44,20 @@ type listBucketEntry struct {
 
 func writeS3Error(c *gin.Context, status int, code, message string) {
 	c.XML(status, s3Error{Code: code, Message: message})
+}
+
+func objectETag(file repository.File) string {
+	h := sha256.New()
+	_, _ = h.Write([]byte(file.Name))
+	_, _ = h.Write([]byte(file.CreatedAt.UTC().Format(time.RFC3339Nano)))
+	for _, chunk := range file.Chunks {
+		_, _ = h.Write([]byte(chunk.SourceID.Hex()))
+		_, _ = h.Write([]byte(chunk.Name))
+		_, _ = h.Write([]byte(strconv.Itoa(chunk.Order)))
+		_, _ = h.Write([]byte(":"))
+		_, _ = h.Write([]byte(strconv.FormatInt(chunk.Size, 10)))
+	}
+	return "\"" + hex.EncodeToString(h.Sum(nil)) + "\""
 }
 
 // ListObjects godoc
@@ -91,7 +107,7 @@ func ListObjects(bucketRepo *repository.BucketRepository, fileRepo *repository.F
 			entries = append(entries, listBucketEntry{
 				Key:          file.Name,
 				LastModified: file.CreatedAt.UTC().Format(time.RFC3339),
-				ETag:         "\"" + file.ID.Hex() + "\"",
+				ETag:         objectETag(file),
 				Size:         size,
 				StorageClass: "STANDARD",
 			})

--- a/api-go/internal/handlers/s3.go
+++ b/api-go/internal/handlers/s3.go
@@ -20,8 +20,93 @@ type s3Error struct {
 	Message string   `xml:"Message"`
 }
 
+type listBucketResult struct {
+	XMLName      xml.Name          `xml:"ListBucketResult"`
+	Xmlns        string            `xml:"xmlns,attr"`
+	Name         string            `xml:"Name"`
+	Prefix       string            `xml:"Prefix"`
+	MaxKeys      int               `xml:"MaxKeys"`
+	IsTruncated  bool              `xml:"IsTruncated"`
+	Contents     []listBucketEntry `xml:"Contents"`
+	KeyCount     int               `xml:"KeyCount"`
+	Continuation string            `xml:"ContinuationToken,omitempty"`
+}
+
+type listBucketEntry struct {
+	Key          string `xml:"Key"`
+	LastModified string `xml:"LastModified"`
+	ETag         string `xml:"ETag"`
+	Size         int64  `xml:"Size"`
+	StorageClass string `xml:"StorageClass"`
+}
+
 func writeS3Error(c *gin.Context, status int, code, message string) {
 	c.XML(status, s3Error{Code: code, Message: message})
+}
+
+// ListObjects godoc
+// @Summary List objects
+// @Tags s3
+// @Produce xml
+// @Param bucket path string true "Bucket key"
+// @Success 200 {string} string ""
+// @Failure 404 {string} string ""
+// @Failure 500 {string} string ""
+// @Router /api/s3/{bucket} [get]
+func ListObjects(bucketRepo *repository.BucketRepository, fileRepo *repository.FileRepository) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if bucketRepo == nil || fileRepo == nil {
+			c.Status(http.StatusServiceUnavailable)
+			return
+		}
+		bucketKey := c.Param("bucket")
+		ctx := c.Request.Context()
+		bucketDoc, err := bucketRepo.GetByKey(ctx, bucketKey)
+		if err != nil {
+			if err == mongo.ErrNoDocuments {
+				writeS3Error(c, http.StatusNotFound, "NoSuchBucket", "")
+				return
+			}
+			log.Printf("list objects: get bucket: %v", err)
+			writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
+			return
+		}
+		accessKey := c.GetString("accessKey")
+		if accessKey == "" || bucketDoc.AccessKey != accessKey {
+			writeS3Error(c, http.StatusNotFound, "NoSuchBucket", "")
+			return
+		}
+		files, err := fileRepo.ListByBucket(ctx, bucketDoc.ID)
+		if err != nil {
+			log.Printf("list objects: list files: %v", err)
+			writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
+			return
+		}
+		entries := make([]listBucketEntry, 0, len(files))
+		for _, file := range files {
+			var size int64
+			for _, chunk := range file.Chunks {
+				size += chunk.Size
+			}
+			entries = append(entries, listBucketEntry{
+				Key:          file.Name,
+				LastModified: file.CreatedAt.UTC().Format(time.RFC3339),
+				ETag:         "\"" + file.ID.Hex() + "\"",
+				Size:         size,
+				StorageClass: "STANDARD",
+			})
+		}
+		result := listBucketResult{
+			Xmlns:       "http://s3.amazonaws.com/doc/2006-03-01/",
+			Name:        bucketKey,
+			Prefix:      "",
+			MaxKeys:     1000,
+			IsTruncated: false,
+			Contents:    entries,
+			KeyCount:    len(entries),
+		}
+		c.XML(http.StatusOK, result)
+	}
 }
 
 // GetObject godoc


### PR DESCRIPTION
### Motivation
- Provide an S3-compatible object listing endpoint so clients can list bucket contents via the S3 API.
- Expose object metadata (key, size, ETag, last modified, storage class) derived from stored file chunks for compatibility with S3 clients.

### Description
- Implemented `ListObjects` handler that returns an S3-style `ListBucketResult` XML response and validates bucket/access key before listing files (`internal/handlers/s3.go`).
- Computed object metadata (`Key`, `LastModified`, `ETag`, `Size`, `StorageClass`, `KeyCount`) from repository `File` records and their chunks and wired handler into router at `GET /api/s3/:bucket` (`internal/app/router.go`).
- Regenerated Swagger docs (`internal/docs/docs.go`) to include the new endpoint and added a Python e2e client helper `list_objects_s3` that calls `list_objects_v2` (`e2e/s3aas_client.py`).
- Added an e2e test which uploads two objects via S3 and asserts they appear in `list_objects_v2` results with expected sizes (`e2e/test_api_e2e.py`).

### Testing
- Ran `go test ./...` and unit tests completed successfully.
- Compiled e2e Python code with `python3 -m compileall e2e` and it succeeded.
- Ran `golangci-lint run` which reported a pre-existing `staticcheck` warning in `internal/s3sigv4/validator.go` unrelated to these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b4c241a248324a18abf09f9730673)