### PR TITLE
Restrict bucket uploads to explicitly selected sources

### DIFF
--- a/api-go/go.mod
+++ b/api-go/go.mod
@@ -1,6 +1,6 @@
 module github.com/example/s3aas/api-go
 
-go 1.24.3
+go 1.24.0
 
 require (
 	github.com/gin-contrib/cors v1.5.0

--- a/api-go/internal/app/router.go
+++ b/api-go/internal/app/router.go
@@ -48,7 +48,7 @@ func SetupRouter(m *db.Mongo, cfg *config.Config) *gin.Engine {
 		if cfg != nil {
 			secretKey = cfg.AccessSecretKey
 		}
-		router.POST("/api/v1/buckets", auth, handlers.CreateBucket(bucketRepo, secretKey))
+		router.POST("/api/v1/buckets", auth, handlers.CreateBucket(bucketRepo, sourceRepo, secretKey))
 		router.GET("/api/v1/buckets", auth, handlers.ListBuckets(bucketRepo))
 		router.DELETE("/api/v1/buckets/:id", auth, handlers.DeleteBucket(bucketRepo))
 		if sourceRepo != nil && fileRepo != nil {

--- a/api-go/internal/docs/docs.go
+++ b/api-go/internal/docs/docs.go
@@ -1055,11 +1055,19 @@ const docTemplate = `{
         "handlers.createBucketRequest": {
             "type": "object",
             "required": [
-                "key"
+                "key",
+                "source_ids"
             ],
             "properties": {
                 "key": {
                     "type": "string"
+                },
+                "source_ids": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "string"
+                    }
                 }
             }
         },

--- a/api-go/internal/handlers/bucket.go
+++ b/api-go/internal/handlers/bucket.go
@@ -16,7 +16,8 @@ import (
 )
 
 type createBucketRequest struct {
-	Key string `json:"key" binding:"required"`
+	Key       string   `json:"key" binding:"required"`
+	SourceIDs []string `json:"source_ids" binding:"required,min=1"`
 }
 
 type createBucketResponse struct {
@@ -52,7 +53,7 @@ type fileResponse struct {
 // @Failure 409 {string} string ""
 // @Security BasicAuth
 // @Router /api/v1/buckets [post]
-func CreateBucket(repo *repository.BucketRepository, secretKey string) gin.HandlerFunc {
+func CreateBucket(repo *repository.BucketRepository, sourceRepo *repository.SourceRepository, secretKey string) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var req createBucketRequest
 		if err := c.ShouldBindJSON(&req); err != nil {
@@ -60,7 +61,7 @@ func CreateBucket(repo *repository.BucketRepository, secretKey string) gin.Handl
 			c.Status(http.StatusBadRequest)
 			return
 		}
-		if repo == nil {
+		if repo == nil || sourceRepo == nil {
 			log.Print("create bucket: repository is nil")
 			c.Status(http.StatusServiceUnavailable)
 			return
@@ -93,11 +94,35 @@ func CreateBucket(repo *repository.BucketRepository, secretKey string) gin.Handl
 			c.Status(http.StatusInternalServerError)
 			return
 		}
+		sourceIDs := make([]primitive.ObjectID, 0, len(req.SourceIDs))
+		for _, sourceIDHex := range req.SourceIDs {
+			sourceID, err := primitive.ObjectIDFromHex(sourceIDHex)
+			if err != nil {
+				c.Status(http.StatusBadRequest)
+				return
+			}
+			sourceDoc, err := sourceRepo.GetByID(c.Request.Context(), sourceID)
+			if err != nil {
+				if err == mongo.ErrNoDocuments {
+					c.Status(http.StatusBadRequest)
+					return
+				}
+				log.Printf("create bucket: get source: %v", err)
+				c.Status(http.StatusInternalServerError)
+				return
+			}
+			if sourceDoc.UserID != userID {
+				c.Status(http.StatusBadRequest)
+				return
+			}
+			sourceIDs = append(sourceIDs, sourceID)
+		}
 		bucket := repository.Bucket{
 			UserID:          userID,
 			Key:             req.Key,
 			AccessKey:       accessKey,
 			AccessSecretEnc: encrypted,
+			SourceIDs:       sourceIDs,
 			CreatedAt:       time.Now().UTC(),
 		}
 		created, err := repo.Create(c.Request.Context(), bucket)
@@ -269,7 +294,7 @@ func UploadFile(bucketRepo *repository.BucketRepository, sourceRepo *repository.
 			c.Status(http.StatusNotFound)
 			return
 		}
-		sources, err := sourceRepo.ListByUser(c.Request.Context(), userID)
+		sources, err := sourceRepo.ListByIDs(c.Request.Context(), bucketDoc.SourceIDs)
 		if err != nil {
 			log.Printf("upload file: list sources: %v", err)
 			c.Status(http.StatusInternalServerError)

--- a/api-go/internal/handlers/bucket_test.go
+++ b/api-go/internal/handlers/bucket_test.go
@@ -33,7 +33,7 @@ func TestCreateBucket(t *testing.T) {
 		t.Fatal(err)
 	}
 	hash, _ := bcrypt.GenerateFromPassword([]byte("pass"), bcrypt.DefaultCost)
-	_, err = userRepo.Create(context.Background(), repository.User{
+	user, err := userRepo.Create(context.Background(), repository.User{
 		Username:     "tester",
 		PasswordHash: string(hash),
 		CreatedAt:    time.Now().UTC(),
@@ -45,10 +45,24 @@ func TestCreateBucket(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	sourceRepo, err := repository.NewSourceRepository(mongoConn.DB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	source, err := sourceRepo.Create(context.Background(), repository.Source{
+		UserID:    user.ID,
+		Type:      repository.SourceTypeGDrive,
+		Name:      "src-test",
+		Key:       "{}",
+		CreatedAt: time.Now().UTC(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
 	router := gin.New()
 	auth := BasicAuth(userRepo)
-	router.POST("/api/v1/buckets", auth, CreateBucket(repo, "testkey"))
-	body, _ := json.Marshal(map[string]string{"key": "bucket-test"})
+	router.POST("/api/v1/buckets", auth, CreateBucket(repo, sourceRepo, "testkey"))
+	body, _ := json.Marshal(map[string]any{"key": "bucket-test", "source_ids": []string{source.ID.Hex()}})
 	req, _ := http.NewRequest(http.MethodPost, "/api/v1/buckets", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	req.SetBasicAuth("tester", "pass")

--- a/api-go/internal/handlers/s3.go
+++ b/api-go/internal/handlers/s3.go
@@ -222,7 +222,7 @@ func PutObject(bucketRepo *repository.BucketRepository, sourceRepo *repository.S
 			writeS3Error(c, http.StatusNotFound, "NoSuchBucket", "")
 			return
 		}
-		sources, err := sourceRepo.ListByUser(ctx, bucketDoc.UserID)
+		sources, err := sourceRepo.ListByIDs(ctx, bucketDoc.SourceIDs)
 		if err != nil {
 			log.Printf("put object: list sources: %v", err)
 			writeS3Error(c, http.StatusInternalServerError, "InternalError", "")

--- a/api-go/internal/repository/bucket.go
+++ b/api-go/internal/repository/bucket.go
@@ -11,12 +11,13 @@ import (
 )
 
 type Bucket struct {
-	ID              primitive.ObjectID `bson:"_id,omitempty"`
-	UserID          primitive.ObjectID `bson:"user_id"`
-	Key             string             `bson:"key"`
-	AccessKey       string             `bson:"access_key"`
-	AccessSecretEnc string             `bson:"access_secret"`
-	CreatedAt       time.Time          `bson:"created_at"`
+	ID              primitive.ObjectID   `bson:"_id,omitempty"`
+	UserID          primitive.ObjectID   `bson:"user_id"`
+	Key             string               `bson:"key"`
+	AccessKey       string               `bson:"access_key"`
+	AccessSecretEnc string               `bson:"access_secret"`
+	SourceIDs       []primitive.ObjectID `bson:"source_ids"`
+	CreatedAt       time.Time            `bson:"created_at"`
 }
 
 type BucketRepository struct {

--- a/api-go/internal/repository/source.go
+++ b/api-go/internal/repository/source.go
@@ -62,6 +62,37 @@ func (r *SourceRepository) GetByID(ctx context.Context, id primitive.ObjectID) (
 	return &s, nil
 }
 
+func (r *SourceRepository) ListByIDs(ctx context.Context, ids []primitive.ObjectID) ([]Source, error) {
+	if len(ids) == 0 {
+		return []Source{}, nil
+	}
+	cursor, err := r.coll.Find(ctx, bson.M{"_id": bson.M{"$in": ids}})
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = cursor.Close(ctx) }()
+	byID := make(map[primitive.ObjectID]Source, len(ids))
+	for cursor.Next(ctx) {
+		var src Source
+		if err := cursor.Decode(&src); err != nil {
+			return nil, err
+		}
+		byID[src.ID] = src
+	}
+	if err := cursor.Err(); err != nil {
+		return nil, err
+	}
+	sources := make([]Source, 0, len(ids))
+	for _, id := range ids {
+		source, ok := byID[id]
+		if !ok {
+			continue
+		}
+		sources = append(sources, source)
+	}
+	return sources, nil
+}
+
 func (r *SourceRepository) ListByUser(ctx context.Context, userID primitive.ObjectID) ([]Source, error) {
 	cursor, err := r.coll.Find(ctx, bson.M{"user_id": userID})
 	if err != nil {


### PR DESCRIPTION
### Motivation
- Currently buckets implicitly used all user sources for uploads; buckets must instead be bound to an explicit list of sources chosen at creation time.  
- The Docker image build in CI was failing during `go mod download` due to automatic toolchain patch resolution, so the module `go` directive was adjusted to avoid that problem.

### Description
- Added `SourceIDs []primitive.ObjectID` to the `Bucket` model so a bucket stores the explicit list of allowed sources (`internal/repository/bucket.go`).
- Changed `CreateBucket` API to accept `source_ids` in the request, validate each `source_id` (format, existence and ownership), and persist the list to the bucket; signature now is `CreateBucket(bucketRepo, sourceRepo, secretKey)` and router wiring updated accordingly (`internal/handlers/bucket.go`, `internal/app/router.go`).
- Added `ListByIDs` to `SourceRepository` which fetches sources by a list of IDs while preserving requested order, and switched upload flows to use `ListByIDs(bucket.SourceIDs)` instead of listing all user sources (`internal/repository/source.go`, `internal/handlers/bucket.go`, `internal/handlers/s3.go`).
- Regenerated Swagger documentation (`internal/docs/docs.go`) to mark `source_ids` as a required field (`minItems: 1`) for the create-bucket request (generated via `swag init` and cleaned up generated `swagger.json`/`swagger.yaml`).
- Adjusted `go` directive in `go.mod` from `1.24.3` to `1.24.0` to avoid toolchain patch auto-downloads during image build environments (`api-go/go.mod`).

### Testing
- Ran `go test ./...` in `api-go` and unit tests passed (packages reported `ok` or `[no test files]`).
- Ran `golangci-lint run` and it returned `0 issues`.
- Ran `go mod download` successfully in the repo to verify dependency resolution after the `go` directive change.
- Regenerated Swagger with `swag init` to update `internal/docs/docs.go` to reflect the API change.
- Attempted `docker build -t api-go:test .` but `docker` is not available in the current environment (so image build could not be validated here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998138fc48c8324952b3668ebbdfb64)