### PR TITLE
Restrict bucket uploads to explicitly selected sources

### DIFF
--- a/api-go/e2e/conftest.py
+++ b/api-go/e2e/conftest.py
@@ -109,5 +109,5 @@ async def e2e_context(client: S3AASClient) -> E2EContext:
         files = await client.list_files(auth, bucket_id)
         for file_doc in files:
             await client.delete_file(auth, bucket_id, file_doc["id"])
-        await client.delete_source(auth, source["id"])
         await client.delete_bucket(auth, bucket_id)
+        await client.delete_source(auth, source["id"])

--- a/api-go/e2e/conftest.py
+++ b/api-go/e2e/conftest.py
@@ -87,14 +87,13 @@ async def e2e_context(client: S3AASClient) -> E2EContext:
     user = await client.create_user(username)
     auth = BasicAuth(login=username, password=user["password"])
 
-    bucket = await client.create_bucket(auth=auth, key=bucket_key)
-    buckets = await client.list_buckets(auth)
-    bucket_id = next(item["id"] for item in buckets if item["key"] == bucket_key)
-
     if client.config.source_type == "s3":
         await client.ensure_s3_source_bucket()
 
     source = await client.create_source(auth, source_name)
+    bucket = await client.create_bucket(auth=auth, key=bucket_key, source_ids=[source["id"]])
+    buckets = await client.list_buckets(auth)
+    bucket_id = next(item["id"] for item in buckets if item["key"] == bucket_key)
 
     try:
         yield E2EContext(

--- a/api-go/e2e/s3aas_client.py
+++ b/api-go/e2e/s3aas_client.py
@@ -164,6 +164,14 @@ class S3AASClient:
         async with self._http.delete(f"{self.config.sources_url}/{source_id}", auth=auth):
             return
 
+    async def delete_source_status(self, auth: BasicAuth, source_id: str) -> int:
+        async with self._http.delete(
+            f"{self.config.sources_url}/{source_id}",
+            auth=auth,
+            raise_for_status=False,
+        ) as response:
+            return response.status
+
     async def upload_file_http(self, auth: BasicAuth, bucket_id: str, filename: str, content: bytes) -> dict[str, Any]:
         form = FormData()
         form.add_field("file", content, filename=filename, content_type="application/octet-stream")

--- a/api-go/e2e/s3aas_client.py
+++ b/api-go/e2e/s3aas_client.py
@@ -102,8 +102,9 @@ class S3AASClient:
         async with self._http.post(self.config.users_url, json={"username": username}) as response:
             return await response.json()
 
-    async def create_bucket(self, auth: BasicAuth, key: str) -> dict[str, Any]:
-        async with self._http.post(self.config.buckets_url, auth=auth, json={"key": key}) as response:
+    async def create_bucket(self, auth: BasicAuth, key: str, source_ids: list[str]) -> dict[str, Any]:
+        payload = {"key": key, "source_ids": source_ids}
+        async with self._http.post(self.config.buckets_url, auth=auth, json=payload) as response:
             return await response.json()
 
     async def list_buckets(self, auth: BasicAuth) -> list[dict[str, Any]]:

--- a/api-go/e2e/test_api_e2e.py
+++ b/api-go/e2e/test_api_e2e.py
@@ -164,3 +164,8 @@ async def test_s3_delete_object_removes_file_metadata_and_content(client, e2e_co
         bucket_key=e2e_context.bucket_key,
         object_key=filename,
     )
+
+
+async def test_delete_source_returns_conflict_while_bucket_uses_it(client, e2e_context):
+    status = await client.delete_source_status(e2e_context.auth, e2e_context.source_id)
+    assert status == 409

--- a/api-go/go.mod
+++ b/api-go/go.mod
@@ -1,6 +1,6 @@
 module github.com/example/s3aas/api-go
 
-go 1.24.3
+go 1.24.0
 
 require (
 	github.com/gin-contrib/cors v1.5.0

--- a/api-go/internal/app/router.go
+++ b/api-go/internal/app/router.go
@@ -48,7 +48,7 @@ func SetupRouter(m *db.Mongo, cfg *config.Config) *gin.Engine {
 		if cfg != nil {
 			secretKey = cfg.AccessSecretKey
 		}
-		router.POST("/api/v1/buckets", auth, handlers.CreateBucket(bucketRepo, secretKey))
+		router.POST("/api/v1/buckets", auth, handlers.CreateBucket(bucketRepo, sourceRepo, secretKey))
 		router.GET("/api/v1/buckets", auth, handlers.ListBuckets(bucketRepo))
 		router.DELETE("/api/v1/buckets/:id", auth, handlers.DeleteBucket(bucketRepo))
 		if sourceRepo != nil && fileRepo != nil {
@@ -69,7 +69,7 @@ func SetupRouter(m *db.Mongo, cfg *config.Config) *gin.Engine {
 		router.POST("/api/v1/sources/s3", auth, handlers.CreateS3Source(sourceRepo))
 		router.GET("/api/v1/sources", auth, handlers.ListSources(sourceRepo))
 		router.GET("/api/v1/sources/:id/info", auth, handlers.GetSourceInfo(sourceRepo))
-		router.DELETE("/api/v1/sources/:id", auth, handlers.DeleteSource(sourceRepo))
+		router.DELETE("/api/v1/sources/:id", auth, handlers.DeleteSource(sourceRepo, bucketRepo))
 	}
 
 	router.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))

--- a/api-go/internal/docs/docs.go
+++ b/api-go/internal/docs/docs.go
@@ -855,6 +855,12 @@ const docTemplate = `{
                             "type": "string"
                         }
                     },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
@@ -1055,11 +1061,19 @@ const docTemplate = `{
         "handlers.createBucketRequest": {
             "type": "object",
             "required": [
-                "key"
+                "key",
+                "source_ids"
             ],
             "properties": {
                 "key": {
                     "type": "string"
+                },
+                "source_ids": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "string"
+                    }
                 }
             }
         },

--- a/api-go/internal/handlers/bucket.go
+++ b/api-go/internal/handlers/bucket.go
@@ -16,7 +16,8 @@ import (
 )
 
 type createBucketRequest struct {
-	Key string `json:"key" binding:"required"`
+	Key       string   `json:"key" binding:"required"`
+	SourceIDs []string `json:"source_ids" binding:"required,min=1"`
 }
 
 type createBucketResponse struct {
@@ -52,7 +53,7 @@ type fileResponse struct {
 // @Failure 409 {string} string ""
 // @Security BasicAuth
 // @Router /api/v1/buckets [post]
-func CreateBucket(repo *repository.BucketRepository, secretKey string) gin.HandlerFunc {
+func CreateBucket(repo *repository.BucketRepository, sourceRepo *repository.SourceRepository, secretKey string) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var req createBucketRequest
 		if err := c.ShouldBindJSON(&req); err != nil {
@@ -60,7 +61,7 @@ func CreateBucket(repo *repository.BucketRepository, secretKey string) gin.Handl
 			c.Status(http.StatusBadRequest)
 			return
 		}
-		if repo == nil {
+		if repo == nil || sourceRepo == nil {
 			log.Print("create bucket: repository is nil")
 			c.Status(http.StatusServiceUnavailable)
 			return
@@ -93,11 +94,35 @@ func CreateBucket(repo *repository.BucketRepository, secretKey string) gin.Handl
 			c.Status(http.StatusInternalServerError)
 			return
 		}
+		sourceIDs := make([]primitive.ObjectID, 0, len(req.SourceIDs))
+		for _, sourceIDHex := range req.SourceIDs {
+			sourceID, err := primitive.ObjectIDFromHex(sourceIDHex)
+			if err != nil {
+				c.Status(http.StatusBadRequest)
+				return
+			}
+			sourceDoc, err := sourceRepo.GetByID(c.Request.Context(), sourceID)
+			if err != nil {
+				if err == mongo.ErrNoDocuments {
+					c.Status(http.StatusBadRequest)
+					return
+				}
+				log.Printf("create bucket: get source: %v", err)
+				c.Status(http.StatusInternalServerError)
+				return
+			}
+			if sourceDoc.UserID != userID {
+				c.Status(http.StatusBadRequest)
+				return
+			}
+			sourceIDs = append(sourceIDs, sourceID)
+		}
 		bucket := repository.Bucket{
 			UserID:          userID,
 			Key:             req.Key,
 			AccessKey:       accessKey,
 			AccessSecretEnc: encrypted,
+			SourceIDs:       sourceIDs,
 			CreatedAt:       time.Now().UTC(),
 		}
 		created, err := repo.Create(c.Request.Context(), bucket)
@@ -269,7 +294,7 @@ func UploadFile(bucketRepo *repository.BucketRepository, sourceRepo *repository.
 			c.Status(http.StatusNotFound)
 			return
 		}
-		sources, err := sourceRepo.ListByUser(c.Request.Context(), userID)
+		sources, err := sourceRepo.ListByIDs(c.Request.Context(), bucketDoc.SourceIDs)
 		if err != nil {
 			log.Printf("upload file: list sources: %v", err)
 			c.Status(http.StatusInternalServerError)

--- a/api-go/internal/handlers/bucket_test.go
+++ b/api-go/internal/handlers/bucket_test.go
@@ -33,7 +33,7 @@ func TestCreateBucket(t *testing.T) {
 		t.Fatal(err)
 	}
 	hash, _ := bcrypt.GenerateFromPassword([]byte("pass"), bcrypt.DefaultCost)
-	_, err = userRepo.Create(context.Background(), repository.User{
+	user, err := userRepo.Create(context.Background(), repository.User{
 		Username:     "tester",
 		PasswordHash: string(hash),
 		CreatedAt:    time.Now().UTC(),
@@ -45,10 +45,24 @@ func TestCreateBucket(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	sourceRepo, err := repository.NewSourceRepository(mongoConn.DB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	source, err := sourceRepo.Create(context.Background(), repository.Source{
+		UserID:    user.ID,
+		Type:      repository.SourceTypeGDrive,
+		Name:      "src-test",
+		Key:       "{}",
+		CreatedAt: time.Now().UTC(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
 	router := gin.New()
 	auth := BasicAuth(userRepo)
-	router.POST("/api/v1/buckets", auth, CreateBucket(repo, "testkey"))
-	body, _ := json.Marshal(map[string]string{"key": "bucket-test"})
+	router.POST("/api/v1/buckets", auth, CreateBucket(repo, sourceRepo, "testkey"))
+	body, _ := json.Marshal(map[string]any{"key": "bucket-test", "source_ids": []string{source.ID.Hex()}})
 	req, _ := http.NewRequest(http.MethodPost, "/api/v1/buckets", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	req.SetBasicAuth("tester", "pass")

--- a/api-go/internal/handlers/s3.go
+++ b/api-go/internal/handlers/s3.go
@@ -222,7 +222,7 @@ func PutObject(bucketRepo *repository.BucketRepository, sourceRepo *repository.S
 			writeS3Error(c, http.StatusNotFound, "NoSuchBucket", "")
 			return
 		}
-		sources, err := sourceRepo.ListByUser(ctx, bucketDoc.UserID)
+		sources, err := sourceRepo.ListByIDs(ctx, bucketDoc.SourceIDs)
 		if err != nil {
 			log.Printf("put object: list sources: %v", err)
 			writeS3Error(c, http.StatusInternalServerError, "InternalError", "")

--- a/api-go/internal/handlers/source.go
+++ b/api-go/internal/handlers/source.go
@@ -241,12 +241,13 @@ func ListSources(repo *repository.SourceRepository) gin.HandlerFunc {
 // @Failure 400 {string} string ""
 // @Failure 401 {string} string ""
 // @Failure 404 {string} string ""
+// @Failure 409 {string} string ""
 // @Failure 500 {string} string ""
 // @Security BasicAuth
 // @Router /api/v1/sources/{id} [delete]
-func DeleteSource(repo *repository.SourceRepository) gin.HandlerFunc {
+func DeleteSource(repo *repository.SourceRepository, bucketRepo *repository.BucketRepository) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		if repo == nil {
+		if repo == nil || bucketRepo == nil {
 			log.Print("delete source: repository is nil")
 			c.Status(http.StatusServiceUnavailable)
 			return
@@ -265,6 +266,16 @@ func DeleteSource(repo *repository.SourceRepository) gin.HandlerFunc {
 		id, err := primitive.ObjectIDFromHex(idHex)
 		if err != nil {
 			c.Status(http.StatusBadRequest)
+			return
+		}
+		inUse, err := bucketRepo.HasSourceReference(c.Request.Context(), userID, id)
+		if err != nil {
+			log.Printf("delete source: check buckets: %v", err)
+			c.Status(http.StatusInternalServerError)
+			return
+		}
+		if inUse {
+			c.Status(http.StatusConflict)
 			return
 		}
 		if err := repo.Delete(c.Request.Context(), id, userID); err != nil {

--- a/api-go/internal/handlers/source_test.go
+++ b/api-go/internal/handlers/source_test.go
@@ -147,3 +147,69 @@ func TestCreateTelegramSource(t *testing.T) {
 		t.Fatalf("unexpected user id: %s != %s", stored.UserID.Hex(), user.ID.Hex())
 	}
 }
+
+func TestDeleteSourceBlockedWhenBucketUsesIt(t *testing.T) {
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	mongoConn, err := db.Connect(context.Background(), cfg.Mongo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	userRepo, err := repository.NewUserRepository(mongoConn.DB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hash, _ := bcrypt.GenerateFromPassword([]byte("pass"), bcrypt.DefaultCost)
+	user, err := userRepo.Create(context.Background(), repository.User{
+		Username:     "tester-delete-src",
+		PasswordHash: string(hash),
+		CreatedAt:    time.Now().UTC(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sourceRepo, err := repository.NewSourceRepository(mongoConn.DB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bucketRepo, err := repository.NewBucketRepository(mongoConn.DB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	source, err := sourceRepo.Create(context.Background(), repository.Source{
+		UserID:    user.ID,
+		Type:      repository.SourceTypeGDrive,
+		Name:      "src-delete-block",
+		Key:       "{}",
+		CreatedAt: time.Now().UTC(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = bucketRepo.Create(context.Background(), repository.Bucket{
+		UserID:          user.ID,
+		Key:             "bucket-delete-block",
+		AccessKey:       "bucket-delete-block",
+		AccessSecretEnc: "enc",
+		SourceIDs:       []primitive.ObjectID{source.ID},
+		CreatedAt:       time.Now().UTC(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	router := gin.New()
+	auth := BasicAuth(userRepo)
+	router.DELETE("/api/v1/sources/:id", auth, DeleteSource(sourceRepo, bucketRepo))
+	req, _ := http.NewRequest(http.MethodDelete, "/api/v1/sources/"+source.ID.Hex(), nil)
+	req.SetBasicAuth("tester-delete-src", "pass")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d", w.Code)
+	}
+	if _, err := sourceRepo.GetByID(context.Background(), source.ID); err != nil {
+		t.Fatalf("expected source to remain after conflict: %v", err)
+	}
+}

--- a/api-go/internal/repository/bucket.go
+++ b/api-go/internal/repository/bucket.go
@@ -11,12 +11,13 @@ import (
 )
 
 type Bucket struct {
-	ID              primitive.ObjectID `bson:"_id,omitempty"`
-	UserID          primitive.ObjectID `bson:"user_id"`
-	Key             string             `bson:"key"`
-	AccessKey       string             `bson:"access_key"`
-	AccessSecretEnc string             `bson:"access_secret"`
-	CreatedAt       time.Time          `bson:"created_at"`
+	ID              primitive.ObjectID   `bson:"_id,omitempty"`
+	UserID          primitive.ObjectID   `bson:"user_id"`
+	Key             string               `bson:"key"`
+	AccessKey       string               `bson:"access_key"`
+	AccessSecretEnc string               `bson:"access_secret"`
+	SourceIDs       []primitive.ObjectID `bson:"source_ids"`
+	CreatedAt       time.Time            `bson:"created_at"`
 }
 
 type BucketRepository struct {
@@ -101,6 +102,14 @@ func (r *BucketRepository) ListByUser(ctx context.Context, userID primitive.Obje
 		return nil, err
 	}
 	return buckets, nil
+}
+
+func (r *BucketRepository) HasSourceReference(ctx context.Context, userID, sourceID primitive.ObjectID) (bool, error) {
+	count, err := r.coll.CountDocuments(ctx, bson.M{"user_id": userID, "source_ids": sourceID})
+	if err != nil {
+		return false, err
+	}
+	return count > 0, nil
 }
 
 func (r *BucketRepository) Delete(ctx context.Context, id, userID primitive.ObjectID) error {

--- a/api-go/internal/repository/source.go
+++ b/api-go/internal/repository/source.go
@@ -62,6 +62,37 @@ func (r *SourceRepository) GetByID(ctx context.Context, id primitive.ObjectID) (
 	return &s, nil
 }
 
+func (r *SourceRepository) ListByIDs(ctx context.Context, ids []primitive.ObjectID) ([]Source, error) {
+	if len(ids) == 0 {
+		return []Source{}, nil
+	}
+	cursor, err := r.coll.Find(ctx, bson.M{"_id": bson.M{"$in": ids}})
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = cursor.Close(ctx) }()
+	byID := make(map[primitive.ObjectID]Source, len(ids))
+	for cursor.Next(ctx) {
+		var src Source
+		if err := cursor.Decode(&src); err != nil {
+			return nil, err
+		}
+		byID[src.ID] = src
+	}
+	if err := cursor.Err(); err != nil {
+		return nil, err
+	}
+	sources := make([]Source, 0, len(ids))
+	for _, id := range ids {
+		source, ok := byID[id]
+		if !ok {
+			continue
+		}
+		sources = append(sources, source)
+	}
+	return sources, nil
+}
+
 func (r *SourceRepository) ListByUser(ctx context.Context, userID primitive.ObjectID) ([]Source, error) {
 	cursor, err := r.coll.Find(ctx, bson.M{"user_id": userID})
 	if err != nil {

--- a/webui/src/features/bucket/ui/create-bucket-dialog.tsx
+++ b/webui/src/features/bucket/ui/create-bucket-dialog.tsx
@@ -1,13 +1,51 @@
-import {Button, Input, Modal, ModalBody, ModalContent, ModalFooter, ModalHeader, Snippet} from "@heroui/react";
-import {useState} from "react";
+import {Button, Checkbox, CheckboxGroup, Input, Modal, ModalBody, ModalContent, ModalFooter, ModalHeader, Snippet} from "@heroui/react";
+import {useEffect, useMemo, useState} from "react";
 import {createBucket} from "../../../shared/api/buckets";
+import {listSources} from "../../../shared/api/sources";
+import type {Source} from "../../../shared/api/sources";
 
 type Props = {isOpen: boolean; onOpenChange: (open: boolean) => void; onCreated: () => void};
 
 export function CreateBucketDialog({isOpen, onOpenChange, onCreated}: Props) {
   const [key, setKey] = useState("");
+  const [sources, setSources] = useState<Source[]>([]);
+  const [selectedSourceIds, setSelectedSourceIds] = useState<string[]>([]);
   const [creds, setCreds] = useState<{accessKey: string; accessSecret: string} | null>(null);
   const [isLoading, setIsLoading] = useState(false);
+  const [isSourcesLoading, setIsSourcesLoading] = useState(false);
+
+  useEffect(() => {
+    if (!isOpen || creds) return;
+
+    let isActive = true;
+
+    async function loadSources() {
+      setIsSourcesLoading(true);
+      try {
+        const nextSources = await listSources();
+        if (!isActive) return;
+        setSources(nextSources);
+      } finally {
+        if (isActive) {
+          setIsSourcesLoading(false);
+        }
+      }
+    }
+
+    loadSources();
+
+    return () => {
+      isActive = false;
+    };
+  }, [creds, isOpen]);
+
+  const hasSources = sources.length > 0;
+  const canCreate = key.trim() !== "" && selectedSourceIds.length > 0;
+  const helperText = useMemo(() => {
+    if (isSourcesLoading) return "Loading sources...";
+    if (!hasSources) return "Create at least one source before creating a bucket.";
+    return "Choose which sources this bucket is allowed to use for uploads.";
+  }, [hasSources, isSourcesLoading]);
 
   return (
     <Modal
@@ -15,7 +53,10 @@ export function CreateBucketDialog({isOpen, onOpenChange, onCreated}: Props) {
       onOpenChange={(open) => {
         if (!open) {
           setKey("");
+          setSources([]);
+          setSelectedSourceIds([]);
           setCreds(null);
+          setIsSourcesLoading(false);
         }
         onOpenChange(open);
       }}
@@ -34,7 +75,25 @@ export function CreateBucketDialog({isOpen, onOpenChange, onCreated}: Props) {
                   </p>
                 </>
               ) : (
-                <Input label="Key" value={key} onChange={(e) => setKey(e.target.value)} />
+                <>
+                  <Input label="Key" value={key} onChange={(e) => setKey(e.target.value)} />
+                  <div className="flex flex-col gap-2">
+                    <p className="text-sm font-medium">Allowed sources</p>
+                    <p className="text-sm text-default-500">{helperText}</p>
+                    {hasSources ? (
+                      <CheckboxGroup
+                        value={selectedSourceIds}
+                        onValueChange={(values) => setSelectedSourceIds(values as string[])}
+                      >
+                        {sources.map((source) => (
+                          <Checkbox key={source.id} value={source.id}>
+                            {source.name}
+                          </Checkbox>
+                        ))}
+                      </CheckboxGroup>
+                    ) : null}
+                  </div>
+                </>
               )}
             </ModalBody>
             <ModalFooter>
@@ -45,11 +104,12 @@ export function CreateBucketDialog({isOpen, onOpenChange, onCreated}: Props) {
               ) : (
                 <Button
                   color="primary"
+                  isDisabled={!canCreate || isSourcesLoading}
                   isLoading={isLoading}
                   onPress={async () => {
                     setIsLoading(true);
                     try {
-                      const res = await createBucket(key);
+                      const res = await createBucket(key, selectedSourceIds);
                       setCreds({accessKey: res.access_key, accessSecret: res.access_secret});
                       onCreated();
                     } finally {

--- a/webui/src/shared/api/buckets.ts
+++ b/webui/src/shared/api/buckets.ts
@@ -27,7 +27,7 @@ export async function listBuckets(): Promise<Bucket[]> {
   return res.json();
 }
 
-export async function createBucket(key: string): Promise<{
+export async function createBucket(key: string, sourceIds: string[]): Promise<{
   key: string;
   access_key: string;
   access_secret: string;
@@ -39,7 +39,7 @@ export async function createBucket(key: string): Promise<{
       "Content-Type": "application/json",
       ...authHeader(),
     },
-    body: JSON.stringify({ key }),
+    body: JSON.stringify({key, source_ids: sourceIds}),
   });
   if (!res.ok) throw new Error("failed to create bucket");
   return res.json();


### PR DESCRIPTION
### Motivation
- Enforce explicit association between buckets and sources so uploads/operations only use allowed sources and users cannot delete sources that are referenced by buckets.
- Propagate source selection through API, repository, handlers, docs, e2e client and UI to provide first-class support for source-scoped buckets.

### Description
- API and handlers: `CreateBucket` now requires `sourceRepo` and accepts `source_ids` in the request, validates ownership of each source, stores `source_ids` on the bucket, and returns `409` on duplicate key; `DeleteSource` now checks for bucket references and returns `409` if the source is in use.
- Repository: `Bucket` model gained `SourceIDs []ObjectID`, added `HasSourceReference(ctx, userID, sourceID)`; `SourceRepository` gained `ListByIDs(ctx, ids)` to fetch sources in a defined order.
- S3/handlers: handlers that previously listed all user sources now load only the bucket's `SourceIDs` via `ListByIDs` for uploads/puts to ensure allowed sources are used.
- Docs: OpenAPI docs updated to require `source_ids` in `createBucketRequest` and to include `409` responses where applicable.
- E2E and client changes: e2e `S3AASClient.create_bucket` and `conftest` updated to send `source_ids`; UI now lists sources and requires selecting at least one when creating a bucket, and the frontend `createBucket` API sends `source_ids`.
- Misc: router wiring updated to pass `sourceRepo` into bucket and source handlers; Go module `go` directive adjusted.

### Testing
- Ran backend unit/integration tests with `go test ./...` and handler tests under `internal/handlers`; tests passed.
- Ran Python e2e tests in `api-go/e2e` with `pytest` and the updated e2e flow for creating buckets with `source_ids`; tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998138fc48c8324952b3668ebbdfb64)