### PR TITLE
Add GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,30 @@
+---
+name: Bug report
+about: Report a broken flow, regression, or unexpected behavior
+title: "[Bug] "
+---
+
+## Summary
+
+What is broken?
+
+## Expected Behavior
+
+What should have happened instead?
+
+## Reproduction
+
+1. 
+2. 
+3. 
+
+## Environment
+
+- area affected:
+- browser or client:
+- source type, if relevant:
+- endpoint, if relevant:
+
+## Evidence
+
+Logs, screenshots, request samples, or error messages.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/docs-or-devrel.md
+++ b/.github/ISSUE_TEMPLATE/docs-or-devrel.md
@@ -1,0 +1,21 @@
+---
+name: Docs or devrel
+about: Suggest documentation, onboarding, or community-facing improvements
+title: "[Docs] "
+---
+
+## Gap
+
+What is unclear, missing, or hard to discover today?
+
+## Audience
+
+Who is blocked by this gap?
+
+## Proposed Asset
+
+Examples: README update, quickstart, architecture doc, landing copy, tutorial, demo, issue cleanup.
+
+## Success Signal
+
+How would we know this work helped?

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,21 @@
+---
+name: Feature request
+about: Propose a product, DX, or platform improvement
+title: "[Feature] "
+---
+
+## Problem
+
+What user or contributor problem are you trying to solve?
+
+## Proposed Change
+
+Describe the change as concretely as you can.
+
+## Why It Matters
+
+Who benefits, and what gets better?
+
+## Scope Notes
+
+Call out anything that is explicitly out of scope.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+## Summary
+
+Describe the change in a few lines.
+
+## Linked Issue
+
+Reference the issue this PR addresses.
+
+## What Changed
+
+- 
+
+## Validation
+
+- tests run:
+- manual checks:
+
+## Docs Impact
+
+- [ ] no docs change needed
+- [ ] docs updated in this PR
+- [ ] follow-up docs issue needed


### PR DESCRIPTION
## Summary

- Adds structured issue templates (bug report, feature request, docs/devrel) for contributor intake
- Adds a pull request template to standardize PR descriptions
- Enables blank issues alongside templates

## Test plan

- [ ] Verify templates appear when creating a new issue on GitHub
- [ ] Verify PR template auto-populates on new pull requests
- [ ] Confirm blank issues remain available

🤖 Generated with [Claude Code](https://claude.com/claude-code)