### PR TITLE
Self-hostable docker-compose with S3 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,38 +63,101 @@ read and write objects directly.
 
 ### Prerequisites
 
+- Docker and Docker Compose
+
+### 1. Start the full stack
+
+```bash
+git clone https://github.com/siberianbearofficial/sfree.git
+cd sfree
+docker compose up --build
+```
+
+This starts MongoDB, the Go API, a React frontend (with nginx), and a MinIO
+instance for local S3-compatible source testing.
+
+| Service  | URL                          |
+| -------- | ---------------------------- |
+| Frontend | http://localhost:3000        |
+| API      | http://localhost:8080        |
+| Swagger  | http://localhost:8080/swagger/index.html |
+| MinIO Console | http://localhost:9001   |
+
+### 2. Try it out
+
+1. Open http://localhost:3000 and sign up.
+2. Create an S3-compatible source via the API (using the bundled MinIO):
+   ```bash
+   # Create user first, note the password from the response
+   curl -X POST http://localhost:8080/api/v1/users \
+     -H 'Content-Type: application/json' \
+     -d '{"username": "demo"}'
+
+   # Use the returned password for Basic Auth (base64 of demo:PASSWORD)
+   # Create an S3-compatible source backed by MinIO
+   curl -X POST http://localhost:8080/api/v1/sources/s3 \
+     -H 'Content-Type: application/json' \
+     -H 'Authorization: Basic BASE64_CREDENTIALS' \
+     -d '{
+       "name": "local-minio",
+       "endpoint": "http://minio:9000",
+       "bucket": "sfree-data",
+       "access_key_id": "minioadmin",
+       "secret_access_key": "minioadmin",
+       "region": "us-east-1",
+       "path_style": true
+     }'
+   ```
+3. Create a bucket in the UI (select the MinIO source).
+4. Upload a file through the UI.
+5. Download the same file via aws-cli using the bucket's S3 credentials:
+   ```bash
+   aws s3 ls s3://BUCKET_KEY/ \
+     --endpoint-url http://localhost:8080/api/s3
+
+   aws s3 cp s3://BUCKET_KEY/OBJECT_KEY ./local-copy \
+     --endpoint-url http://localhost:8080/api/s3
+   ```
+
+### Manual dev setup (without Docker Compose)
+
+<details>
+<summary>Click to expand</summary>
+
+#### Prerequisites
+
 - Go 1.24+
 - Docker (for MongoDB)
 - Node.js with npm (for the browser UI)
 
-### 1. Start MongoDB
+#### 1. Start MongoDB
 
 ```bash
 cd api-go
 docker compose up -d
 ```
 
-### 2. Run the Go API
+#### 2. Run the Go API
 
 ```bash
 cd api-go
 ENV=local go run ./cmd/server
 ```
 
-The API listens on `http://localhost:8080`. Swagger docs are at
-`http://localhost:8080/swagger/index.html`.
+The API listens on `http://localhost:8080`.
 
-### 3. Run the browser UI (optional)
+#### 3. Run the browser UI
 
 ```bash
 cd webui
-npm install
-npm run dev
+VITE_API_BASE=http://localhost:8080/api/v1 npm run dev
 ```
 
-> **Note:** The checked-in frontend points at a hosted dev API URL in
-> `webui/src/shared/api/*.ts`. Update those modules to `http://localhost:8080`
-> for a fully local workflow.
+Set `VITE_API_BASE` to point the frontend at your local API. Without it, the
+frontend defaults to a relative `/api/v1` path (designed for the Docker Compose
+setup where nginx proxies to the API).
+
+</details>
 
 ## Repository Layout
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,63 @@
+services:
+  mongo:
+    image: mongo:7
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: root
+      MONGO_INITDB_ROOT_PASSWORD: example
+    volumes:
+      - mongo-data:/data/db
+
+  minio:
+    image: minio/minio:RELEASE.2025-01-20T14-49-07Z
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    command: server /data --console-address ":9001"
+    ports:
+      - "9001:9001"
+    volumes:
+      - minio-data:/data
+
+  minio-init:
+    image: minio/mc
+    depends_on:
+      - minio
+    entrypoint: >
+      /bin/sh -c "
+      until mc alias set local http://minio:9000 minioadmin minioadmin 2>/dev/null; do sleep 1; done;
+      mc mb --ignore-existing local/sfree-data;
+      exit 0;
+      "
+
+  api:
+    build:
+      context: ./api-go
+      dockerfile: Dockerfile
+    environment:
+      ENV: local
+      DB_HOST: mongo
+      DB_PORT: "27017"
+      DB_USER: root
+      DB_PASSWORD: example
+      DB_NAME: sfree
+      ACCESS_SECRET_KEY: examplesecret
+    depends_on:
+      - mongo
+    ports:
+      - "8080:8080"
+
+  webui:
+    build:
+      context: ./webui
+      dockerfile: Dockerfile
+    environment:
+      API_HOST: api
+      API_PORT: "8080"
+    depends_on:
+      - api
+    ports:
+      - "3000:80"
+
+volumes:
+  mongo-data:
+  minio-data:

--- a/webui/Dockerfile
+++ b/webui/Dockerfile
@@ -9,6 +9,8 @@ RUN npm run build
 # Production stage
 FROM nginx:alpine
 COPY --from=build /app/dist /usr/share/nginx/html
-COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY nginx.conf /etc/nginx/templates/default.conf.template
+ENV API_HOST=api
+ENV API_PORT=8080
+ENV NGINX_ENVSUBST_FILTER=^API_
 EXPOSE 80
-CMD ["nginx", "-g", "daemon off;"]

--- a/webui/nginx.conf
+++ b/webui/nginx.conf
@@ -2,6 +2,15 @@ server {
   listen 80;
   server_name _;
   root /usr/share/nginx/html;
+
+  location /api/ {
+    proxy_pass http://${API_HOST}:${API_PORT};
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    client_max_body_size 100m;
+  }
+
   location / {
     try_files $uri /index.html;
   }

--- a/webui/src/shared/api/buckets.ts
+++ b/webui/src/shared/api/buckets.ts
@@ -1,4 +1,4 @@
-const API_BASE = "https://s3aas-api.dev.nachert.art/api/v1";
+const API_BASE = import.meta.env.VITE_API_BASE || "/api/v1";
 
 export type Bucket = {
   id: string;

--- a/webui/src/shared/api/sources.ts
+++ b/webui/src/shared/api/sources.ts
@@ -1,4 +1,4 @@
-const API_BASE = "https://s3aas-api.dev.nachert.art/api/v1";
+const API_BASE = import.meta.env.VITE_API_BASE || "/api/v1";
 
 export type Source = {id: string; name: string; type: string; key: string; created_at: string};
 

--- a/webui/src/shared/api/users.ts
+++ b/webui/src/shared/api/users.ts
@@ -1,4 +1,4 @@
-const API_BASE = "https://s3aas-api.dev.nachert.art/api/v1";
+const API_BASE = import.meta.env.VITE_API_BASE || "/api/v1";
 
 export async function createUser(username: string): Promise<{id: string; created_at: string; password: string}> {
   const res = await fetch(`${API_BASE}/users`, {


### PR DESCRIPTION
## Summary
- Adds root `docker-compose.yml` that starts the full stack: MongoDB, Go API, React frontend (nginx proxy), and MinIO with a pre-created `sfree-data` bucket
- Makes frontend API URL configurable via `VITE_API_BASE` env var (defaults to relative `/api/v1` for Docker setup where nginx proxies to the API)
- Updates webui Dockerfile to use nginx template for runtime `API_HOST`/`API_PORT` configuration
- Rewrites README quickstart around the single `docker compose up --build` flow; manual dev setup preserved in collapsible section

## Test plan
- [ ] `docker compose up --build` starts all services without errors
- [ ] Frontend loads at http://localhost:3000
- [ ] Sign up via UI works
- [ ] Create S3-compatible source via API pointing at bundled MinIO
- [ ] Create bucket in UI selecting the MinIO source
- [ ] Upload file through UI
- [ ] `aws s3 ls s3://BUCKET_KEY/ --endpoint-url http://localhost:8080/api/s3` lists the file
- [ ] `aws s3 cp s3://BUCKET_KEY/FILE ./local --endpoint-url http://localhost:8080/api/s3` downloads it
- [ ] `aws s3 cp ./local s3://BUCKET_KEY/new-file --endpoint-url http://localhost:8080/api/s3` uploads via S3
- [ ] `aws s3 rm s3://BUCKET_KEY/new-file --endpoint-url http://localhost:8080/api/s3` deletes via S3
- [ ] Woodpecker CI pipelines still pass (no changes to api-go/ or webui/ CI paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)