### PR TITLE
Fix source file download endpoint (fixes #107)

### DIFF
--- a/.woodpecker/api-go.yml
+++ b/.woodpecker/api-go.yml
@@ -13,6 +13,12 @@ when:
         - api-go/**
 
 steps:
+  - name: unit tests
+    image: golang:1.24
+    commands:
+      - cd api-go
+      - go test ./...
+
   - name: e2e tests
     image: docker:27-cli
     environment:

--- a/api-go/internal/app/router.go
+++ b/api-go/internal/app/router.go
@@ -69,6 +69,7 @@ func SetupRouter(m *db.Mongo, cfg *config.Config) *gin.Engine {
 		router.POST("/api/v1/sources/s3", auth, handlers.CreateS3Source(sourceRepo))
 		router.GET("/api/v1/sources", auth, handlers.ListSources(sourceRepo))
 		router.GET("/api/v1/sources/:id/info", auth, handlers.GetSourceInfo(sourceRepo))
+		router.GET("/api/v1/sources/:id/files/:file_id/download", auth, handlers.DownloadSourceFile(sourceRepo))
 		router.DELETE("/api/v1/sources/:id", auth, handlers.DeleteSource(sourceRepo, bucketRepo))
 	}
 

--- a/api-go/internal/handlers/source.go
+++ b/api-go/internal/handlers/source.go
@@ -1,6 +1,8 @@
 package handlers
 
 import (
+	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"time"
@@ -416,6 +418,113 @@ func GetSourceInfo(repo *repository.SourceRepository) gin.HandlerFunc {
 			})
 		default:
 			c.Status(http.StatusBadRequest)
+		}
+	}
+}
+
+// DownloadSourceFile godoc
+// @Summary Download a file from a source
+// @Tags sources
+// @Produce octet-stream
+// @Param id path string true "Source ID"
+// @Param file_id path string true "File ID (GDrive file ID or S3 object key)"
+// @Success 200 {file} file
+// @Failure 400 {string} string ""
+// @Failure 401 {string} string ""
+// @Failure 404 {string} string ""
+// @Failure 500 {string} string ""
+// @Security BasicAuth
+// @Router /api/v1/sources/{id}/files/{file_id}/download [get]
+func DownloadSourceFile(sourceRepo *repository.SourceRepository) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if sourceRepo == nil {
+			log.Print("download source file: repository is nil")
+			c.Status(http.StatusServiceUnavailable)
+			return
+		}
+		userIDHex := c.GetString("userID")
+		if userIDHex == "" {
+			c.Status(http.StatusUnauthorized)
+			return
+		}
+		userID, err := primitive.ObjectIDFromHex(userIDHex)
+		if err != nil {
+			c.Status(http.StatusUnauthorized)
+			return
+		}
+		idHex := c.Param("id")
+		id, err := primitive.ObjectIDFromHex(idHex)
+		if err != nil {
+			c.Status(http.StatusBadRequest)
+			return
+		}
+		fileID := c.Param("file_id")
+		if fileID == "" {
+			c.Status(http.StatusBadRequest)
+			return
+		}
+		src, err := sourceRepo.GetByID(c.Request.Context(), id)
+		if err != nil {
+			if err == mongo.ErrNoDocuments {
+				c.Status(http.StatusNotFound)
+				return
+			}
+			log.Printf("download source file: get source: %v", err)
+			c.Status(http.StatusInternalServerError)
+			return
+		}
+		if src.UserID != userID {
+			c.Status(http.StatusNotFound)
+			return
+		}
+
+		var body io.ReadCloser
+		filename := fileID
+
+		switch src.Type {
+		case repository.SourceTypeGDrive:
+			cli, err := gdrive.NewClient(c.Request.Context(), []byte(src.Key))
+			if err != nil {
+				log.Printf("download source file: create gdrive client: %v", err)
+				c.Status(http.StatusInternalServerError)
+				return
+			}
+			body, err = cli.Download(c.Request.Context(), fileID)
+			if err != nil {
+				log.Printf("download source file: gdrive download: %v", err)
+				c.Status(http.StatusInternalServerError)
+				return
+			}
+		case repository.SourceTypeS3:
+			cfg, err := s3compat.ParseConfig(src.Key)
+			if err != nil {
+				log.Printf("download source file: parse s3 config: %v", err)
+				c.Status(http.StatusInternalServerError)
+				return
+			}
+			cli, err := s3compat.NewClient(c.Request.Context(), cfg)
+			if err != nil {
+				log.Printf("download source file: create s3 client: %v", err)
+				c.Status(http.StatusInternalServerError)
+				return
+			}
+			body, err = cli.Download(c.Request.Context(), fileID)
+			if err != nil {
+				log.Printf("download source file: s3 download: %v", err)
+				c.Status(http.StatusInternalServerError)
+				return
+			}
+		default:
+			c.JSON(http.StatusBadRequest, gin.H{"error": "download not supported for this source type"})
+			return
+		}
+		defer func() { _ = body.Close() }()
+
+		c.Header("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s\"", filename))
+		c.Header("Content-Type", "application/octet-stream")
+		c.Status(http.StatusOK)
+		if _, err := io.Copy(c.Writer, body); err != nil {
+			log.Printf("download source file: stream: %v", err)
 		}
 	}
 }

--- a/api-go/internal/handlers/unit_test.go
+++ b/api-go/internal/handlers/unit_test.go
@@ -1,0 +1,383 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/example/sfree/api-go/internal/repository"
+	"github.com/gin-gonic/gin"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+func init() {
+	gin.SetMode(gin.TestMode)
+}
+
+// setUserID is a helper middleware that injects a userID into the gin context.
+func setUserID(id string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Set("userID", id)
+		c.Next()
+	}
+}
+
+func validUserID() string { return primitive.NewObjectID().Hex() }
+
+// --- Source handler unit tests ---
+
+func TestCreateGDriveSourceMissingFields(t *testing.T) {
+	t.Parallel()
+	r := gin.New()
+	r.POST("/sources/gdrive", CreateGDriveSource(nil))
+
+	body, _ := json.Marshal(map[string]string{"name": "only-name"}) // missing key
+	req, _ := http.NewRequest(http.MethodPost, "/sources/gdrive", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestCreateTelegramSourceMissingFields(t *testing.T) {
+	t.Parallel()
+	r := gin.New()
+	r.POST("/sources/telegram", CreateTelegramSource(nil))
+
+	body, _ := json.Marshal(map[string]string{"name": "tg"}) // missing token and chat_id
+	req, _ := http.NewRequest(http.MethodPost, "/sources/telegram", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestCreateS3SourceMissingFields(t *testing.T) {
+	t.Parallel()
+	r := gin.New()
+	r.POST("/sources/s3", CreateS3Source(nil))
+
+	body, _ := json.Marshal(map[string]string{"name": "s3"}) // missing required fields
+	req, _ := http.NewRequest(http.MethodPost, "/sources/s3", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestListSourcesNilRepo(t *testing.T) {
+	t.Parallel()
+	r := gin.New()
+	r.GET("/sources", ListSources(nil))
+
+	req, _ := http.NewRequest(http.MethodGet, "/sources", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d", w.Code)
+	}
+}
+
+func TestListSourcesNoUserID(t *testing.T) {
+	t.Parallel()
+	r := gin.New()
+	r.GET("/sources", ListSources(&repository.SourceRepository{}))
+
+	req, _ := http.NewRequest(http.MethodGet, "/sources", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestListSourcesInvalidUserID(t *testing.T) {
+	t.Parallel()
+	r := gin.New()
+	r.GET("/sources", setUserID("not-a-valid-oid"), ListSources(&repository.SourceRepository{}))
+
+	req, _ := http.NewRequest(http.MethodGet, "/sources", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestDeleteSourceNilRepos(t *testing.T) {
+	t.Parallel()
+	r := gin.New()
+	r.DELETE("/sources/:id", DeleteSource(nil, nil))
+
+	req, _ := http.NewRequest(http.MethodDelete, "/sources/"+primitive.NewObjectID().Hex(), nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d", w.Code)
+	}
+}
+
+func TestDeleteSourceNoUserID(t *testing.T) {
+	t.Parallel()
+	r := gin.New()
+	r.DELETE("/sources/:id", DeleteSource(&repository.SourceRepository{}, &repository.BucketRepository{}))
+
+	req, _ := http.NewRequest(http.MethodDelete, "/sources/"+primitive.NewObjectID().Hex(), nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestDeleteSourceInvalidIDParam(t *testing.T) {
+	t.Parallel()
+	r := gin.New()
+	r.DELETE("/sources/:id",
+		setUserID(validUserID()),
+		DeleteSource(&repository.SourceRepository{}, &repository.BucketRepository{}),
+	)
+
+	req, _ := http.NewRequest(http.MethodDelete, "/sources/not-a-valid-oid", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestGetSourceInfoNilRepo(t *testing.T) {
+	t.Parallel()
+	r := gin.New()
+	r.GET("/sources/:id/info", GetSourceInfo(nil))
+
+	req, _ := http.NewRequest(http.MethodGet, "/sources/"+primitive.NewObjectID().Hex()+"/info", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d", w.Code)
+	}
+}
+
+func TestGetSourceInfoInvalidIDParam(t *testing.T) {
+	t.Parallel()
+	r := gin.New()
+	r.GET("/sources/:id/info",
+		setUserID(validUserID()),
+		GetSourceInfo(&repository.SourceRepository{}),
+	)
+
+	req, _ := http.NewRequest(http.MethodGet, "/sources/not-a-valid-oid/info", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestDownloadSourceFileNilRepo(t *testing.T) {
+	t.Parallel()
+	r := gin.New()
+	r.GET("/sources/:id/files/:file_id/download", DownloadSourceFile(nil))
+
+	req, _ := http.NewRequest(http.MethodGet, "/sources/"+primitive.NewObjectID().Hex()+"/files/somefile/download", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d", w.Code)
+	}
+}
+
+func TestDownloadSourceFileNoUserID(t *testing.T) {
+	t.Parallel()
+	r := gin.New()
+	r.GET("/sources/:id/files/:file_id/download", DownloadSourceFile(&repository.SourceRepository{}))
+
+	req, _ := http.NewRequest(http.MethodGet, "/sources/"+primitive.NewObjectID().Hex()+"/files/somefile/download", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestDownloadSourceFileInvalidSourceID(t *testing.T) {
+	t.Parallel()
+	r := gin.New()
+	r.GET("/sources/:id/files/:file_id/download",
+		setUserID(validUserID()),
+		DownloadSourceFile(&repository.SourceRepository{}),
+	)
+
+	req, _ := http.NewRequest(http.MethodGet, "/sources/not-a-valid-oid/files/somefile/download", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+// --- Bucket handler unit tests ---
+
+func TestCreateBucketMissingFields(t *testing.T) {
+	t.Parallel()
+	r := gin.New()
+	r.POST("/buckets", CreateBucket(nil, nil, "secret"))
+
+	body, _ := json.Marshal(map[string]string{"key": "k"}) // missing source_ids
+	req, _ := http.NewRequest(http.MethodPost, "/buckets", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestCreateBucketNilRepos(t *testing.T) {
+	t.Parallel()
+	r := gin.New()
+	r.POST("/buckets", CreateBucket(nil, nil, "secret"))
+
+	body, _ := json.Marshal(map[string]any{"key": "k", "source_ids": []string{primitive.NewObjectID().Hex()}})
+	req, _ := http.NewRequest(http.MethodPost, "/buckets", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d", w.Code)
+	}
+}
+
+func TestCreateBucketNoUserID(t *testing.T) {
+	t.Parallel()
+	r := gin.New()
+	r.POST("/buckets", CreateBucket(&repository.BucketRepository{}, &repository.SourceRepository{}, "secret"))
+
+	body, _ := json.Marshal(map[string]any{"key": "k", "source_ids": []string{primitive.NewObjectID().Hex()}})
+	req, _ := http.NewRequest(http.MethodPost, "/buckets", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestListBucketsNilRepo(t *testing.T) {
+	t.Parallel()
+	r := gin.New()
+	r.GET("/buckets", ListBuckets(nil))
+
+	req, _ := http.NewRequest(http.MethodGet, "/buckets", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d", w.Code)
+	}
+}
+
+func TestListBucketsNoUserID(t *testing.T) {
+	t.Parallel()
+	r := gin.New()
+	r.GET("/buckets", ListBuckets(&repository.BucketRepository{}))
+
+	req, _ := http.NewRequest(http.MethodGet, "/buckets", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestDeleteBucketNilRepo(t *testing.T) {
+	t.Parallel()
+	r := gin.New()
+	r.DELETE("/buckets/:id", DeleteBucket(nil))
+
+	req, _ := http.NewRequest(http.MethodDelete, "/buckets/"+primitive.NewObjectID().Hex(), nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d", w.Code)
+	}
+}
+
+func TestDeleteBucketInvalidIDParam(t *testing.T) {
+	t.Parallel()
+	r := gin.New()
+	r.DELETE("/buckets/:id",
+		setUserID(validUserID()),
+		DeleteBucket(&repository.BucketRepository{}),
+	)
+
+	req, _ := http.NewRequest(http.MethodDelete, "/buckets/not-a-valid-oid", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+// --- User handler unit tests ---
+
+func TestCreateUserMissingUsername(t *testing.T) {
+	t.Parallel()
+	r := gin.New()
+	r.POST("/users", CreateUser(nil))
+
+	body, _ := json.Marshal(map[string]string{}) // missing username
+	req, _ := http.NewRequest(http.MethodPost, "/users", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestCreateUserNilRepo(t *testing.T) {
+	t.Parallel()
+	r := gin.New()
+	r.POST("/users", CreateUser(nil))
+
+	body, _ := json.Marshal(map[string]string{"username": "alice"})
+	req, _ := http.NewRequest(http.MethodPost, "/users", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d", w.Code)
+	}
+}

--- a/api-go/internal/manager/file_test.go
+++ b/api-go/internal/manager/file_test.go
@@ -3,6 +3,7 @@ package manager
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"testing"
 
@@ -11,20 +12,29 @@ import (
 )
 
 type stubSourceClient struct {
-	uploaded [][]byte
+	uploaded    [][]byte
+	uploadErr   error
+	downloadErr error
+	deleteErr   error
 }
 
 func (c *stubSourceClient) Upload(_ context.Context, _ string, r io.Reader) (string, error) {
+	if c.uploadErr != nil {
+		return "", c.uploadErr
+	}
 	data, _ := io.ReadAll(r)
 	c.uploaded = append(c.uploaded, data)
 	return string(data), nil
 }
 
-func (c *stubSourceClient) Download(_ context.Context, _ string) (io.ReadCloser, error) {
-	return io.NopCloser(bytes.NewReader(nil)), nil
+func (c *stubSourceClient) Download(_ context.Context, name string) (io.ReadCloser, error) {
+	if c.downloadErr != nil {
+		return nil, c.downloadErr
+	}
+	return io.NopCloser(bytes.NewReader([]byte(name))), nil
 }
 
-func (c *stubSourceClient) Delete(_ context.Context, _ string) error { return nil }
+func (c *stubSourceClient) Delete(_ context.Context, _ string) error { return c.deleteErr }
 
 func TestUploadFileChunksWithRoundRobinStrategy(t *testing.T) {
 	t.Parallel()
@@ -55,5 +65,111 @@ func TestUploadFileChunksWithRoundRobinStrategy(t *testing.T) {
 	}
 	if got := len(clients[s2.ID].uploaded); got != 2 {
 		t.Fatalf("unexpected uploads for source2: %d", got)
+	}
+}
+
+func TestRoundRobinSelectorNoSources(t *testing.T) {
+	t.Parallel()
+	sel := &RoundRobinSelector{}
+	_, _, err := sel.NextSource(nil)
+	if err == nil {
+		t.Fatal("expected error for empty sources, got nil")
+	}
+	_, _, err = sel.NextSource([]repository.Source{})
+	if err == nil {
+		t.Fatal("expected error for empty sources slice, got nil")
+	}
+}
+
+func TestRoundRobinSelectorAdvances(t *testing.T) {
+	t.Parallel()
+	s1 := repository.Source{ID: primitive.NewObjectID()}
+	s2 := repository.Source{ID: primitive.NewObjectID()}
+	sources := []repository.Source{s1, s2}
+	sel := &RoundRobinSelector{}
+
+	idxA, srcA, _ := sel.NextSource(sources)
+	idxB, srcB, _ := sel.NextSource(sources)
+	idxC, srcC, _ := sel.NextSource(sources)
+
+	if idxA != 0 || srcA.ID != s1.ID {
+		t.Fatalf("first call: expected index 0 / s1, got %d / %v", idxA, srcA.ID)
+	}
+	if idxB != 1 || srcB.ID != s2.ID {
+		t.Fatalf("second call: expected index 1 / s2, got %d / %v", idxB, srcB.ID)
+	}
+	if idxC != 0 || srcC.ID != s1.ID {
+		t.Fatalf("third call: expected wrap to index 0 / s1, got %d / %v", idxC, srcC.ID)
+	}
+}
+
+func TestUploadFileChunksNoSources(t *testing.T) {
+	t.Parallel()
+	_, err := UploadFileChunksWithStrategy(context.Background(), bytes.NewReader([]byte("data")), nil, 4, func(_ context.Context, _ *repository.Source) (sourceClient, error) {
+		return &stubSourceClient{}, nil
+	}, &RoundRobinSelector{})
+	if err == nil {
+		t.Fatal("expected error for no sources")
+	}
+}
+
+func TestUploadFileChunksFactoryError(t *testing.T) {
+	t.Parallel()
+	factoryErr := errors.New("factory failed")
+	src := repository.Source{ID: primitive.NewObjectID()}
+	_, err := UploadFileChunksWithStrategy(context.Background(), bytes.NewReader([]byte("hello")), []repository.Source{src}, 10, func(_ context.Context, _ *repository.Source) (sourceClient, error) {
+		return nil, factoryErr
+	}, &RoundRobinSelector{})
+	if !errors.Is(err, factoryErr) {
+		t.Fatalf("expected factory error, got %v", err)
+	}
+}
+
+func TestUploadFileChunksUploadError(t *testing.T) {
+	t.Parallel()
+	uploadErr := errors.New("upload failed")
+	src := repository.Source{ID: primitive.NewObjectID()}
+	stub := &stubSourceClient{uploadErr: uploadErr}
+	_, err := UploadFileChunksWithStrategy(context.Background(), bytes.NewReader([]byte("hello")), []repository.Source{src}, 10, func(_ context.Context, _ *repository.Source) (sourceClient, error) {
+		return stub, nil
+	}, &RoundRobinSelector{})
+	if !errors.Is(err, uploadErr) {
+		t.Fatalf("expected upload error, got %v", err)
+	}
+}
+
+func TestNewSourceClientNilSource(t *testing.T) {
+	t.Parallel()
+	_, err := NewSourceClient(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error for nil source")
+	}
+}
+
+func TestNewSourceClientUnsupportedType(t *testing.T) {
+	t.Parallel()
+	src := &repository.Source{Type: "unsupported_type_xyz"}
+	_, err := NewSourceClient(context.Background(), src)
+	if !errors.Is(err, ErrUnsupportedSourceType) {
+		t.Fatalf("expected ErrUnsupportedSourceType, got %v", err)
+	}
+}
+
+func TestStreamFileNoChunks(t *testing.T) {
+	t.Parallel()
+	f := &repository.File{Chunks: []repository.FileChunk{}}
+	var buf bytes.Buffer
+	if err := StreamFile(context.Background(), nil, f, &buf); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Fatalf("expected empty output, got %d bytes", buf.Len())
+	}
+}
+
+func TestDeleteFileChunksNoChunks(t *testing.T) {
+	t.Parallel()
+	if err := DeleteFileChunks(context.Background(), nil, []repository.FileChunk{}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

- Added `GET /api/v1/sources/:id/files/:file_id/download` endpoint that was missing from the backend, causing the web UI source detail page download buttons to fail
- Supports GDrive (by file ID) and S3 (by object key) source types; returns 400 for unsupported types (Telegram returns no files so download buttons never appear)
- Added unit tests for the new handler (nil repo, no auth, invalid ID) and a Woodpecker CI step to run `go test ./...` on PRs
- Expanded manager package test coverage

## Test plan

- [ ] CI unit tests pass (`go test ./...`)
- [ ] E2E: create a GDrive source, navigate to source detail, click download on a file — file downloads
- [ ] E2E: create an S3 source, navigate to source detail, click download on an object — file downloads
- [ ] Verify Telegram source detail page shows no download buttons (no files listed)

Fixes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)