### PR TITLE
Add observability: Prometheus metrics and structured logging

### DIFF
--- a/api-go/cmd/server/main.go
+++ b/api-go/cmd/server/main.go
@@ -8,26 +8,34 @@ package main
 
 import (
 	"context"
-	"log"
+	"log/slog"
+	"os"
 
 	"github.com/example/sfree/api-go/internal/app"
 	"github.com/example/sfree/api-go/internal/config"
 	"github.com/example/sfree/api-go/internal/db"
 	_ "github.com/example/sfree/api-go/internal/docs"
+	"github.com/example/sfree/api-go/internal/observability"
 )
 
 func main() {
+	observability.SetupLogger()
+
 	cfg, err := config.Load()
 	if err != nil {
-		log.Fatalf("failed to load config: %v", err)
+		slog.Error("failed to load config", slog.String("error", err.Error()))
+		os.Exit(1)
 	}
 	ctx := context.Background()
 	mongoConn, err := db.Connect(ctx, cfg.Mongo)
 	if err != nil {
-		log.Fatalf("failed to connect mongo: %v", err)
+		slog.Error("failed to connect mongo", slog.String("error", err.Error()))
+		os.Exit(1)
 	}
 	router := app.SetupRouter(mongoConn, cfg)
+	slog.Info("starting server")
 	if err := router.Run(); err != nil {
-		log.Fatalf("failed to run server: %v", err)
+		slog.Error("failed to run server", slog.String("error", err.Error()))
+		os.Exit(1)
 	}
 }

--- a/api-go/docker-compose.yml
+++ b/api-go/docker-compose.yml
@@ -6,3 +6,11 @@ services:
       - MONGO_INITDB_ROOT_PASSWORD=example
     ports:
       - "27017:27017"
+
+  # Optional: uncomment to enable Prometheus metrics scraping
+  # prometheus:
+  #   image: prom/prometheus:v3.2.1
+  #   volumes:
+  #     - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+  #   ports:
+  #     - "9090:9090"

--- a/api-go/go.mod
+++ b/api-go/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/gin-contrib/cors v1.5.0
 	github.com/gin-gonic/gin v1.10.1
 	github.com/golang-jwt/jwt/v5 v5.2.1
+	github.com/google/uuid v1.6.0
 	github.com/prometheus/client_golang v1.22.0
 	github.com/swaggo/files v1.0.1
 	github.com/swaggo/gin-swagger v1.6.0
@@ -64,7 +65,6 @@ require (
 	github.com/goccy/go-json v0.10.2 // indirect
 	github.com/golang/snappy v0.0.1 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.6 // indirect
 	github.com/googleapis/gax-go/v2 v2.15.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect

--- a/api-go/internal/app/router.go
+++ b/api-go/internal/app/router.go
@@ -4,6 +4,7 @@ import (
 	"github.com/example/sfree/api-go/internal/config"
 	"github.com/example/sfree/api-go/internal/db"
 	"github.com/example/sfree/api-go/internal/handlers"
+	"github.com/example/sfree/api-go/internal/observability"
 	"github.com/example/sfree/api-go/internal/repository"
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
@@ -21,6 +22,7 @@ func SetupRouter(m *db.Mongo, cfg *config.Config) *gin.Engine {
 		AllowCredentials: true,
 	}))
 	router.Use(gin.Recovery())
+	router.Use(observability.Middleware())
 	router.GET("/readyz", handlers.Readyz)
 	router.GET("/healthz", handlers.Healthz)
 	router.GET("/publication/ready", handlers.PublicationReady)

--- a/api-go/internal/handlers/auth.go
+++ b/api-go/internal/handlers/auth.go
@@ -1,7 +1,7 @@
 package handlers
 
 import (
-	"log"
+	"log/slog"
 	"net/http"
 	"strings"
 
@@ -65,7 +65,7 @@ func Auth(repo *repository.UserRepository, jwtSecret string) gin.HandlerFunc {
 			return
 		}
 		if repo == nil {
-			log.Print("auth: user repository is nil")
+			slog.ErrorContext(c.Request.Context(), "basic auth: user repository is nil")
 			c.AbortWithStatus(http.StatusServiceUnavailable)
 			return
 		}
@@ -75,7 +75,7 @@ func Auth(repo *repository.UserRepository, jwtSecret string) gin.HandlerFunc {
 				c.AbortWithStatus(http.StatusUnauthorized)
 				return
 			}
-			log.Printf("auth: failed to get user: %v", err)
+			slog.ErrorContext(c.Request.Context(), "basic auth: failed to get user", slog.String("error", err.Error()))
 			c.AbortWithStatus(http.StatusInternalServerError)
 			return
 		}

--- a/api-go/internal/handlers/aws4.go
+++ b/api-go/internal/handlers/aws4.go
@@ -1,7 +1,7 @@
 package handlers
 
 import (
-	"log"
+	"log/slog"
 	"net/http"
 
 	"github.com/example/sfree/api-go/internal/cryptoutil"
@@ -16,20 +16,21 @@ func AWS4Auth(repo *repository.BucketRepository, secretKey string) gin.HandlerFu
 	validator := &s3sigv4.Validator{}
 
 	return func(c *gin.Context) {
+		ctx := c.Request.Context()
 		if repo == nil {
-			log.Print("aws4 auth: bucket repository is nil")
+			slog.ErrorContext(ctx, "aws4 auth: bucket repository is nil")
 			c.AbortWithStatus(http.StatusServiceUnavailable)
 			return
 		}
 		if secretKey == "" {
-			log.Print("aws4 auth: secret key is empty")
+			slog.ErrorContext(ctx, "aws4 auth: secret key is empty")
 			c.AbortWithStatus(http.StatusInternalServerError)
 			return
 		}
 
 		accessKey, err := s3sigv4.AccessKeyFromRequest(c.Request)
 		if err != nil || accessKey == "" {
-			log.Printf("aws4 auth: failed to extract access key: %v", err)
+			slog.WarnContext(ctx, "aws4 auth: failed to extract access key", slog.String("error", errString(err)))
 			c.AbortWithStatus(http.StatusUnauthorized)
 			return
 		}
@@ -37,29 +38,36 @@ func AWS4Auth(repo *repository.BucketRepository, secretKey string) gin.HandlerFu
 		encSecret, err := repo.GetSecretByAccessKey(c.Request.Context(), accessKey)
 		if err != nil {
 			if err == mongo.ErrNoDocuments {
-				log.Print("aws4 auth: get secret by access key lead to ErrNoDocuments")
+				slog.WarnContext(ctx, "aws4 auth: unknown access key")
 				c.AbortWithStatus(http.StatusUnauthorized)
 				return
 			}
-			log.Printf("aws4 auth: failed to get secret: %v", err)
+			slog.ErrorContext(ctx, "aws4 auth: failed to get secret", slog.String("error", err.Error()))
 			c.AbortWithStatus(http.StatusInternalServerError)
 			return
 		}
 		secret, err := cryptoutil.Decrypt(encSecret, secretKey)
 		if err != nil {
-			log.Printf("aws4 auth: decrypt secret: %v", err)
+			slog.ErrorContext(ctx, "aws4 auth: decrypt secret", slog.String("error", err.Error()))
 			c.AbortWithStatus(http.StatusInternalServerError)
 			return
 		}
 
 		if _, err = validator.Validate(c.Request.Context(), c.Request, accessKey, secret); err != nil {
-			log.Printf("aws4 auth: signature validation failed: %v", err)
+			slog.WarnContext(ctx, "aws4 auth: signature validation failed", slog.String("error", err.Error()))
 			c.AbortWithStatus(http.StatusUnauthorized)
 			return
 		}
 
-		log.Print("aws4 auth success")
+		slog.DebugContext(ctx, "aws4 auth success")
 		c.Set("accessKey", accessKey)
 		c.Next()
 	}
+}
+
+func errString(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
 }

--- a/api-go/internal/handlers/bucket.go
+++ b/api-go/internal/handlers/bucket.go
@@ -2,7 +2,7 @@ package handlers
 
 import (
 	"fmt"
-	"log"
+	"log/slog"
 	"net/http"
 	"strconv"
 	"time"
@@ -55,14 +55,15 @@ type fileResponse struct {
 // @Router /api/v1/buckets [post]
 func CreateBucket(repo *repository.BucketRepository, sourceRepo *repository.SourceRepository, secretKey string) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		ctx := c.Request.Context()
 		var req createBucketRequest
 		if err := c.ShouldBindJSON(&req); err != nil {
-			log.Printf("create bucket: invalid request: %v", err)
+			slog.WarnContext(ctx, "create bucket: invalid request", slog.String("error", err.Error()))
 			c.Status(http.StatusBadRequest)
 			return
 		}
 		if repo == nil || sourceRepo == nil {
-			log.Print("create bucket: repository is nil")
+			slog.ErrorContext(ctx, "create bucket: repository is nil")
 			c.Status(http.StatusServiceUnavailable)
 			return
 		}
@@ -77,20 +78,20 @@ func CreateBucket(repo *repository.BucketRepository, sourceRepo *repository.Sour
 			return
 		}
 		if secretKey == "" {
-			log.Print("create bucket: secret key is empty")
+			slog.ErrorContext(ctx, "create bucket: secret key is empty")
 			c.Status(http.StatusInternalServerError)
 			return
 		}
 		accessKey := req.Key
 		accessSecret, err := cryptoutil.GenerateSecret()
 		if err != nil {
-			log.Printf("create bucket: generate secret: %v", err)
+			slog.ErrorContext(ctx, "create bucket: generate secret", slog.String("error", err.Error()))
 			c.Status(http.StatusInternalServerError)
 			return
 		}
 		encrypted, err := cryptoutil.Encrypt(accessSecret, secretKey)
 		if err != nil {
-			log.Printf("create bucket: encrypt secret: %v", err)
+			slog.ErrorContext(ctx, "create bucket: encrypt secret", slog.String("error", err.Error()))
 			c.Status(http.StatusInternalServerError)
 			return
 		}
@@ -107,7 +108,7 @@ func CreateBucket(repo *repository.BucketRepository, sourceRepo *repository.Sour
 					c.Status(http.StatusBadRequest)
 					return
 				}
-				log.Printf("create bucket: get source: %v", err)
+				slog.ErrorContext(ctx, "create bucket: get source", slog.String("error", err.Error()))
 				c.Status(http.StatusInternalServerError)
 				return
 			}
@@ -128,11 +129,11 @@ func CreateBucket(repo *repository.BucketRepository, sourceRepo *repository.Sour
 		created, err := repo.Create(c.Request.Context(), bucket)
 		if err != nil {
 			if mongo.IsDuplicateKeyError(err) {
-				log.Printf("create bucket: key %s already exists: %v", req.Key, err)
+				slog.WarnContext(ctx, "create bucket: key already exists", slog.String("key", req.Key))
 				c.Status(http.StatusConflict)
 				return
 			}
-			log.Printf("create bucket: failed to create bucket: %v", err)
+			slog.ErrorContext(ctx, "create bucket: failed to create bucket", slog.String("error", err.Error()))
 			c.Status(http.StatusInternalServerError)
 			return
 		}
@@ -156,8 +157,9 @@ func CreateBucket(repo *repository.BucketRepository, sourceRepo *repository.Sour
 // @Router /api/v1/buckets [get]
 func ListBuckets(repo *repository.BucketRepository) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		ctx := c.Request.Context()
 		if repo == nil {
-			log.Print("list buckets: repository is nil")
+			slog.ErrorContext(ctx, "list buckets: repository is nil")
 			c.Status(http.StatusServiceUnavailable)
 			return
 		}
@@ -173,7 +175,7 @@ func ListBuckets(repo *repository.BucketRepository) gin.HandlerFunc {
 		}
 		buckets, err := repo.ListByUser(c.Request.Context(), userID)
 		if err != nil {
-			log.Printf("list buckets: failed to list buckets: %v", err)
+			slog.ErrorContext(ctx, "list buckets: failed to list buckets", slog.String("error", err.Error()))
 			c.Status(http.StatusInternalServerError)
 			return
 		}
@@ -203,8 +205,9 @@ func ListBuckets(repo *repository.BucketRepository) gin.HandlerFunc {
 // @Router /api/v1/buckets/{id} [delete]
 func DeleteBucket(repo *repository.BucketRepository) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		ctx := c.Request.Context()
 		if repo == nil {
-			log.Print("delete bucket: repository is nil")
+			slog.ErrorContext(ctx, "delete bucket: repository is nil")
 			c.Status(http.StatusServiceUnavailable)
 			return
 		}
@@ -229,7 +232,7 @@ func DeleteBucket(repo *repository.BucketRepository) gin.HandlerFunc {
 				c.Status(http.StatusNotFound)
 				return
 			}
-			log.Printf("delete bucket: failed to delete: %v", err)
+			slog.ErrorContext(ctx, "delete bucket: failed to delete", slog.String("error", err.Error()))
 			c.Status(http.StatusInternalServerError)
 			return
 		}
@@ -259,8 +262,9 @@ type uploadFileResponse struct {
 // @Router /api/v1/buckets/{id}/upload [post]
 func UploadFile(bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository, chunkSize int) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		ctx := c.Request.Context()
 		if bucketRepo == nil || sourceRepo == nil || fileRepo == nil {
-			log.Print("upload file: repository is nil")
+			slog.ErrorContext(ctx, "upload file: repository is nil")
 			c.Status(http.StatusServiceUnavailable)
 			return
 		}
@@ -286,7 +290,7 @@ func UploadFile(bucketRepo *repository.BucketRepository, sourceRepo *repository.
 				c.Status(http.StatusNotFound)
 				return
 			}
-			log.Printf("upload file: get bucket: %v", err)
+			slog.ErrorContext(ctx, "upload file: get bucket", slog.String("error", err.Error()))
 			c.Status(http.StatusInternalServerError)
 			return
 		}
@@ -296,7 +300,7 @@ func UploadFile(bucketRepo *repository.BucketRepository, sourceRepo *repository.
 		}
 		sources, err := sourceRepo.ListByIDs(c.Request.Context(), bucketDoc.SourceIDs)
 		if err != nil {
-			log.Printf("upload file: list sources: %v", err)
+			slog.ErrorContext(ctx, "upload file: list sources", slog.String("error", err.Error()))
 			c.Status(http.StatusInternalServerError)
 			return
 		}
@@ -306,22 +310,21 @@ func UploadFile(bucketRepo *repository.BucketRepository, sourceRepo *repository.
 		}
 		fh, err := c.FormFile("file")
 		if err != nil {
-			log.Printf("upload file: get file: %v", err)
+			slog.WarnContext(ctx, "upload file: get file", slog.String("error", err.Error()))
 			c.Status(http.StatusBadRequest)
 			return
 		}
 		f, err := fh.Open()
 		if err != nil {
-			log.Printf("upload file: open file: %v", err)
+			slog.WarnContext(ctx, "upload file: open file", slog.String("error", err.Error()))
 			c.Status(http.StatusBadRequest)
 			return
 		}
 		defer func() { _ = f.Close() }()
 
-		ctx := c.Request.Context()
 		chunks, err := manager.UploadFileChunks(ctx, f, sources, chunkSize)
 		if err != nil {
-			log.Printf("upload file: upload chunks: %v", err)
+			slog.ErrorContext(ctx, "upload file: upload chunks", slog.String("error", err.Error()))
 			c.Status(http.StatusInternalServerError)
 			return
 		}
@@ -335,7 +338,7 @@ func UploadFile(bucketRepo *repository.BucketRepository, sourceRepo *repository.
 		created, err := fileRepo.Create(ctx, fileDoc)
 		if err != nil {
 			_ = manager.DeleteFileChunks(ctx, sourceRepo, chunks)
-			log.Printf("upload file: save file: %v", err)
+			slog.ErrorContext(ctx, "upload file: save file", slog.String("error", err.Error()))
 			c.Status(http.StatusInternalServerError)
 			return
 		}
@@ -361,8 +364,9 @@ func UploadFile(bucketRepo *repository.BucketRepository, sourceRepo *repository.
 // @Router /api/v1/buckets/{id}/files [get]
 func ListFiles(bucketRepo *repository.BucketRepository, fileRepo *repository.FileRepository) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		ctx := c.Request.Context()
 		if bucketRepo == nil || fileRepo == nil {
-			log.Print("list files: repository is nil")
+			slog.ErrorContext(ctx, "list files: repository is nil")
 			c.Status(http.StatusServiceUnavailable)
 			return
 		}
@@ -388,7 +392,7 @@ func ListFiles(bucketRepo *repository.BucketRepository, fileRepo *repository.Fil
 				c.Status(http.StatusNotFound)
 				return
 			}
-			log.Printf("list files: get bucket: %v", err)
+			slog.ErrorContext(ctx, "list files: get bucket", slog.String("error", err.Error()))
 			c.Status(http.StatusInternalServerError)
 			return
 		}
@@ -398,7 +402,7 @@ func ListFiles(bucketRepo *repository.BucketRepository, fileRepo *repository.Fil
 		}
 		files, err := fileRepo.ListByBucket(c.Request.Context(), bucketID)
 		if err != nil {
-			log.Printf("list files: list files: %v", err)
+			slog.ErrorContext(ctx, "list files: list files", slog.String("error", err.Error()))
 			c.Status(http.StatusInternalServerError)
 			return
 		}
@@ -434,8 +438,9 @@ func ListFiles(bucketRepo *repository.BucketRepository, fileRepo *repository.Fil
 // @Router /api/v1/buckets/{id}/files/{file_id}/download [get]
 func DownloadFile(bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		ctx := c.Request.Context()
 		if bucketRepo == nil || sourceRepo == nil || fileRepo == nil {
-			log.Print("download file: repository is nil")
+			slog.ErrorContext(ctx, "download file: repository is nil")
 			c.Status(http.StatusServiceUnavailable)
 			return
 		}
@@ -467,7 +472,7 @@ func DownloadFile(bucketRepo *repository.BucketRepository, sourceRepo *repositor
 				c.Status(http.StatusNotFound)
 				return
 			}
-			log.Printf("download file: get bucket: %v", err)
+			slog.ErrorContext(ctx, "download file: get bucket", slog.String("error", err.Error()))
 			c.Status(http.StatusInternalServerError)
 			return
 		}
@@ -481,7 +486,7 @@ func DownloadFile(bucketRepo *repository.BucketRepository, sourceRepo *repositor
 				c.Status(http.StatusNotFound)
 				return
 			}
-			log.Printf("download file: get file: %v", err)
+			slog.ErrorContext(ctx, "download file: get file", slog.String("error", err.Error()))
 			c.Status(http.StatusInternalServerError)
 			return
 		}
@@ -498,7 +503,7 @@ func DownloadFile(bucketRepo *repository.BucketRepository, sourceRepo *repositor
 		c.Header("Content-Length", strconv.FormatInt(total, 10))
 		c.Status(http.StatusOK)
 		if err := manager.StreamFile(c.Request.Context(), sourceRepo, fileDoc, c.Writer); err != nil {
-			log.Printf("download file: %v", err)
+			slog.ErrorContext(ctx, "download file: stream failed", slog.String("error", err.Error()))
 		}
 	}
 }
@@ -517,8 +522,9 @@ func DownloadFile(bucketRepo *repository.BucketRepository, sourceRepo *repositor
 // @Router /api/v1/buckets/{id}/files/{file_id} [delete]
 func DeleteFile(bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		ctx := c.Request.Context()
 		if bucketRepo == nil || sourceRepo == nil || fileRepo == nil {
-			log.Print("delete file: repository is nil")
+			slog.ErrorContext(ctx, "delete file: repository is nil")
 			c.Status(http.StatusServiceUnavailable)
 			return
 		}
@@ -550,7 +556,7 @@ func DeleteFile(bucketRepo *repository.BucketRepository, sourceRepo *repository.
 				c.Status(http.StatusNotFound)
 				return
 			}
-			log.Printf("delete file: get bucket: %v", err)
+			slog.ErrorContext(ctx, "delete file: get bucket", slog.String("error", err.Error()))
 			c.Status(http.StatusInternalServerError)
 			return
 		}
@@ -564,7 +570,7 @@ func DeleteFile(bucketRepo *repository.BucketRepository, sourceRepo *repository.
 				c.Status(http.StatusNotFound)
 				return
 			}
-			log.Printf("delete file: get file: %v", err)
+			slog.ErrorContext(ctx, "delete file: get file", slog.String("error", err.Error()))
 			c.Status(http.StatusInternalServerError)
 			return
 		}
@@ -572,14 +578,13 @@ func DeleteFile(bucketRepo *repository.BucketRepository, sourceRepo *repository.
 			c.Status(http.StatusNotFound)
 			return
 		}
-		ctx := c.Request.Context()
 		if err := manager.DeleteFileChunks(ctx, sourceRepo, fileDoc.Chunks); err != nil {
-			log.Printf("delete file: delete chunk: %v", err)
+			slog.ErrorContext(ctx, "delete file: delete chunk", slog.String("error", err.Error()))
 			c.Status(http.StatusInternalServerError)
 			return
 		}
 		if err := fileRepo.Delete(ctx, fileID); err != nil {
-			log.Printf("delete file: delete metadata: %v", err)
+			slog.ErrorContext(ctx, "delete file: delete metadata", slog.String("error", err.Error()))
 			c.Status(http.StatusInternalServerError)
 			return
 		}

--- a/api-go/internal/handlers/s3.go
+++ b/api-go/internal/handlers/s3.go
@@ -4,7 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/xml"
-	"log"
+	"log/slog"
 	"net/http"
 	"strconv"
 	"strings"
@@ -71,19 +71,19 @@ func objectETag(file repository.File) string {
 // @Router /api/s3/{bucket} [get]
 func ListObjects(bucketRepo *repository.BucketRepository, fileRepo *repository.FileRepository) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		ctx := c.Request.Context()
 		if bucketRepo == nil || fileRepo == nil {
 			c.Status(http.StatusServiceUnavailable)
 			return
 		}
 		bucketKey := c.Param("bucket")
-		ctx := c.Request.Context()
 		bucketDoc, err := bucketRepo.GetByKey(ctx, bucketKey)
 		if err != nil {
 			if err == mongo.ErrNoDocuments {
 				writeS3Error(c, http.StatusNotFound, "NoSuchBucket", "")
 				return
 			}
-			log.Printf("list objects: get bucket: %v", err)
+			slog.ErrorContext(ctx, "list objects: get bucket", slog.String("error", err.Error()))
 			writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
 			return
 		}
@@ -94,7 +94,7 @@ func ListObjects(bucketRepo *repository.BucketRepository, fileRepo *repository.F
 		}
 		files, err := fileRepo.ListByBucket(ctx, bucketDoc.ID)
 		if err != nil {
-			log.Printf("list objects: list files: %v", err)
+			slog.ErrorContext(ctx, "list objects: list files", slog.String("error", err.Error()))
 			writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
 			return
 		}
@@ -137,20 +137,20 @@ func ListObjects(bucketRepo *repository.BucketRepository, fileRepo *repository.F
 // @Router /api/s3/{bucket}/{object} [get]
 func GetObject(bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		ctx := c.Request.Context()
 		if bucketRepo == nil || sourceRepo == nil || fileRepo == nil {
 			c.Status(http.StatusServiceUnavailable)
 			return
 		}
 		bucketKey := c.Param("bucket")
 		name := strings.TrimPrefix(c.Param("object"), "/")
-		ctx := c.Request.Context()
 		bucketDoc, err := bucketRepo.GetByKey(ctx, bucketKey)
 		if err != nil {
 			if err == mongo.ErrNoDocuments {
 				writeS3Error(c, http.StatusNotFound, "NoSuchBucket", "")
 				return
 			}
-			log.Printf("get object: get bucket: %v", err)
+			slog.ErrorContext(ctx, "get object: get bucket", slog.String("error", err.Error()))
 			writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
 			return
 		}
@@ -165,7 +165,7 @@ func GetObject(bucketRepo *repository.BucketRepository, sourceRepo *repository.S
 				writeS3Error(c, http.StatusNotFound, "NoSuchKey", "")
 				return
 			}
-			log.Printf("get object: get file: %v", err)
+			slog.ErrorContext(ctx, "get object: get file", slog.String("error", err.Error()))
 			writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
 			return
 		}
@@ -177,7 +177,7 @@ func GetObject(bucketRepo *repository.BucketRepository, sourceRepo *repository.S
 		c.Header("Content-Length", strconv.FormatInt(total, 10))
 		c.Status(http.StatusOK)
 		if err := manager.StreamFile(c.Request.Context(), sourceRepo, fileDoc, c.Writer); err != nil {
-			log.Printf("get object: %v", err)
+			slog.ErrorContext(ctx, "get object: stream failed", slog.String("error", err.Error()))
 		}
 	}
 }
@@ -196,6 +196,7 @@ func GetObject(bucketRepo *repository.BucketRepository, sourceRepo *repository.S
 // @Router /api/s3/{bucket}/{object} [put]
 func PutObject(bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository, chunkSize int) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		ctx := c.Request.Context()
 		if bucketRepo == nil || sourceRepo == nil || fileRepo == nil {
 			c.Status(http.StatusServiceUnavailable)
 			return
@@ -206,14 +207,13 @@ func PutObject(bucketRepo *repository.BucketRepository, sourceRepo *repository.S
 			writeS3Error(c, http.StatusBadRequest, "InvalidRequest", "")
 			return
 		}
-		ctx := c.Request.Context()
 		bucketDoc, err := bucketRepo.GetByKey(ctx, bucketKey)
 		if err != nil {
 			if err == mongo.ErrNoDocuments {
 				writeS3Error(c, http.StatusNotFound, "NoSuchBucket", "")
 				return
 			}
-			log.Printf("put object: get bucket: %v", err)
+			slog.ErrorContext(ctx, "put object: get bucket", slog.String("error", err.Error()))
 			writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
 			return
 		}
@@ -224,7 +224,7 @@ func PutObject(bucketRepo *repository.BucketRepository, sourceRepo *repository.S
 		}
 		sources, err := sourceRepo.ListByIDs(ctx, bucketDoc.SourceIDs)
 		if err != nil {
-			log.Printf("put object: list sources: %v", err)
+			slog.ErrorContext(ctx, "put object: list sources", slog.String("error", err.Error()))
 			writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
 			return
 		}
@@ -235,7 +235,7 @@ func PutObject(bucketRepo *repository.BucketRepository, sourceRepo *repository.S
 		var existingFile *repository.File
 		existingFile, err = fileRepo.GetByName(ctx, bucketDoc.ID, name)
 		if err != nil && err != mongo.ErrNoDocuments {
-			log.Printf("put object: get existing file: %v", err)
+			slog.ErrorContext(ctx, "put object: get existing file", slog.String("error", err.Error()))
 			writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
 			return
 		}
@@ -244,7 +244,7 @@ func PutObject(bucketRepo *repository.BucketRepository, sourceRepo *repository.S
 		}
 		chunks, err := manager.UploadFileChunks(ctx, c.Request.Body, sources, chunkSize)
 		if err != nil {
-			log.Printf("put object: upload chunks: %v", err)
+			slog.ErrorContext(ctx, "put object: upload chunks", slog.String("error", err.Error()))
 			writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
 			return
 		}
@@ -253,7 +253,7 @@ func PutObject(bucketRepo *repository.BucketRepository, sourceRepo *repository.S
 		if existingFile == nil {
 			if _, err := fileRepo.Create(ctx, fileDoc); err != nil {
 				_ = manager.DeleteFileChunks(ctx, sourceRepo, chunks)
-				log.Printf("put object: save file: %v", err)
+				slog.ErrorContext(ctx, "put object: save file", slog.String("error", err.Error()))
 				writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
 				return
 			}
@@ -263,12 +263,12 @@ func PutObject(bucketRepo *repository.BucketRepository, sourceRepo *repository.S
 		fileDoc.ID = existingFile.ID
 		if _, err := fileRepo.UpdateByID(ctx, fileDoc); err != nil {
 			_ = manager.DeleteFileChunks(ctx, sourceRepo, chunks)
-			log.Printf("put object: update file: %v", err)
+			slog.ErrorContext(ctx, "put object: update file", slog.String("error", err.Error()))
 			writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
 			return
 		}
 		if err := manager.DeleteFileChunks(ctx, sourceRepo, existingFile.Chunks); err != nil {
-			log.Printf("put object: delete old chunks: %v", err)
+			slog.WarnContext(ctx, "put object: delete old chunks", slog.String("error", err.Error()))
 		}
 		c.Status(http.StatusOK)
 	}
@@ -285,19 +285,19 @@ func PutObject(bucketRepo *repository.BucketRepository, sourceRepo *repository.S
 // @Router /api/s3/{bucket}/{object} [delete]
 func DeleteObject(bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		ctx := c.Request.Context()
 		if bucketRepo == nil || sourceRepo == nil || fileRepo == nil {
 			c.Status(http.StatusServiceUnavailable)
 			return
 		}
 		bucketKey := c.Param("bucket")
-		ctx := c.Request.Context()
 		bucketDoc, err := bucketRepo.GetByKey(ctx, bucketKey)
 		if err != nil {
 			if err == mongo.ErrNoDocuments {
 				writeS3Error(c, http.StatusNotFound, "NoSuchBucket", "")
 				return
 			}
-			log.Printf("delete object: get bucket: %v", err)
+			slog.ErrorContext(ctx, "delete object: get bucket", slog.String("error", err.Error()))
 			writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
 			return
 		}
@@ -317,7 +317,7 @@ func DeleteObject(bucketRepo *repository.BucketRepository, sourceRepo *repositor
 				c.Status(http.StatusNoContent)
 				return
 			}
-			log.Printf("delete object: get file: %v", err)
+			slog.ErrorContext(ctx, "delete object: get file", slog.String("error", err.Error()))
 			writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
 			return
 		}
@@ -326,12 +326,12 @@ func DeleteObject(bucketRepo *repository.BucketRepository, sourceRepo *repositor
 				c.Status(http.StatusNoContent)
 				return
 			}
-			log.Printf("delete object: delete file: %v", err)
+			slog.ErrorContext(ctx, "delete object: delete file", slog.String("error", err.Error()))
 			writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
 			return
 		}
 		if err := manager.DeleteFileChunks(ctx, sourceRepo, fileDoc.Chunks); err != nil {
-			log.Printf("delete object: delete chunks: %v", err)
+			slog.WarnContext(ctx, "delete object: delete chunks", slog.String("error", err.Error()))
 		}
 		c.Status(http.StatusNoContent)
 	}

--- a/api-go/internal/handlers/source.go
+++ b/api-go/internal/handlers/source.go
@@ -3,7 +3,7 @@ package handlers
 import (
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"time"
 
@@ -76,7 +76,7 @@ func CreateGDriveSource(repo *repository.SourceRepository) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var req createGDriveSourceRequest
 		if err := c.ShouldBindJSON(&req); err != nil {
-			log.Printf("create gdrive source: invalid request: %v", err)
+			slog.WarnContext(c.Request.Context(), "create gdrive source: invalid request", slog.String("error", err.Error()))
 			c.Status(http.StatusBadRequest)
 			return
 		}
@@ -100,13 +100,13 @@ func CreateTelegramSource(repo *repository.SourceRepository) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var req createTelegramSourceRequest
 		if err := c.ShouldBindJSON(&req); err != nil {
-			log.Printf("create telegram source: invalid request: %v", err)
+			slog.WarnContext(c.Request.Context(), "create telegram source: invalid request", slog.String("error", err.Error()))
 			c.Status(http.StatusBadRequest)
 			return
 		}
 		key, err := telegram.EncodeConfig(telegram.Config{Token: req.Token, ChatID: req.ChatID})
 		if err != nil {
-			log.Printf("create telegram source: encode key: %v", err)
+			slog.ErrorContext(c.Request.Context(), "create telegram source: encode key", slog.String("error", err.Error()))
 			c.Status(http.StatusInternalServerError)
 			return
 		}
@@ -130,7 +130,7 @@ func CreateS3Source(repo *repository.SourceRepository) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var req createS3SourceRequest
 		if err := c.ShouldBindJSON(&req); err != nil {
-			log.Printf("create s3 source: invalid request: %v", err)
+			slog.WarnContext(c.Request.Context(), "create s3 source: invalid request", slog.String("error", err.Error()))
 			c.Status(http.StatusBadRequest)
 			return
 		}
@@ -143,7 +143,7 @@ func CreateS3Source(repo *repository.SourceRepository) gin.HandlerFunc {
 			PathStyle:    req.PathStyle,
 		})
 		if err != nil {
-			log.Printf("create s3 source: encode key: %v", err)
+			slog.ErrorContext(c.Request.Context(), "create s3 source: encode key", slog.String("error", err.Error()))
 			c.Status(http.StatusInternalServerError)
 			return
 		}
@@ -152,6 +152,7 @@ func CreateS3Source(repo *repository.SourceRepository) gin.HandlerFunc {
 }
 
 func saveSource(c *gin.Context, repo *repository.SourceRepository, sourceType repository.SourceType, name, key string) {
+	ctx := c.Request.Context()
 	if repo == nil {
 		c.Status(http.StatusServiceUnavailable)
 		return
@@ -175,7 +176,7 @@ func saveSource(c *gin.Context, repo *repository.SourceRepository, sourceType re
 	}
 	created, err := repo.Create(c.Request.Context(), source)
 	if err != nil {
-		log.Printf("create source: failed to create: %v", err)
+		slog.ErrorContext(ctx, "create source: failed to create", slog.String("error", err.Error()))
 		c.Status(http.StatusInternalServerError)
 		return
 	}
@@ -198,8 +199,9 @@ func saveSource(c *gin.Context, repo *repository.SourceRepository, sourceType re
 // @Router /api/v1/sources [get]
 func ListSources(repo *repository.SourceRepository) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		ctx := c.Request.Context()
 		if repo == nil {
-			log.Print("list sources: repository is nil")
+			slog.ErrorContext(ctx, "list sources: repository is nil")
 			c.Status(http.StatusServiceUnavailable)
 			return
 		}
@@ -215,7 +217,7 @@ func ListSources(repo *repository.SourceRepository) gin.HandlerFunc {
 		}
 		sources, err := repo.ListByUser(c.Request.Context(), userID)
 		if err != nil {
-			log.Printf("list sources: failed to list: %v", err)
+			slog.ErrorContext(ctx, "list sources: failed to list", slog.String("error", err.Error()))
 			c.Status(http.StatusInternalServerError)
 			return
 		}
@@ -246,8 +248,9 @@ func ListSources(repo *repository.SourceRepository) gin.HandlerFunc {
 // @Router /api/v1/sources/{id} [delete]
 func DeleteSource(repo *repository.SourceRepository, bucketRepo *repository.BucketRepository) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		ctx := c.Request.Context()
 		if repo == nil || bucketRepo == nil {
-			log.Print("delete source: repository is nil")
+			slog.ErrorContext(ctx, "delete source: repository is nil")
 			c.Status(http.StatusServiceUnavailable)
 			return
 		}
@@ -269,7 +272,7 @@ func DeleteSource(repo *repository.SourceRepository, bucketRepo *repository.Buck
 		}
 		inUse, err := bucketRepo.HasSourceReference(c.Request.Context(), userID, id)
 		if err != nil {
-			log.Printf("delete source: check buckets: %v", err)
+			slog.ErrorContext(ctx, "delete source: check buckets", slog.String("error", err.Error()))
 			c.Status(http.StatusInternalServerError)
 			return
 		}
@@ -282,7 +285,7 @@ func DeleteSource(repo *repository.SourceRepository, bucketRepo *repository.Buck
 				c.Status(http.StatusNotFound)
 				return
 			}
-			log.Printf("delete source: failed to delete: %v", err)
+			slog.ErrorContext(ctx, "delete source: failed to delete", slog.String("error", err.Error()))
 			c.Status(http.StatusInternalServerError)
 			return
 		}
@@ -303,8 +306,9 @@ func DeleteSource(repo *repository.SourceRepository, bucketRepo *repository.Buck
 // @Router /api/v1/sources/{id}/info [get]
 func GetSourceInfo(repo *repository.SourceRepository) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		ctx := c.Request.Context()
 		if repo == nil {
-			log.Print("get source info: repository is nil")
+			slog.ErrorContext(ctx, "get source info: repository is nil")
 			c.Status(http.StatusServiceUnavailable)
 			return
 		}
@@ -330,7 +334,7 @@ func GetSourceInfo(repo *repository.SourceRepository) gin.HandlerFunc {
 				c.Status(http.StatusNotFound)
 				return
 			}
-			log.Printf("get source info: get source: %v", err)
+			slog.ErrorContext(ctx, "get source info: get source", slog.String("error", err.Error()))
 			c.Status(http.StatusInternalServerError)
 			return
 		}
@@ -342,19 +346,19 @@ func GetSourceInfo(repo *repository.SourceRepository) gin.HandlerFunc {
 		case repository.SourceTypeGDrive:
 			cli, err := gdrive.NewClient(c.Request.Context(), []byte(src.Key))
 			if err != nil {
-				log.Printf("get source info: create client: %v", err)
+				slog.ErrorContext(ctx, "get source info: create client", slog.String("error", err.Error()))
 				c.Status(http.StatusInternalServerError)
 				return
 			}
 			files, err := cli.ListFiles(c.Request.Context())
 			if err != nil {
-				log.Printf("get source info: list files: %v", err)
+				slog.ErrorContext(ctx, "get source info: list files", slog.String("error", err.Error()))
 				c.Status(http.StatusInternalServerError)
 				return
 			}
 			total, used, free, err := cli.StorageInfo(c.Request.Context())
 			if err != nil {
-				log.Printf("get source info: storage info: %v", err)
+				slog.ErrorContext(ctx, "get source info: storage info", slog.String("error", err.Error()))
 				c.Status(http.StatusInternalServerError)
 				return
 			}
@@ -384,19 +388,19 @@ func GetSourceInfo(repo *repository.SourceRepository) gin.HandlerFunc {
 		case repository.SourceTypeS3:
 			cfg, err := s3compat.ParseConfig(src.Key)
 			if err != nil {
-				log.Printf("get source info: parse s3 source config: %v", err)
+				slog.ErrorContext(ctx, "get source info: parse s3 source config", slog.String("error", err.Error()))
 				c.Status(http.StatusInternalServerError)
 				return
 			}
 			cli, err := s3compat.NewClient(c.Request.Context(), cfg)
 			if err != nil {
-				log.Printf("get source info: create s3 client: %v", err)
+				slog.ErrorContext(ctx, "get source info: create s3 client", slog.String("error", err.Error()))
 				c.Status(http.StatusInternalServerError)
 				return
 			}
 			files, used, err := cli.ListObjects(c.Request.Context())
 			if err != nil {
-				log.Printf("get source info: list s3 objects: %v", err)
+				slog.ErrorContext(ctx, "get source info: list s3 objects", slog.String("error", err.Error()))
 				c.Status(http.StatusInternalServerError)
 				return
 			}
@@ -435,7 +439,7 @@ func GetSourceInfo(repo *repository.SourceRepository) gin.HandlerFunc {
 func DownloadSourceFile(sourceRepo *repository.SourceRepository) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		if sourceRepo == nil {
-			log.Print("download source file: repository is nil")
+			slog.ErrorContext(c.Request.Context(), "download source file: repository is nil")
 			c.Status(http.StatusServiceUnavailable)
 			return
 		}
@@ -466,7 +470,7 @@ func DownloadSourceFile(sourceRepo *repository.SourceRepository) gin.HandlerFunc
 				c.Status(http.StatusNotFound)
 				return
 			}
-			log.Printf("download source file: get source: %v", err)
+			slog.ErrorContext(c.Request.Context(), "download source file: get source", slog.String("error", err.Error()))
 			c.Status(http.StatusInternalServerError)
 			return
 		}
@@ -482,32 +486,32 @@ func DownloadSourceFile(sourceRepo *repository.SourceRepository) gin.HandlerFunc
 		case repository.SourceTypeGDrive:
 			cli, err := gdrive.NewClient(c.Request.Context(), []byte(src.Key))
 			if err != nil {
-				log.Printf("download source file: create gdrive client: %v", err)
+				slog.ErrorContext(c.Request.Context(), "download source file: create gdrive client", slog.String("error", err.Error()))
 				c.Status(http.StatusInternalServerError)
 				return
 			}
 			body, err = cli.Download(c.Request.Context(), fileID)
 			if err != nil {
-				log.Printf("download source file: gdrive download: %v", err)
+				slog.ErrorContext(c.Request.Context(), "download source file: gdrive download", slog.String("error", err.Error()))
 				c.Status(http.StatusInternalServerError)
 				return
 			}
 		case repository.SourceTypeS3:
 			cfg, err := s3compat.ParseConfig(src.Key)
 			if err != nil {
-				log.Printf("download source file: parse s3 config: %v", err)
+				slog.ErrorContext(c.Request.Context(), "download source file: parse s3 config", slog.String("error", err.Error()))
 				c.Status(http.StatusInternalServerError)
 				return
 			}
 			cli, err := s3compat.NewClient(c.Request.Context(), cfg)
 			if err != nil {
-				log.Printf("download source file: create s3 client: %v", err)
+				slog.ErrorContext(c.Request.Context(), "download source file: create s3 client", slog.String("error", err.Error()))
 				c.Status(http.StatusInternalServerError)
 				return
 			}
 			body, err = cli.Download(c.Request.Context(), fileID)
 			if err != nil {
-				log.Printf("download source file: s3 download: %v", err)
+				slog.ErrorContext(c.Request.Context(), "download source file: s3 download", slog.String("error", err.Error()))
 				c.Status(http.StatusInternalServerError)
 				return
 			}
@@ -521,7 +525,7 @@ func DownloadSourceFile(sourceRepo *repository.SourceRepository) gin.HandlerFunc
 		c.Header("Content-Type", "application/octet-stream")
 		c.Status(http.StatusOK)
 		if _, err := io.Copy(c.Writer, body); err != nil {
-			log.Printf("download source file: stream: %v", err)
+			slog.ErrorContext(c.Request.Context(), "download source file: stream", slog.String("error", err.Error()))
 		}
 	}
 }

--- a/api-go/internal/handlers/user.go
+++ b/api-go/internal/handlers/user.go
@@ -1,7 +1,7 @@
 package handlers
 
 import (
-	"log"
+	"log/slog"
 	"net/http"
 	"time"
 
@@ -75,26 +75,27 @@ type createUserResponse struct {
 // @Router /api/v1/users [post]
 func CreateUser(repo *repository.UserRepository) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		ctx := c.Request.Context()
 		var req createUserRequest
 		if err := c.ShouldBindJSON(&req); err != nil {
-			log.Printf("create user: invalid request: %v", err)
+			slog.WarnContext(ctx, "create user: invalid request", slog.String("error", err.Error()))
 			c.Status(http.StatusBadRequest)
 			return
 		}
 		if repo == nil {
-			log.Print("create user: repository is nil")
+			slog.ErrorContext(ctx, "create user: repository is nil")
 			c.Status(http.StatusServiceUnavailable)
 			return
 		}
 		password, err := generatePassword()
 		if err != nil {
-			log.Printf("create user: generate password: %v", err)
+			slog.ErrorContext(ctx, "create user: generate password", slog.String("error", err.Error()))
 			c.Status(http.StatusInternalServerError)
 			return
 		}
 		hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
 		if err != nil {
-			log.Printf("create user: failed to hash password: %v", err)
+			slog.ErrorContext(ctx, "create user: failed to hash password", slog.String("error", err.Error()))
 			c.Status(http.StatusInternalServerError)
 			return
 		}
@@ -106,11 +107,11 @@ func CreateUser(repo *repository.UserRepository) gin.HandlerFunc {
 		created, err := repo.Create(c.Request.Context(), user)
 		if err != nil {
 			if mongo.IsDuplicateKeyError(err) {
-				log.Printf("create user: username %s already exists: %v", req.Username, err)
+				slog.WarnContext(ctx, "create user: username already exists", slog.String("username", req.Username))
 				c.Status(http.StatusConflict)
 				return
 			}
-			log.Printf("create user: failed to create user: %v", err)
+			slog.ErrorContext(ctx, "create user: failed to create user", slog.String("error", err.Error()))
 			c.Status(http.StatusInternalServerError)
 			return
 		}

--- a/api-go/internal/observability/logger.go
+++ b/api-go/internal/observability/logger.go
@@ -1,0 +1,50 @@
+package observability
+
+import (
+	"context"
+	"log/slog"
+	"os"
+)
+
+type traceIDKey struct{}
+
+// ContextWithTraceID returns a new context with the given trace ID.
+func ContextWithTraceID(ctx context.Context, traceID string) context.Context {
+	return context.WithValue(ctx, traceIDKey{}, traceID)
+}
+
+// TraceIDFromContext extracts the trace ID from the context, or returns empty string.
+func TraceIDFromContext(ctx context.Context) string {
+	if v, ok := ctx.Value(traceIDKey{}).(string); ok {
+		return v
+	}
+	return ""
+}
+
+// traceHandler wraps an slog.Handler to automatically include trace_id from context.
+type traceHandler struct {
+	slog.Handler
+}
+
+func (h *traceHandler) Handle(ctx context.Context, r slog.Record) error {
+	if id := TraceIDFromContext(ctx); id != "" {
+		r.AddAttrs(slog.String("trace_id", id))
+	}
+	return h.Handler.Handle(ctx, r)
+}
+
+func (h *traceHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &traceHandler{h.Handler.WithAttrs(attrs)}
+}
+
+func (h *traceHandler) WithGroup(name string) slog.Handler {
+	return &traceHandler{h.Handler.WithGroup(name)}
+}
+
+// SetupLogger configures the global slog logger with JSON output and trace ID support.
+func SetupLogger() {
+	h := &traceHandler{slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	})}
+	slog.SetDefault(slog.New(h))
+}

--- a/api-go/internal/observability/logger_test.go
+++ b/api-go/internal/observability/logger_test.go
@@ -1,0 +1,18 @@
+package observability
+
+import (
+	"context"
+	"testing"
+)
+
+func TestTraceIDContext(t *testing.T) {
+	ctx := context.Background()
+	if got := TraceIDFromContext(ctx); got != "" {
+		t.Errorf("expected empty trace ID from background context, got %s", got)
+	}
+
+	ctx = ContextWithTraceID(ctx, "abc-123")
+	if got := TraceIDFromContext(ctx); got != "abc-123" {
+		t.Errorf("expected abc-123, got %s", got)
+	}
+}

--- a/api-go/internal/observability/metrics.go
+++ b/api-go/internal/observability/metrics.go
@@ -1,0 +1,61 @@
+package observability
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	HTTPRequestsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "http_requests_total",
+		Help: "Total number of HTTP requests.",
+	}, []string{"method", "path", "status"})
+
+	HTTPRequestDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "http_request_duration_seconds",
+		Help:    "HTTP request latency in seconds.",
+		Buckets: prometheus.DefBuckets,
+	}, []string{"method", "path"})
+
+	HTTPActiveRequests = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "http_active_requests",
+		Help: "Number of in-flight HTTP requests.",
+	})
+
+	ChunkUploadsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "chunk_uploads_total",
+		Help: "Total number of chunk upload operations.",
+	}, []string{"status"})
+
+	ChunkDownloadsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "chunk_downloads_total",
+		Help: "Total number of chunk download operations.",
+	}, []string{"status"})
+
+	ChunkDeletesTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "chunk_deletes_total",
+		Help: "Total number of chunk delete operations.",
+	}, []string{"status"})
+
+	ChunkBytesUploaded = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "chunk_bytes_uploaded_total",
+		Help: "Total bytes uploaded across all chunk operations.",
+	})
+
+	ChunkBytesDownloaded = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "chunk_bytes_downloaded_total",
+		Help: "Total bytes downloaded across all chunk operations.",
+	})
+)
+
+func init() {
+	prometheus.MustRegister(
+		HTTPRequestsTotal,
+		HTTPRequestDuration,
+		HTTPActiveRequests,
+		ChunkUploadsTotal,
+		ChunkDownloadsTotal,
+		ChunkDeletesTotal,
+		ChunkBytesUploaded,
+		ChunkBytesDownloaded,
+	)
+}

--- a/api-go/internal/observability/middleware.go
+++ b/api-go/internal/observability/middleware.go
@@ -1,0 +1,63 @@
+package observability
+
+import (
+	"fmt"
+	"log/slog"
+	"strconv"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+)
+
+const TraceIDHeader = "X-Trace-ID"
+
+// Middleware returns a Gin middleware that:
+// - generates a trace ID per request (or uses an incoming X-Trace-ID header)
+// - records Prometheus metrics (request count, latency, active connections)
+// - emits a structured JSON log line per request
+func Middleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		traceID := c.GetHeader(TraceIDHeader)
+		if traceID == "" {
+			traceID = uuid.New().String()
+		}
+		c.Header(TraceIDHeader, traceID)
+
+		ctx := ContextWithTraceID(c.Request.Context(), traceID)
+		c.Request = c.Request.WithContext(ctx)
+
+		path := normalizedPath(c)
+
+		HTTPActiveRequests.Inc()
+		start := time.Now()
+
+		c.Next()
+
+		duration := time.Since(start)
+		status := c.Writer.Status()
+		statusStr := strconv.Itoa(status)
+
+		HTTPActiveRequests.Dec()
+		HTTPRequestsTotal.WithLabelValues(c.Request.Method, path, statusStr).Inc()
+		HTTPRequestDuration.WithLabelValues(c.Request.Method, path).Observe(duration.Seconds())
+
+		slog.InfoContext(ctx, "request",
+			slog.String("method", c.Request.Method),
+			slog.String("path", c.Request.URL.Path),
+			slog.Int("status", status),
+			slog.String("duration", fmt.Sprintf("%.3fms", float64(duration.Microseconds())/1000)),
+			slog.String("client_ip", c.ClientIP()),
+		)
+	}
+}
+
+// normalizedPath returns the route template (e.g. /api/v1/buckets/:id) to avoid
+// high-cardinality label values in Prometheus metrics.
+func normalizedPath(c *gin.Context) string {
+	route := c.FullPath()
+	if route == "" {
+		return "unmatched"
+	}
+	return route
+}

--- a/api-go/internal/observability/middleware_test.go
+++ b/api-go/internal/observability/middleware_test.go
@@ -1,0 +1,73 @@
+package observability
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestMiddleware_SetsTraceIDHeader(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(Middleware())
+	r.GET("/ping", func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+
+	req, _ := http.NewRequest(http.MethodGet, "/ping", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	traceID := w.Header().Get(TraceIDHeader)
+	if traceID == "" {
+		t.Error("expected X-Trace-ID header to be set")
+	}
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestMiddleware_PreservesIncomingTraceID(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(Middleware())
+	r.GET("/ping", func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+
+	req, _ := http.NewRequest(http.MethodGet, "/ping", nil)
+	req.Header.Set(TraceIDHeader, "my-trace-123")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	traceID := w.Header().Get(TraceIDHeader)
+	if traceID != "my-trace-123" {
+		t.Errorf("expected trace ID to be preserved, got %s", traceID)
+	}
+}
+
+func TestMiddleware_TraceIDInContext(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(Middleware())
+
+	var gotTraceID string
+	r.GET("/ping", func(c *gin.Context) {
+		gotTraceID = TraceIDFromContext(c.Request.Context())
+		c.Status(http.StatusOK)
+	})
+
+	req, _ := http.NewRequest(http.MethodGet, "/ping", nil)
+	req.Header.Set(TraceIDHeader, "ctx-trace-456")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if gotTraceID != "ctx-trace-456" {
+		t.Errorf("expected trace ID in context to be ctx-trace-456, got %s", gotTraceID)
+	}
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+}

--- a/api-go/prometheus.yml
+++ b/api-go/prometheus.yml
@@ -1,0 +1,8 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: sfree-api
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["host.docker.internal:8080"]


### PR DESCRIPTION
## Summary

- Adds `internal/observability` package with Gin middleware for Prometheus metrics (request count, latency histograms, active connections, chunk operation counters) and structured JSON request logging
- Generates `X-Trace-ID` per request (propagates incoming header if present), included in all log context and response headers
- Replaces all stdlib `log.Print`/`log.Printf` calls with `log/slog` structured logging across every handler file
- Adds `prometheus.yml` scrape config and optional Prometheus service in `docker-compose.yml`

Closes #92, #93, #5

## What now works

- `GET /metrics` returns Prometheus exposition format with HTTP request metrics, active connections, and chunk operation counters
- All API requests produce structured JSON log lines with trace ID, method, path, status, duration, and client IP
- `X-Trace-ID` response header on every request for request correlation

## What remains limited

- No Grafana dashboards (out of scope per task definition)
- Chunk operation metrics (`chunk_uploads_total`, etc.) are registered but not yet incremented from the upload/download pipeline — wiring those counters into `manager.UploadFileChunks`/`StreamFile` is a follow-up
- Go not available in CI-less dev environment, so tests verified by code review only; CI pipeline will validate on PR

## Test plan

- [ ] CI pipeline runs e2e tests successfully
- [ ] `GET /metrics` returns valid Prometheus format
- [ ] Request logs are structured JSON with `trace_id` field
- [ ] `X-Trace-ID` header present in responses
- [ ] Incoming `X-Trace-ID` header is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)