### PR TITLE
Add GitHub OAuth authentication

### DIFF
--- a/api-go/config/local.yaml
+++ b/api-go/config/local.yaml
@@ -7,3 +7,9 @@ mongo:
 upload:
   chunk_size: 5242880
 access_secret_key: examplesecret
+jwt_secret: ""
+github_oauth:
+  client_id: ""
+  client_secret: ""
+  redirect_url: "http://localhost:8080/api/v1/auth/github/callback"
+frontend_url: "http://localhost:3000"

--- a/api-go/go.mod
+++ b/api-go/go.mod
@@ -24,10 +24,10 @@ require (
 	github.com/KyleBanks/depth v1.2.1 // indirect
 	github.com/PuerkitoBio/purell v1.1.1 // indirect
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
-	github.com/aws/aws-sdk-go-v2 v1.41.1 // indirect
+	github.com/aws/aws-sdk-go-v2 v1.41.1
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.4 // indirect
-	github.com/aws/aws-sdk-go-v2/config v1.32.9 // indirect
-	github.com/aws/aws-sdk-go-v2/credentials v1.19.9 // indirect
+	github.com/aws/aws-sdk-go-v2/config v1.32.9
+	github.com/aws/aws-sdk-go-v2/credentials v1.19.9
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.17 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.17 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.17 // indirect
@@ -37,7 +37,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.8 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.17 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.17 // indirect
-	github.com/aws/aws-sdk-go-v2/service/s3 v1.96.0 // indirect
+	github.com/aws/aws-sdk-go-v2/service/s3 v1.96.0
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.10 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.14 // indirect
@@ -95,7 +95,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.36.0 // indirect
 	golang.org/x/arch v0.8.0 // indirect
 	golang.org/x/net v0.43.0 // indirect
-	golang.org/x/oauth2 v0.30.0
 	golang.org/x/sync v0.16.0 // indirect
 	golang.org/x/sys v0.35.0 // indirect
 	golang.org/x/text v0.28.0 // indirect

--- a/api-go/go.mod
+++ b/api-go/go.mod
@@ -5,12 +5,14 @@ go 1.24.0
 require (
 	github.com/gin-contrib/cors v1.5.0
 	github.com/gin-gonic/gin v1.10.1
+	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/prometheus/client_golang v1.22.0
 	github.com/swaggo/files v1.0.1
 	github.com/swaggo/gin-swagger v1.6.0
 	github.com/swaggo/swag v1.16.4
 	go.mongodb.org/mongo-driver v1.15.0
 	golang.org/x/crypto v0.41.0
+	golang.org/x/oauth2 v0.30.0
 	google.golang.org/api v0.248.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -93,7 +95,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.36.0 // indirect
 	golang.org/x/arch v0.8.0 // indirect
 	golang.org/x/net v0.43.0 // indirect
-	golang.org/x/oauth2 v0.30.0 // indirect
+	golang.org/x/oauth2 v0.30.0
 	golang.org/x/sync v0.16.0 // indirect
 	golang.org/x/sys v0.35.0 // indirect
 	golang.org/x/text v0.28.0 // indirect

--- a/api-go/go.sum
+++ b/api-go/go.sum
@@ -101,6 +101,8 @@ github.com/go-playground/validator/v10 v10.20.0 h1:K9ISHbSaI0lyB2eWMPJo+kOS/FBEx
 github.com/go-playground/validator/v10 v10.20.0/go.mod h1:dbuPbCMFw/DrkbEynArYaCwl3amGuJotoKCe95atGMM=
 github.com/goccy/go-json v0.10.2 h1:CrxCmQqYDkv1z7lO7Wbh2HN93uovUHgrECaO5ZrCXAU=
 github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
+github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
+github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/golang/snappy v0.0.1 h1:Qgr9rKW7uDUkrbSmQeiDsGa8SjGyCOGtuasMWwvp2P4=

--- a/api-go/internal/app/router.go
+++ b/api-go/internal/app/router.go
@@ -28,19 +28,40 @@ func SetupRouter(m *db.Mongo, cfg *config.Config) *gin.Engine {
 
 	var (
 		auth       gin.HandlerFunc
+		userRepo   *repository.UserRepository
 		bucketRepo *repository.BucketRepository
 		sourceRepo *repository.SourceRepository
 		fileRepo   *repository.FileRepository
 	)
 
+	jwtSecret := ""
+	if cfg != nil {
+		jwtSecret = cfg.JWTSecret
+		if jwtSecret == "" {
+			jwtSecret = cfg.AccessSecretKey
+		}
+	}
+
 	if m != nil {
-		if userRepo, err := repository.NewUserRepository(m.DB); err == nil {
-			auth = handlers.BasicAuth(userRepo)
+		var err error
+		userRepo, err = repository.NewUserRepository(m.DB)
+		if err == nil {
+			auth = handlers.Auth(userRepo, jwtSecret)
 			router.POST("/api/v1/users", handlers.CreateUser(userRepo))
 		}
 		bucketRepo, _ = repository.NewBucketRepository(m.DB)
 		sourceRepo, _ = repository.NewSourceRepository(m.DB)
 		fileRepo, _ = repository.NewFileRepository(m.DB)
+	}
+
+	// OAuth and auth utility routes.
+	if cfg != nil && userRepo != nil {
+		router.GET("/api/v1/auth/github", handlers.GitHubLogin(cfg))
+		router.GET("/api/v1/auth/github/callback", handlers.GitHubCallback(cfg, userRepo))
+		if auth != nil {
+			router.GET("/api/v1/auth/me", auth, handlers.GetCurrentUser(userRepo))
+			router.POST("/api/v1/auth/token", auth, handlers.TokenLogin(cfg, userRepo))
+		}
 	}
 
 	if auth != nil && bucketRepo != nil {

--- a/api-go/internal/config/config.go
+++ b/api-go/internal/config/config.go
@@ -22,10 +22,19 @@ type UploadConfig struct {
 	ChunkSize int `yaml:"chunk_size"`
 }
 
+type GitHubOAuthConfig struct {
+	ClientID     string `yaml:"client_id"`
+	ClientSecret string `yaml:"client_secret"`
+	RedirectURL  string `yaml:"redirect_url"`
+}
+
 type Config struct {
-	Mongo           MongoConfig  `yaml:"mongo"`
-	Upload          UploadConfig `yaml:"upload"`
-	AccessSecretKey string       `yaml:"access_secret_key"`
+	Mongo           MongoConfig      `yaml:"mongo"`
+	Upload          UploadConfig     `yaml:"upload"`
+	AccessSecretKey string           `yaml:"access_secret_key"`
+	JWTSecret       string           `yaml:"jwt_secret"`
+	GitHubOAuth     GitHubOAuthConfig `yaml:"github_oauth"`
+	FrontendURL     string           `yaml:"frontend_url"`
 }
 
 func Load() (*Config, error) {
@@ -73,5 +82,20 @@ func overrideEnv(cfg *Config) {
 	}
 	if v := os.Getenv("ACCESS_SECRET_KEY"); v != "" {
 		cfg.AccessSecretKey = v
+	}
+	if v := os.Getenv("JWT_SECRET"); v != "" {
+		cfg.JWTSecret = v
+	}
+	if v := os.Getenv("GITHUB_CLIENT_ID"); v != "" {
+		cfg.GitHubOAuth.ClientID = v
+	}
+	if v := os.Getenv("GITHUB_CLIENT_SECRET"); v != "" {
+		cfg.GitHubOAuth.ClientSecret = v
+	}
+	if v := os.Getenv("GITHUB_REDIRECT_URL"); v != "" {
+		cfg.GitHubOAuth.RedirectURL = v
+	}
+	if v := os.Getenv("FRONTEND_URL"); v != "" {
+		cfg.FrontendURL = v
 	}
 }

--- a/api-go/internal/handlers/auth.go
+++ b/api-go/internal/handlers/auth.go
@@ -3,16 +3,61 @@ package handlers
 import (
 	"log"
 	"net/http"
+	"strings"
 
 	"github.com/example/sfree/api-go/internal/repository"
 	"github.com/gin-gonic/gin"
+	"github.com/golang-jwt/jwt/v5"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 	"golang.org/x/crypto/bcrypt"
 )
 
-// BasicAuth is a middleware that validates HTTP Basic credentials and sets the user ID in context.
-func BasicAuth(repo *repository.UserRepository) gin.HandlerFunc {
+// Auth returns a middleware that accepts both HTTP Basic Auth and Bearer JWT tokens.
+// If a valid Bearer token is present it takes precedence over Basic Auth.
+func Auth(repo *repository.UserRepository, jwtSecret string) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		authHeader := c.GetHeader("Authorization")
+
+		// Try Bearer JWT first.
+		if strings.HasPrefix(authHeader, "Bearer ") {
+			tokenStr := strings.TrimPrefix(authHeader, "Bearer ")
+			token, err := jwt.Parse(tokenStr, func(t *jwt.Token) (interface{}, error) {
+				if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
+					return nil, jwt.ErrSignatureInvalid
+				}
+				return []byte(jwtSecret), nil
+			})
+			if err != nil || !token.Valid {
+				c.AbortWithStatus(http.StatusUnauthorized)
+				return
+			}
+			claims, ok := token.Claims.(jwt.MapClaims)
+			if !ok {
+				c.AbortWithStatus(http.StatusUnauthorized)
+				return
+			}
+			sub, _ := claims.GetSubject()
+			if sub == "" {
+				c.AbortWithStatus(http.StatusUnauthorized)
+				return
+			}
+			// Validate that the user still exists.
+			oid, err := primitive.ObjectIDFromHex(sub)
+			if err != nil {
+				c.AbortWithStatus(http.StatusUnauthorized)
+				return
+			}
+			if _, err := repo.GetByID(c.Request.Context(), oid); err != nil {
+				c.AbortWithStatus(http.StatusUnauthorized)
+				return
+			}
+			c.Set("userID", sub)
+			c.Next()
+			return
+		}
+
+		// Fall back to Basic Auth.
 		username, password, ok := c.Request.BasicAuth()
 		if !ok {
 			c.Header("WWW-Authenticate", `Basic realm="restricted"`)
@@ -20,7 +65,7 @@ func BasicAuth(repo *repository.UserRepository) gin.HandlerFunc {
 			return
 		}
 		if repo == nil {
-			log.Print("basic auth: user repository is nil")
+			log.Print("auth: user repository is nil")
 			c.AbortWithStatus(http.StatusServiceUnavailable)
 			return
 		}
@@ -30,15 +75,20 @@ func BasicAuth(repo *repository.UserRepository) gin.HandlerFunc {
 				c.AbortWithStatus(http.StatusUnauthorized)
 				return
 			}
-			log.Printf("basic auth: failed to get user: %v", err)
+			log.Printf("auth: failed to get user: %v", err)
 			c.AbortWithStatus(http.StatusInternalServerError)
 			return
 		}
-		if bcrypt.CompareHashAndPassword([]byte(user.PasswordHash), []byte(password)) != nil {
+		if user.PasswordHash == "" || bcrypt.CompareHashAndPassword([]byte(user.PasswordHash), []byte(password)) != nil {
 			c.AbortWithStatus(http.StatusUnauthorized)
 			return
 		}
 		c.Set("userID", user.ID.Hex())
 		c.Next()
 	}
+}
+
+// BasicAuth is kept for backward compatibility. Prefer Auth() for new routes.
+func BasicAuth(repo *repository.UserRepository) gin.HandlerFunc {
+	return Auth(repo, "")
 }

--- a/api-go/internal/handlers/oauth.go
+++ b/api-go/internal/handlers/oauth.go
@@ -1,0 +1,167 @@
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/example/sfree/api-go/internal/config"
+	"github.com/example/sfree/api-go/internal/repository"
+	"github.com/gin-gonic/gin"
+	"github.com/golang-jwt/jwt/v5"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/github"
+)
+
+func newGitHubOAuthConfig(cfg *config.Config) *oauth2.Config {
+	return &oauth2.Config{
+		ClientID:     cfg.GitHubOAuth.ClientID,
+		ClientSecret: cfg.GitHubOAuth.ClientSecret,
+		RedirectURL:  cfg.GitHubOAuth.RedirectURL,
+		Scopes:       []string{"read:user"},
+		Endpoint:     github.Endpoint,
+	}
+}
+
+// GitHubLogin redirects the user to GitHub's OAuth consent page.
+func GitHubLogin(cfg *config.Config) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if cfg.GitHubOAuth.ClientID == "" {
+			c.JSON(http.StatusNotImplemented, gin.H{"error": "GitHub OAuth is not configured"})
+			return
+		}
+		oauthCfg := newGitHubOAuthConfig(cfg)
+		state, err := generatePassword()
+		if err != nil {
+			c.Status(http.StatusInternalServerError)
+			return
+		}
+		c.SetCookie("oauth_state", state, 600, "/", "", false, true)
+		c.Redirect(http.StatusTemporaryRedirect, oauthCfg.AuthCodeURL(state))
+	}
+}
+
+type githubUser struct {
+	ID        int64  `json:"id"`
+	Login     string `json:"login"`
+	AvatarURL string `json:"avatar_url"`
+}
+
+// GitHubCallback handles the OAuth callback from GitHub.
+func GitHubCallback(cfg *config.Config, userRepo *repository.UserRepository) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		savedState, err := c.Cookie("oauth_state")
+		if err != nil || savedState == "" || c.Query("state") != savedState {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid oauth state"})
+			return
+		}
+
+		oauthCfg := newGitHubOAuthConfig(cfg)
+		token, err := oauthCfg.Exchange(c.Request.Context(), c.Query("code"))
+		if err != nil {
+			log.Printf("oauth callback: token exchange failed: %v", err)
+			c.JSON(http.StatusBadRequest, gin.H{"error": "failed to exchange code"})
+			return
+		}
+
+		client := oauthCfg.Client(c.Request.Context(), token)
+		resp, err := client.Get("https://api.github.com/user")
+		if err != nil {
+			log.Printf("oauth callback: github user fetch failed: %v", err)
+			c.Status(http.StatusInternalServerError)
+			return
+		}
+		defer resp.Body.Close()
+
+		var ghUser githubUser
+		if err := json.NewDecoder(resp.Body).Decode(&ghUser); err != nil {
+			log.Printf("oauth callback: failed to decode github user: %v", err)
+			c.Status(http.StatusInternalServerError)
+			return
+		}
+
+		// Find or create user by GitHub ID.
+		user, err := userRepo.GetByGitHubID(c.Request.Context(), ghUser.ID)
+		if err != nil {
+			// User not found — create a new one.
+			newUser := repository.User{
+				Username:  ghUser.Login,
+				GitHubID:  ghUser.ID,
+				AvatarURL: ghUser.AvatarURL,
+				CreatedAt: time.Now().UTC(),
+			}
+			user, err = userRepo.Create(c.Request.Context(), newUser)
+			if err != nil {
+				// Username conflict — try with GitHub ID suffix.
+				newUser.Username = fmt.Sprintf("%s-%d", ghUser.Login, ghUser.ID)
+				user, err = userRepo.Create(c.Request.Context(), newUser)
+				if err != nil {
+					log.Printf("oauth callback: failed to create user: %v", err)
+					c.Status(http.StatusInternalServerError)
+					return
+				}
+			}
+		}
+
+		// Issue JWT.
+		jwtSecret := cfg.JWTSecret
+		if jwtSecret == "" {
+			jwtSecret = cfg.AccessSecretKey
+		}
+		jwtToken, err := IssueJWT(user.ID.Hex(), jwtSecret)
+		if err != nil {
+			log.Printf("oauth callback: failed to issue jwt: %v", err)
+			c.Status(http.StatusInternalServerError)
+			return
+		}
+
+		// Redirect to frontend OAuth callback page with token.
+		frontendURL := cfg.FrontendURL
+		if frontendURL == "" {
+			frontendURL = ""
+		}
+		redirectURL, _ := url.Parse(frontendURL + "/auth/callback")
+		q := redirectURL.Query()
+		q.Set("token", jwtToken)
+		q.Set("username", user.Username)
+		redirectURL.RawQuery = q.Encode()
+
+		c.Redirect(http.StatusTemporaryRedirect, redirectURL.String())
+	}
+}
+
+// IssueJWT creates a signed JWT for the given user ID.
+func IssueJWT(userID string, secret string) (string, error) {
+	claims := jwt.MapClaims{
+		"sub": userID,
+		"iat": time.Now().Unix(),
+		"exp": time.Now().Add(7 * 24 * time.Hour).Unix(),
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	return token.SignedString([]byte(secret))
+}
+
+// TokenLogin issues a JWT for an existing Basic Auth session.
+func TokenLogin(cfg *config.Config, userRepo *repository.UserRepository) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		userIDHex := c.GetString("userID")
+		if userIDHex == "" {
+			c.Status(http.StatusUnauthorized)
+			return
+		}
+		jwtSecret := cfg.JWTSecret
+		if jwtSecret == "" {
+			jwtSecret = cfg.AccessSecretKey
+		}
+		token, err := IssueJWT(userIDHex, jwtSecret)
+		if err != nil {
+			log.Printf("token login: failed to issue jwt: %v", err)
+			c.Status(http.StatusInternalServerError)
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"token": token})
+	}
+}

--- a/api-go/internal/handlers/user.go
+++ b/api-go/internal/handlers/user.go
@@ -8,11 +8,46 @@ import (
 	"github.com/example/sfree/api-go/internal/cryptoutil"
 	"github.com/example/sfree/api-go/internal/repository"
 	"github.com/gin-gonic/gin"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 	"golang.org/x/crypto/bcrypt"
 )
 
 const passwordLength = 12
+
+type currentUserResponse struct {
+	ID        string `json:"id"`
+	Username  string `json:"username"`
+	AvatarURL string `json:"avatar_url,omitempty"`
+	GitHubID  int64  `json:"github_id,omitempty"`
+}
+
+// GetCurrentUser returns the profile of the authenticated user.
+func GetCurrentUser(repo *repository.UserRepository) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		userIDHex := c.GetString("userID")
+		if userIDHex == "" {
+			c.Status(http.StatusUnauthorized)
+			return
+		}
+		oid, err := primitive.ObjectIDFromHex(userIDHex)
+		if err != nil {
+			c.Status(http.StatusUnauthorized)
+			return
+		}
+		user, err := repo.GetByID(c.Request.Context(), oid)
+		if err != nil {
+			c.Status(http.StatusUnauthorized)
+			return
+		}
+		c.JSON(http.StatusOK, currentUserResponse{
+			ID:        user.ID.Hex(),
+			Username:  user.Username,
+			AvatarURL: user.AvatarURL,
+			GitHubID:  user.GitHubID,
+		})
+	}
+}
 
 func generatePassword() (string, error) {
 	return cryptoutil.RandomString(passwordLength)

--- a/api-go/internal/repository/user.go
+++ b/api-go/internal/repository/user.go
@@ -10,11 +10,13 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
-// User represents basic auth user
+// User represents an authenticated user (basic auth or OAuth).
 type User struct {
 	ID           primitive.ObjectID `bson:"_id,omitempty"`
 	Username     string             `bson:"username"`
-	PasswordHash string             `bson:"password_hash"`
+	PasswordHash string             `bson:"password_hash,omitempty"`
+	GitHubID     int64              `bson:"github_id,omitempty"`
+	AvatarURL    string             `bson:"avatar_url,omitempty"`
 	CreatedAt    time.Time          `bson:"created_at"`
 }
 
@@ -49,6 +51,24 @@ func (r *UserRepository) Create(ctx context.Context, user User) (*User, error) {
 func (r *UserRepository) GetByUsername(ctx context.Context, username string) (*User, error) {
 	var u User
 	err := r.coll.FindOne(ctx, bson.M{"username": username}).Decode(&u)
+	if err != nil {
+		return nil, err
+	}
+	return &u, nil
+}
+
+func (r *UserRepository) GetByGitHubID(ctx context.Context, githubID int64) (*User, error) {
+	var u User
+	err := r.coll.FindOne(ctx, bson.M{"github_id": githubID}).Decode(&u)
+	if err != nil {
+		return nil, err
+	}
+	return &u, nil
+}
+
+func (r *UserRepository) GetByID(ctx context.Context, id primitive.ObjectID) (*User, error) {
+	var u User
+	err := r.coll.FindOne(ctx, bson.M{"_id": id}).Decode(&u)
 	if err != nil {
 		return nil, err
 	}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,10 @@ services:
       DB_PASSWORD: example
       DB_NAME: sfree
       ACCESS_SECRET_KEY: examplesecret
+      GITHUB_CLIENT_ID: "${GITHUB_CLIENT_ID:-}"
+      GITHUB_CLIENT_SECRET: "${GITHUB_CLIENT_SECRET:-}"
+      GITHUB_REDIRECT_URL: "http://localhost:8080/api/v1/auth/github/callback"
+      FRONTEND_URL: "http://localhost:3000"
     depends_on:
       - mongo
     ports:

--- a/webui/src/app/index.tsx
+++ b/webui/src/app/index.tsx
@@ -5,17 +5,18 @@ import BucketsPage from "../pages/buckets";
 import BucketPage from "../pages/bucket";
 import SourcesPage from "../pages/sources";
 import SourcePage from "../pages/source";
+import {OAuthCallback} from "../pages/auth-callback";
+import {isAuthenticated} from "../shared/lib/auth";
 
 export default function App() {
-  const isAuthenticated = Boolean(localStorage.getItem("auth"));
-
   return (
     <BrowserRouter>
       <Routes>
         <Route
           path="/"
-          element={isAuthenticated ? <Navigate to="/dashboard" replace /> : <LandingPage />}
+          element={isAuthenticated() ? <Navigate to="/dashboard" replace /> : <LandingPage />}
         />
+        <Route path="/auth/callback" element={<OAuthCallback />} />
         <Route path="/dashboard" element={<DashboardPage />} />
         <Route path="/buckets" element={<BucketsPage />} />
         <Route path="/buckets/:id" element={<BucketPage />} />

--- a/webui/src/pages/auth-callback/index.tsx
+++ b/webui/src/pages/auth-callback/index.tsx
@@ -1,0 +1,21 @@
+import {useEffect} from "react";
+import {useNavigate, useSearchParams} from "react-router-dom";
+import {saveTokenAuth} from "../../shared/lib/auth";
+
+export function OAuthCallback() {
+  const [params] = useSearchParams();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const token = params.get("token");
+    const username = params.get("username");
+    if (token && username) {
+      saveTokenAuth(token, username);
+      navigate("/dashboard", {replace: true});
+    } else {
+      navigate("/", {replace: true});
+    }
+  }, [params, navigate]);
+
+  return <div className="flex items-center justify-center min-h-screen">Signing in...</div>;
+}

--- a/webui/src/pages/landing/ui/landing-page.tsx
+++ b/webui/src/pages/landing/ui/landing-page.tsx
@@ -56,8 +56,17 @@ export function LandingPage() {
           object store. Upload once — SFree splits, distributes, and reassembles.
         </p>
         <div className="flex flex-wrap gap-4 mt-10 justify-center">
-          <Button color="primary" size="lg" onPress={register.onOpen}>
-            Get Started
+          <Button
+            color="primary"
+            size="lg"
+            as="a"
+            href={(import.meta.env.VITE_API_BASE || "/api/v1") + "/auth/github"}
+            startContent={<GitHubIcon className="w-5 h-5 fill-current" />}
+          >
+            Sign in with GitHub
+          </Button>
+          <Button color="primary" size="lg" variant="bordered" onPress={register.onOpen}>
+            Sign Up
           </Button>
           <Button
             variant="bordered"
@@ -134,7 +143,16 @@ export function LandingPage() {
       <section className="flex flex-col items-center px-6 pt-16 pb-24 text-center gap-6">
         <h2 className="text-2xl font-bold">Ready to unify your storage?</h2>
         <div className="flex flex-wrap gap-4 justify-center">
-          <Button color="primary" size="lg" onPress={register.onOpen}>
+          <Button
+            color="primary"
+            size="lg"
+            as="a"
+            href={(import.meta.env.VITE_API_BASE || "/api/v1") + "/auth/github"}
+            startContent={<GitHubIcon className="w-5 h-5 fill-current" />}
+          >
+            Sign in with GitHub
+          </Button>
+          <Button color="primary" size="lg" variant="bordered" onPress={register.onOpen}>
             Sign Up
           </Button>
           <Button variant="bordered" size="lg" onPress={login.onOpen}>

--- a/webui/src/shared/api/buckets.ts
+++ b/webui/src/shared/api/buckets.ts
@@ -14,9 +14,10 @@ export type FileInfo = {
   size: number;
 };
 
+import { getAuthHeader } from "../lib/auth";
+
 function authHeader(): Record<string, string> {
-  const auth = localStorage.getItem("auth");
-  return auth ? { Authorization: `Basic ${auth}` } : {};
+  return getAuthHeader();
 }
 
 export async function listBuckets(): Promise<Bucket[]> {

--- a/webui/src/shared/api/sources.ts
+++ b/webui/src/shared/api/sources.ts
@@ -14,9 +14,10 @@ export type SourceInfo = {
   storage_free: number;
 };
 
+import { getAuthHeader } from "../lib/auth";
+
 function authHeader(): Record<string, string> {
-  const auth = localStorage.getItem("auth");
-  return auth ? {Authorization: `Basic ${auth}`} : {};
+  return getAuthHeader();
 }
 
 export async function listSources(): Promise<Source[]> {

--- a/webui/src/shared/lib/auth.ts
+++ b/webui/src/shared/lib/auth.ts
@@ -1,3 +1,30 @@
 export function saveAuth(username: string, password: string) {
   localStorage.setItem("auth", btoa(`${username}:${password}`));
+  localStorage.setItem("auth_type", "basic");
+}
+
+export function saveTokenAuth(token: string, username: string) {
+  localStorage.setItem("auth", token);
+  localStorage.setItem("auth_type", "bearer");
+  localStorage.setItem("username", username);
+}
+
+export function getAuthHeader(): Record<string, string> {
+  const auth = localStorage.getItem("auth");
+  if (!auth) return {};
+  const type = localStorage.getItem("auth_type");
+  if (type === "bearer") {
+    return { Authorization: `Bearer ${auth}` };
+  }
+  return { Authorization: `Basic ${auth}` };
+}
+
+export function isAuthenticated(): boolean {
+  return Boolean(localStorage.getItem("auth"));
+}
+
+export function logout() {
+  localStorage.removeItem("auth");
+  localStorage.removeItem("auth_type");
+  localStorage.removeItem("username");
 }


### PR DESCRIPTION
## Summary

- Add GitHub OAuth login flow alongside existing HTTP Basic Auth
- Dual auth middleware accepts both Bearer JWT tokens and Basic Auth credentials
- New "Sign in with GitHub" button on landing page
- OAuth callback page handles redirect and stores JWT token
- User model extended with optional GitHub ID and avatar URL
- All existing Basic Auth flows continue to work unchanged

## New Endpoints

| Route | Method | Auth | Purpose |
| --- | --- | --- | --- |
| `/api/v1/auth/github` | GET | None | Redirects to GitHub OAuth consent |
| `/api/v1/auth/github/callback` | GET | None | Handles OAuth callback, creates/finds user, issues JWT, redirects to frontend |
| `/api/v1/auth/me` | GET | Required | Returns current user profile |
| `/api/v1/auth/token` | POST | Basic | Exchanges Basic Auth credentials for JWT token |

## Configuration

New environment variables (all optional — OAuth is disabled when `GITHUB_CLIENT_ID` is empty):
- `GITHUB_CLIENT_ID` / `GITHUB_CLIENT_SECRET` — GitHub OAuth app credentials
- `GITHUB_REDIRECT_URL` — OAuth callback URL (default: `http://localhost:8080/api/v1/auth/github/callback`)
- `FRONTEND_URL` — Where to redirect after OAuth (default: `http://localhost:3000`)
- `JWT_SECRET` — Secret for signing JWTs (falls back to `ACCESS_SECRET_KEY`)

## Post-merge note

Run `go mod tidy` to regenerate `go.sum` after merging (adds `github.com/golang-jwt/jwt/v5`).

## Test plan

- [ ] Verify existing Basic Auth signup/login flow still works
- [ ] Configure GitHub OAuth app, set env vars, verify "Sign in with GitHub" redirects correctly
- [ ] Verify OAuth callback creates new user and redirects to dashboard with valid JWT
- [ ] Verify returning OAuth user finds existing account by GitHub ID
- [ ] Verify `/api/v1/auth/me` returns user profile with valid JWT
- [ ] Verify protected endpoints accept Bearer JWT tokens
- [ ] Verify frontend lint (`npm run lint`) and build (`npm run build`) pass

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)