### PR TITLE
Polish developer docs and contributor onboarding

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,12 +13,14 @@ current launch boundaries documented in [README.md](README.md) and
 
 ## Repository Ground Rules
 
-- `api-go/` is the primary backend. New backend features belong there.
-- `api/` is deprecated. Do not add new behavior there unless an issue explicitly
-  asks for legacy Python API work.
-- Woodpecker self-hosted is the only supported CI/CD path for this repository.
-  Do not add GitHub Actions workflows. Pipeline triggers, required secrets, and
-  published image targets are documented in [docs/ci.md](docs/ci.md).
+- **`api-go/` is the primary backend.** New backend features belong there.
+- **`api/` is deprecated.** Do not add new behavior there unless an issue
+  explicitly asks for legacy Python API work. See [`api/README.md`](api/README.md)
+  for details.
+- **Woodpecker self-hosted** is the only supported CI/CD path for this
+  repository. Do not add GitHub Actions workflows. Pipeline triggers, required
+  secrets, and published image targets are documented in
+  [docs/ci.md](docs/ci.md).
 - Preserve the current public caveats:
   - backend-supported sources are Google Drive, Telegram, and S3-compatible
     storage
@@ -29,13 +31,14 @@ current launch boundaries documented in [README.md](README.md) and
 
 ## Local Setup
 
-### Backend
+### Backend (Go)
 
 Prerequisites:
 
 - Go 1.24+
 - Docker, or another reachable MongoDB instance
-- `golangci-lint` for the standard lint pass
+- [`golangci-lint`](https://golangci-lint.run/welcome/install/) for the
+  standard lint pass
 
 Start local MongoDB:
 
@@ -53,29 +56,41 @@ ENV=local go run ./cmd/server
 
 Swagger is served from `http://localhost:8080/swagger/index.html`.
 
-### Frontend
+### Frontend (React / Vite)
 
 Prerequisites:
 
-- A recent Node.js release with npm
+- Node.js 20+ with npm
 
-Install dependencies and start Vite:
+Install **all** dependencies (including dev tools like TypeScript and ESLint)
+and start the dev server:
 
 ```bash
 cd webui
-npm install
+npm ci
 npm run dev
 ```
+
+> **Why `npm ci` instead of `npm install`?** `npm ci` installs from the
+> lockfile for deterministic builds and includes dev dependencies by default.
+> Avoid running with `NODE_ENV=production`, which omits `devDependencies` and
+> breaks `npm run lint` and `npm run build` (they need `tsc` and `eslint`).
 
 The frontend reads `VITE_API_BASE` at build time (defaults to `/api/v1`).
 For local development against the Docker Compose stack no changes are needed;
 the webui container proxies API requests to the backend automatically.
 
+For standalone dev against a local Go API:
+
+```bash
+VITE_API_BASE=http://localhost:8080/api/v1 npm run dev
+```
+
 ## Validation
 
 Run the checks that match the area you changed before opening a PR.
 
-Backend:
+### Backend
 
 ```bash
 cd api-go
@@ -83,15 +98,19 @@ golangci-lint run
 go test ./...
 ```
 
-Frontend:
+### Frontend
 
 ```bash
 cd webui
-npm run lint
-npm run build
+npm ci           # ensure deps are installed from lockfile
+npm run lint     # ESLint
+npm run build    # TypeScript type-check + Vite production build
 ```
 
-Optional E2E coverage:
+Both `lint` and `build` must pass — this matches what Woodpecker CI runs on
+pull requests (see [docs/ci.md](docs/ci.md)).
+
+### Optional: E2E Tests
 
 ```bash
 cd api-go

--- a/README.md
+++ b/README.md
@@ -3,33 +3,35 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE.txt)
 [![Go 1.24](https://img.shields.io/badge/Go-1.24-00ADD8.svg)](https://go.dev/)
 
-**Store files across Google Drive, Telegram, and S3-compatible services — access
-them through one API or an S3-compatible interface.**
+**One object store across Google Drive, Telegram, and any S3-compatible
+service — with a REST API, S3-compatible endpoint, and browser UI.**
 
 ## Why SFree
 
 Cloud storage is cheap in pieces — a free Google Drive here, a Telegram bot
-there, a MinIO bucket on a spare VPS. But using them together is a manual mess.
+there, a MinIO bucket on a spare VPS. But stitching them together by hand is
+tedious and error-prone.
 
-SFree turns multiple storage services into a single object store. Upload a file
-and SFree splits it into chunks, distributes them across your configured
-sources, and reassembles them on download. You get one REST API, one
-S3-compatible endpoint, and one browser UI for everything.
+SFree unifies multiple storage backends behind a single interface. Upload a
+file and SFree splits it into chunks, distributes them across your configured
+sources in round-robin order, and reassembles them on download. You interact
+through one REST API, one S3-compatible endpoint, or one browser UI — your
+choice.
 
 **Who it's for:** Self-hosters, homelab enthusiasts, and developers who want to
-unify free-tier and personal storage backends behind a single interface.
+pool free-tier and personal storage services into one namespace.
 
-**What it is not:** SFree is an experimental prototype. It does not replicate
-chunks, provide erasure coding, or guarantee durability if an upstream source is
-lost. See [Launch Caveats](#launch-caveats) for the full picture.
+**What it is not:** SFree is an early-stage prototype. It does not replicate
+chunks, provide erasure coding, or guarantee durability if an upstream source
+disappears. See [Launch Caveats](#launch-caveats) for the full picture.
 
 ## Supported Storage Backends
 
-| Backend | API support | Browser UI support | Notes |
+| Backend | API | Browser UI | Notes |
 | --- | --- | --- | --- |
 | Google Drive | Yes | Yes | Richest quota and file metadata reporting |
-| Telegram | Yes | No (API-only) | Uses bot API for chunk storage |
-| S3-compatible | Yes | No (API-only) | Works with MinIO, Backblaze B2, Wasabi, etc. |
+| Telegram | Yes | Yes | Uses bot API for chunk storage |
+| S3-compatible | Yes | Yes | Works with MinIO, Backblaze B2, Wasabi, etc. |
 
 ## Architecture
 
@@ -131,7 +133,7 @@ instance for local S3-compatible source testing.
 
 - Go 1.24+
 - Docker (for MongoDB)
-- Node.js with npm (for the browser UI)
+- Node.js 20+ with npm (for the browser UI)
 
 #### 1. Start MongoDB
 
@@ -153,12 +155,14 @@ The API listens on `http://localhost:8080`.
 
 ```bash
 cd webui
+npm ci
 VITE_API_BASE=http://localhost:8080/api/v1 npm run dev
 ```
 
-Set `VITE_API_BASE` to point the frontend at your local API. Without it, the
-frontend defaults to a relative `/api/v1` path (designed for the Docker Compose
-setup where nginx proxies to the API).
+`npm ci` installs both production and dev dependencies (TypeScript, ESLint,
+etc.) from the lockfile. Set `VITE_API_BASE` to point the frontend at your
+local API. Without it, the frontend defaults to a relative `/api/v1` path
+(designed for the Docker Compose setup where nginx proxies to the API).
 
 </details>
 
@@ -166,11 +170,11 @@ setup where nginx proxies to the API).
 
 | Directory | Purpose |
 | --- | --- |
-| `api-go/` | Primary Go backend — HTTP API, S3-compatible routes, Swagger docs, MongoDB metadata |
-| `webui/` | React 19 + Vite frontend — signup, bucket management, file operations |
-| `api/` | Deprecated Python backend (historical reference only) |
+| `api-go/` | **Primary backend** — Go HTTP API, S3-compatible routes, Swagger docs, MongoDB metadata |
+| `webui/` | React 19 + Vite frontend — signup, source management, bucket operations, file upload/download |
+| `docs/` | Architecture notes, quickstart walkthrough, CI docs |
 | `.woodpecker/` | Self-hosted Woodpecker CI/CD pipelines |
-| `docs/` | Architecture notes, CI docs |
+| `api/` | **Deprecated** Python backend — kept for reference only, not part of the active stack (see [`api/README.md`](api/README.md)) |
 
 ## Launch Caveats
 
@@ -183,14 +187,18 @@ SFree is an early-stage project. These constraints are current and intentional:
   payloads.
 - **Uneven observability.** Google Drive sources expose the richest file and
   quota info. Telegram and S3-compatible sources return less metadata.
-- **Browser UI covers Google Drive only.** Telegram and S3-compatible source
-  creation requires the API directly.
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for setup, validation, and PR guidelines.
-Architecture details are in [docs/architecture.md](docs/architecture.md) and CI
-expectations in [docs/ci.md](docs/ci.md).
+See [CONTRIBUTING.md](CONTRIBUTING.md) for local setup, validation, and PR
+guidelines. Further reading:
+
+- [docs/architecture.md](docs/architecture.md) — system design, data model, and
+  storage behavior
+- [docs/quickstart.md](docs/quickstart.md) — Docker Compose walkthrough with
+  expected output for every step
+- [docs/ci.md](docs/ci.md) — Woodpecker pipeline triggers, secrets, and
+  published images
 
 ## License
 

--- a/api/README.md
+++ b/api/README.md
@@ -1,0 +1,19 @@
+# api/ — Deprecated Python Backend
+
+> **This directory is deprecated.** The active backend is
+> [`api-go/`](../api-go/). All new features, bug fixes, and contributor work
+> should target `api-go/` unless a GitHub issue explicitly requests legacy
+> Python API changes.
+
+This directory contains the original Python implementation of the SFree API.
+It is kept in the repository for historical reference only and is not part of
+the active development, CI/CD, or Docker Compose stack.
+
+**Do not:**
+
+- Add new endpoints or features here
+- Include this service in Docker Compose setups
+- Route new contributors to this code
+
+**Instead:** See [CONTRIBUTING.md](../CONTRIBUTING.md) for how to get started
+with the active Go backend.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -31,18 +31,17 @@ At a high level:
 ### `webui/`
 
 - React 19 + Vite frontend.
-- Safe public claims today:
+- Current capabilities:
   - signup/login
-  - Google Drive source creation
-  - bucket creation and file operations
-- Not safe to imply today:
-  - Telegram source creation in the browser UI
-  - S3-compatible source creation in the browser UI
+  - source creation for Google Drive, Telegram, and S3-compatible backends
+  - bucket creation, listing, and deletion
+  - file upload, download, and deletion
 
-### `api/`
+### `api/` (deprecated)
 
-- Deprecated Python backend.
+- Deprecated Python backend — see [`api/README.md`](../api/README.md).
 - Kept in the repository for historical reference only.
+- Not part of the active CI/CD pipelines or Docker Compose stack.
 - Do not route new contributors there unless an issue explicitly targets it.
 
 ### `.woodpecker/`
@@ -59,8 +58,8 @@ At a high level:
 | Source type | Backend support | Browser UI creation | Notes |
 | --- | --- | --- | --- |
 | Google Drive | Yes | Yes | Richest source info and quota reporting. |
-| Telegram | Yes | No | Backend-supported, but UI creation is not implemented. |
-| S3-compatible | Yes | No | Backend-supported, but UI creation is not implemented. |
+| Telegram | Yes | Yes | Uses bot API for chunk storage. |
+| S3-compatible | Yes | Yes | Works with MinIO, Backblaze B2, Wasabi, etc. |
 
 ## Data Model And Storage Behavior
 
@@ -85,8 +84,6 @@ copy:
 - Do not imply identical observability across source types. Google Drive,
   Telegram, and S3-compatible sources return different levels of file/quota
   detail.
-- Do not say the browser UI supports all backend source types. It currently
-  creates Google Drive sources only.
 
 ## Local Development Notes
 


### PR DESCRIPTION
## Summary

- Sharpened README value prop and fixed outdated UI support claims (all three source types are now supported in the browser UI)
- Made CONTRIBUTING.md frontend setup reproducible: explicit `npm ci`, Node 20+ requirement, `NODE_ENV=production` pitfall warning, validation commands matching Woodpecker CI
- Added `api/README.md` deprecation notice to isolate the legacy Python backend from default contributor paths
- Updated `docs/architecture.md` source-type table and removed stale caveats

Closes #87, closes #100, closes #106

## What Changed

- **README.md**: Stronger one-liner, corrected backend support table (all sources have UI support now), `npm ci` in manual dev setup, reordered repo layout to lead with active code, deprecated `api/` linked to notice, structured Contributing section with doc links
- **CONTRIBUTING.md**: Full rewrite of frontend section — `npm ci` instead of `npm install`, explicit Node 20+ prerequisite, explanation of `NODE_ENV=production` pitfall, validation section matching CI pipeline, `api/` deprecation callout
- **api/README.md** (new): Deprecation notice directing contributors to `api-go/`
- **docs/architecture.md**: Corrected source-type UI support table, removed "UI covers Google Drive only" caveat, marked `api/` section as deprecated with link

## Validation

- All changes are documentation only (Markdown files)
- No code changes — frontend/backend builds unaffected
- Reviewed against Woodpecker CI pipeline to ensure CONTRIBUTING instructions match actual CI validation steps

## Docs Impact

- [x] README updated
- [x] CONTRIBUTING updated
- [x] Architecture docs updated
- [x] New deprecation notice added for legacy Python API

🤖 Generated with [Claude Code](https://claude.com/claude-code)