### PR TITLE
Add configurable chunk distribution strategies

### DIFF
--- a/api-go/internal/app/router.go
+++ b/api-go/internal/app/router.go
@@ -74,6 +74,7 @@ func SetupRouter(m *db.Mongo, cfg *config.Config) *gin.Engine {
 		router.POST("/api/v1/buckets", auth, handlers.CreateBucket(bucketRepo, sourceRepo, secretKey))
 		router.GET("/api/v1/buckets", auth, handlers.ListBuckets(bucketRepo))
 		router.DELETE("/api/v1/buckets/:id", auth, handlers.DeleteBucket(bucketRepo))
+		router.PATCH("/api/v1/buckets/:id/distribution", auth, handlers.UpdateBucketDistribution(bucketRepo))
 		if sourceRepo != nil && fileRepo != nil {
 			chunkSize := 0
 			if cfg != nil {

--- a/api-go/internal/handlers/bucket.go
+++ b/api-go/internal/handlers/bucket.go
@@ -16,8 +16,10 @@ import (
 )
 
 type createBucketRequest struct {
-	Key       string   `json:"key" binding:"required"`
-	SourceIDs []string `json:"source_ids" binding:"required,min=1"`
+	Key                  string         `json:"key" binding:"required"`
+	SourceIDs            []string       `json:"source_ids" binding:"required,min=1"`
+	DistributionStrategy string         `json:"distribution_strategy,omitempty"`
+	SourceWeights        map[string]int `json:"source_weights,omitempty"`
 }
 
 type createBucketResponse struct {
@@ -118,13 +120,23 @@ func CreateBucket(repo *repository.BucketRepository, sourceRepo *repository.Sour
 			}
 			sourceIDs = append(sourceIDs, sourceID)
 		}
+		strategy := repository.DistributionStrategy(req.DistributionStrategy)
+		if strategy == "" {
+			strategy = repository.StrategyRoundRobin
+		}
+		if strategy != repository.StrategyRoundRobin && strategy != repository.StrategyWeighted {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid distribution_strategy"})
+			return
+		}
 		bucket := repository.Bucket{
-			UserID:          userID,
-			Key:             req.Key,
-			AccessKey:       accessKey,
-			AccessSecretEnc: encrypted,
-			SourceIDs:       sourceIDs,
-			CreatedAt:       time.Now().UTC(),
+			UserID:               userID,
+			Key:                  req.Key,
+			AccessKey:            accessKey,
+			AccessSecretEnc:      encrypted,
+			SourceIDs:            sourceIDs,
+			DistributionStrategy: strategy,
+			SourceWeights:        req.SourceWeights,
+			CreatedAt:            time.Now().UTC(),
 		}
 		created, err := repo.Create(c.Request.Context(), bucket)
 		if err != nil {
@@ -240,6 +252,69 @@ func DeleteBucket(repo *repository.BucketRepository) gin.HandlerFunc {
 	}
 }
 
+type updateDistributionRequest struct {
+	DistributionStrategy string         `json:"distribution_strategy" binding:"required"`
+	SourceWeights        map[string]int `json:"source_weights,omitempty"`
+}
+
+// UpdateBucketDistribution godoc
+// @Summary Update bucket distribution strategy
+// @Tags buckets
+// @Accept json
+// @Produce json
+// @Param id path string true "Bucket ID"
+// @Param body body updateDistributionRequest true "Distribution config"
+// @Success 200 {string} string ""
+// @Failure 400 {string} string ""
+// @Failure 401 {string} string ""
+// @Failure 404 {string} string ""
+// @Security BasicAuth
+// @Router /api/v1/buckets/{id}/distribution [patch]
+func UpdateBucketDistribution(repo *repository.BucketRepository) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if repo == nil {
+			c.Status(http.StatusServiceUnavailable)
+			return
+		}
+		var req updateDistributionRequest
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.Status(http.StatusBadRequest)
+			return
+		}
+		strategy := repository.DistributionStrategy(req.DistributionStrategy)
+		if strategy != repository.StrategyRoundRobin && strategy != repository.StrategyWeighted {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid distribution_strategy"})
+			return
+		}
+		userIDHex := c.GetString("userID")
+		if userIDHex == "" {
+			c.Status(http.StatusUnauthorized)
+			return
+		}
+		userID, err := primitive.ObjectIDFromHex(userIDHex)
+		if err != nil {
+			c.Status(http.StatusUnauthorized)
+			return
+		}
+		idHex := c.Param("id")
+		id, err := primitive.ObjectIDFromHex(idHex)
+		if err != nil {
+			c.Status(http.StatusBadRequest)
+			return
+		}
+		if err := repo.UpdateDistribution(c.Request.Context(), id, userID, strategy, req.SourceWeights); err != nil {
+			if err == mongo.ErrNoDocuments {
+				c.Status(http.StatusNotFound)
+				return
+			}
+			log.Printf("update distribution: %v", err)
+			c.Status(http.StatusInternalServerError)
+			return
+		}
+		c.Status(http.StatusOK)
+	}
+}
+
 type uploadFileResponse struct {
 	ID        string    `json:"id"`
 	Name      string    `json:"name"`
@@ -322,7 +397,8 @@ func UploadFile(bucketRepo *repository.BucketRepository, sourceRepo *repository.
 		}
 		defer func() { _ = f.Close() }()
 
-		chunks, err := manager.UploadFileChunks(ctx, f, sources, chunkSize)
+		selector := manager.SelectorForBucket(bucketDoc, sources)
+		chunks, err := manager.UploadFileChunksWithStrategy(ctx, f, sources, chunkSize, nil, selector)
 		if err != nil {
 			slog.ErrorContext(ctx, "upload file: upload chunks", slog.String("error", err.Error()))
 			c.Status(http.StatusInternalServerError)

--- a/api-go/internal/handlers/s3.go
+++ b/api-go/internal/handlers/s3.go
@@ -242,7 +242,8 @@ func PutObject(bucketRepo *repository.BucketRepository, sourceRepo *repository.S
 		if err == mongo.ErrNoDocuments {
 			existingFile = nil
 		}
-		chunks, err := manager.UploadFileChunks(ctx, c.Request.Body, sources, chunkSize)
+		selector := manager.SelectorForBucket(bucketDoc, sources)
+		chunks, err := manager.UploadFileChunksWithStrategy(ctx, c.Request.Body, sources, chunkSize, nil, selector)
 		if err != nil {
 			slog.ErrorContext(ctx, "put object: upload chunks", slog.String("error", err.Error()))
 			writeS3Error(c, http.StatusInternalServerError, "InternalError", "")

--- a/api-go/internal/manager/file.go
+++ b/api-go/internal/manager/file.go
@@ -40,6 +40,54 @@ func (s *RoundRobinSelector) NextSource(sources []repository.Source) (int, repos
 	return idx, sources[idx], nil
 }
 
+// WeightedSelector distributes chunks across sources proportionally to their
+// configured weights. It builds a repeating sequence where each source appears
+// a number of times equal to its weight, then cycles through that sequence.
+type WeightedSelector struct {
+	sequence []int
+	next     int
+}
+
+// NewWeightedSelector creates a selector that distributes chunks according to
+// per-source weights. The weights map uses source ID hex strings as keys.
+// Sources without an entry default to weight 1.
+func NewWeightedSelector(sources []repository.Source, weights map[string]int) *WeightedSelector {
+	seq := make([]int, 0)
+	for i, src := range sources {
+		w := weights[src.ID.Hex()]
+		if w <= 0 {
+			w = 1
+		}
+		for j := 0; j < w; j++ {
+			seq = append(seq, i)
+		}
+	}
+	return &WeightedSelector{sequence: seq}
+}
+
+func (s *WeightedSelector) NextSource(sources []repository.Source) (int, repository.Source, error) {
+	if len(sources) == 0 || len(s.sequence) == 0 {
+		return 0, repository.Source{}, errors.New("no sources")
+	}
+	idx := s.sequence[s.next%len(s.sequence)]
+	s.next = (s.next + 1) % len(s.sequence)
+	if idx >= len(sources) {
+		return 0, repository.Source{}, errors.New("source index out of range")
+	}
+	return idx, sources[idx], nil
+}
+
+// SelectorForBucket returns the appropriate SourceSelector based on the
+// bucket's configured distribution strategy.
+func SelectorForBucket(bucket *repository.Bucket, sources []repository.Source) SourceSelector {
+	switch bucket.DistributionStrategy {
+	case repository.StrategyWeighted:
+		return NewWeightedSelector(sources, bucket.SourceWeights)
+	default:
+		return &RoundRobinSelector{}
+	}
+}
+
 func NewSourceClient(ctx context.Context, src *repository.Source) (sourceClient, error) {
 	if src == nil {
 		return nil, errors.New("nil source")

--- a/api-go/internal/manager/file_test.go
+++ b/api-go/internal/manager/file_test.go
@@ -138,6 +138,136 @@ func TestUploadFileChunksUploadError(t *testing.T) {
 	}
 }
 
+func TestWeightedSelectorDistribution(t *testing.T) {
+	t.Parallel()
+	s1 := repository.Source{ID: primitive.NewObjectID()}
+	s2 := repository.Source{ID: primitive.NewObjectID()}
+	sources := []repository.Source{s1, s2}
+	weights := map[string]int{s1.ID.Hex(): 3, s2.ID.Hex(): 1}
+	sel := NewWeightedSelector(sources, weights)
+
+	// Sequence should be [s1, s1, s1, s2] repeating
+	counts := map[primitive.ObjectID]int{}
+	for i := 0; i < 8; i++ {
+		_, src, err := sel.NextSource(sources)
+		if err != nil {
+			t.Fatalf("call %d: %v", i, err)
+		}
+		counts[src.ID]++
+	}
+	if counts[s1.ID] != 6 {
+		t.Fatalf("expected s1 count 6, got %d", counts[s1.ID])
+	}
+	if counts[s2.ID] != 2 {
+		t.Fatalf("expected s2 count 2, got %d", counts[s2.ID])
+	}
+}
+
+func TestWeightedSelectorDefaultWeight(t *testing.T) {
+	t.Parallel()
+	s1 := repository.Source{ID: primitive.NewObjectID()}
+	s2 := repository.Source{ID: primitive.NewObjectID()}
+	sources := []repository.Source{s1, s2}
+	// Only s1 has explicit weight; s2 defaults to 1
+	weights := map[string]int{s1.ID.Hex(): 2}
+	sel := NewWeightedSelector(sources, weights)
+
+	// Sequence: [s1, s1, s2] repeating
+	counts := map[primitive.ObjectID]int{}
+	for i := 0; i < 6; i++ {
+		_, src, err := sel.NextSource(sources)
+		if err != nil {
+			t.Fatalf("call %d: %v", i, err)
+		}
+		counts[src.ID]++
+	}
+	if counts[s1.ID] != 4 {
+		t.Fatalf("expected s1 count 4, got %d", counts[s1.ID])
+	}
+	if counts[s2.ID] != 2 {
+		t.Fatalf("expected s2 count 2, got %d", counts[s2.ID])
+	}
+}
+
+func TestWeightedSelectorNoSources(t *testing.T) {
+	t.Parallel()
+	sel := NewWeightedSelector(nil, nil)
+	_, _, err := sel.NextSource(nil)
+	if err == nil {
+		t.Fatal("expected error for empty sources")
+	}
+}
+
+func TestUploadFileChunksWithWeightedStrategy(t *testing.T) {
+	t.Parallel()
+	s1 := repository.Source{ID: primitive.NewObjectID(), Type: repository.SourceTypeTelegram}
+	s2 := repository.Source{ID: primitive.NewObjectID(), Type: repository.SourceTypeTelegram}
+	sources := []repository.Source{s1, s2}
+
+	clients := map[primitive.ObjectID]*stubSourceClient{}
+	factory := func(_ context.Context, src *repository.Source) (sourceClient, error) {
+		cli := &stubSourceClient{}
+		clients[src.ID] = cli
+		return cli, nil
+	}
+
+	weights := map[string]int{s1.ID.Hex(): 2, s2.ID.Hex(): 1}
+	sel := NewWeightedSelector(sources, weights)
+
+	// 9 bytes with chunk size 3 = 3 chunks
+	// Weighted sequence [s1, s1, s2]: chunk0->s1, chunk1->s1, chunk2->s2
+	payload := []byte("abcdefghi")
+	chunks, err := UploadFileChunksWithStrategy(context.Background(), bytes.NewReader(payload), sources, 3, factory, sel)
+	if err != nil {
+		t.Fatalf("upload: %v", err)
+	}
+	if len(chunks) != 3 {
+		t.Fatalf("expected 3 chunks, got %d", len(chunks))
+	}
+	if chunks[0].SourceID != s1.ID || chunks[1].SourceID != s1.ID {
+		t.Fatalf("first two chunks should go to s1: %+v", chunks)
+	}
+	if chunks[2].SourceID != s2.ID {
+		t.Fatalf("third chunk should go to s2: %+v", chunks)
+	}
+}
+
+func TestSelectorForBucketRoundRobin(t *testing.T) {
+	t.Parallel()
+	bucket := &repository.Bucket{DistributionStrategy: repository.StrategyRoundRobin}
+	s1 := repository.Source{ID: primitive.NewObjectID()}
+	sources := []repository.Source{s1}
+	sel := SelectorForBucket(bucket, sources)
+	if _, ok := sel.(*RoundRobinSelector); !ok {
+		t.Fatalf("expected RoundRobinSelector, got %T", sel)
+	}
+}
+
+func TestSelectorForBucketWeighted(t *testing.T) {
+	t.Parallel()
+	s1 := repository.Source{ID: primitive.NewObjectID()}
+	bucket := &repository.Bucket{
+		DistributionStrategy: repository.StrategyWeighted,
+		SourceWeights:        map[string]int{s1.ID.Hex(): 5},
+	}
+	sources := []repository.Source{s1}
+	sel := SelectorForBucket(bucket, sources)
+	if _, ok := sel.(*WeightedSelector); !ok {
+		t.Fatalf("expected WeightedSelector, got %T", sel)
+	}
+}
+
+func TestSelectorForBucketDefault(t *testing.T) {
+	t.Parallel()
+	// Empty strategy should default to round-robin
+	bucket := &repository.Bucket{}
+	sources := []repository.Source{{ID: primitive.NewObjectID()}}
+	sel := SelectorForBucket(bucket, sources)
+	if _, ok := sel.(*RoundRobinSelector); !ok {
+		t.Fatalf("expected RoundRobinSelector for empty strategy, got %T", sel)
+	}
+}
+
 func TestNewSourceClientNilSource(t *testing.T) {
 	t.Parallel()
 	_, err := NewSourceClient(context.Background(), nil)

--- a/api-go/internal/repository/bucket.go
+++ b/api-go/internal/repository/bucket.go
@@ -10,14 +10,23 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
+type DistributionStrategy string
+
+const (
+	StrategyRoundRobin DistributionStrategy = "round_robin"
+	StrategyWeighted   DistributionStrategy = "weighted"
+)
+
 type Bucket struct {
-	ID              primitive.ObjectID   `bson:"_id,omitempty"`
-	UserID          primitive.ObjectID   `bson:"user_id"`
-	Key             string               `bson:"key"`
-	AccessKey       string               `bson:"access_key"`
-	AccessSecretEnc string               `bson:"access_secret"`
-	SourceIDs       []primitive.ObjectID `bson:"source_ids"`
-	CreatedAt       time.Time            `bson:"created_at"`
+	ID                   primitive.ObjectID   `bson:"_id,omitempty"`
+	UserID               primitive.ObjectID   `bson:"user_id"`
+	Key                  string               `bson:"key"`
+	AccessKey            string               `bson:"access_key"`
+	AccessSecretEnc      string               `bson:"access_secret"`
+	SourceIDs            []primitive.ObjectID `bson:"source_ids"`
+	DistributionStrategy DistributionStrategy `bson:"distribution_strategy,omitempty"`
+	SourceWeights        map[string]int       `bson:"source_weights,omitempty"`
+	CreatedAt            time.Time            `bson:"created_at"`
 }
 
 type BucketRepository struct {
@@ -110,6 +119,21 @@ func (r *BucketRepository) HasSourceReference(ctx context.Context, userID, sourc
 		return false, err
 	}
 	return count > 0, nil
+}
+
+func (r *BucketRepository) UpdateDistribution(ctx context.Context, id, userID primitive.ObjectID, strategy DistributionStrategy, weights map[string]int) error {
+	update := bson.M{"$set": bson.M{
+		"distribution_strategy": strategy,
+		"source_weights":        weights,
+	}}
+	res, err := r.coll.UpdateOne(ctx, bson.M{"_id": id, "user_id": userID}, update)
+	if err != nil {
+		return err
+	}
+	if res.MatchedCount == 0 {
+		return mongo.ErrNoDocuments
+	}
+	return nil
 }
 
 func (r *BucketRepository) Delete(ctx context.Context, id, userID primitive.ObjectID) error {


### PR DESCRIPTION
## Summary
- Add per-bucket distribution strategy configuration (round-robin + weighted)
- New `PATCH /api/v1/buckets/:id/distribution` endpoint to update strategy on existing buckets
- Both v1 upload and S3-compatible PutObject paths now use the bucket's configured strategy
- Backward-compatible: existing buckets default to round-robin

## Changes
- **repository/bucket.go**: `DistributionStrategy` type, `SourceWeights` field, `UpdateDistribution` method
- **manager/file.go**: `WeightedSelector` (sequence-based weighted round-robin), `SelectorForBucket` factory
- **handlers/bucket.go**: Updated `CreateBucket` to accept strategy config; new `UpdateBucketDistribution` handler
- **handlers/s3.go**: PutObject wired to use bucket strategy
- **router.go**: New PATCH route

## Test plan
- [x] WeightedSelector distributes proportionally to weights
- [x] Default weight is 1 for sources without explicit weight
- [x] Empty sources returns error
- [x] Upload integration test with weighted strategy
- [x] SelectorForBucket returns correct type for each strategy
- [x] Empty/unknown strategy defaults to round-robin
- [x] All existing tests still pass
- [ ] Manual test with real sources (deferred to integration)

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)