### PR TITLE
Add sfree CLI tool for power users

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,51 @@ local API. Without it, the frontend defaults to a relative `/api/v1` path
 
 </details>
 
+### CLI
+
+Build the CLI from source:
+
+```bash
+cd api-go
+make build-cli
+# binary at bin/sfree
+```
+
+Configure credentials via flags or environment variables:
+
+```bash
+export SFREE_SERVER=http://localhost:8080
+export SFREE_USER=demo
+export SFREE_PASSWORD=your-password
+```
+
+Usage examples:
+
+```bash
+# List storage sources
+sfree sources list
+
+# List buckets
+sfree buckets list
+
+# Create a bucket (generates S3 access keys)
+sfree buckets create --key my-bucket --sources SOURCE_ID_1,SOURCE_ID_2
+
+# Upload a file
+sfree upload BUCKET_ID path/to/file.txt
+
+# List files in a bucket
+sfree files list BUCKET_ID
+
+# Download a file
+sfree download BUCKET_ID FILE_ID output.txt
+
+# Generate S3-compatible credentials
+sfree keys create --bucket my-s3-bucket --sources SOURCE_ID
+```
+
+Run `sfree --help` or `sfree <command> --help` for full usage details.
+
 ## Repository Layout
 
 | Directory | Purpose |

--- a/api-go/Makefile
+++ b/api-go/Makefile
@@ -1,7 +1,10 @@
-.PHONY: build run test test-unit test-integration test-e2e lint docker-build test-e2e-local test-e2e-python
+.PHONY: build build-cli run test test-unit test-integration test-e2e lint docker-build test-e2e-local test-e2e-python
 
 build:
 	go build -o bin/server ./cmd/server
+
+build-cli:
+	go build -o bin/sfree ./cmd/sfree-cli
 
 run: build
 	./bin/server

--- a/api-go/cmd/sfree-cli/buckets.go
+++ b/api-go/cmd/sfree-cli/buckets.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+)
+
+type bucketItem struct {
+	ID        string `json:"id"`
+	Key       string `json:"key"`
+	AccessKey string `json:"access_key"`
+	CreatedAt string `json:"created_at"`
+}
+
+type createBucketReq struct {
+	Key       string   `json:"key"`
+	SourceIDs []string `json:"source_ids"`
+}
+
+type createBucketResp struct {
+	Key          string `json:"key"`
+	AccessKey    string `json:"access_key"`
+	AccessSecret string `json:"access_secret"`
+	CreatedAt    string `json:"created_at"`
+}
+
+var bucketsCmd = &cobra.Command{
+	Use:   "buckets",
+	Short: "Manage buckets",
+}
+
+var bucketsListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all buckets",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		var buckets []bucketItem
+		if err := apiGet("/api/v1/buckets", &buckets); err != nil {
+			return err
+		}
+		if len(buckets) == 0 {
+			fmt.Println("No buckets configured.")
+			return nil
+		}
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(w, "ID\tKEY\tACCESS KEY\tCREATED")
+		for _, b := range buckets {
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", b.ID, b.Key, b.AccessKey, b.CreatedAt)
+		}
+		return w.Flush()
+	},
+}
+
+var (
+	bucketCreateKey     string
+	bucketCreateSources string
+)
+
+var bucketsCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create a new bucket",
+	Long: `Create a new bucket backed by the specified storage sources.
+S3-compatible access credentials are generated automatically.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if bucketCreateKey == "" {
+			return fmt.Errorf("--key is required")
+		}
+		if bucketCreateSources == "" {
+			return fmt.Errorf("--sources is required (comma-separated source IDs)")
+		}
+		ids := strings.Split(bucketCreateSources, ",")
+		var resp createBucketResp
+		if err := apiPost("/api/v1/buckets", createBucketReq{
+			Key:       bucketCreateKey,
+			SourceIDs: ids,
+		}, &resp); err != nil {
+			return err
+		}
+		fmt.Println("Bucket created successfully.")
+		fmt.Println()
+		fmt.Printf("  Bucket Key:      %s\n", resp.Key)
+		fmt.Printf("  Access Key:      %s\n", resp.AccessKey)
+		fmt.Printf("  Access Secret:   %s\n", resp.AccessSecret)
+		fmt.Printf("  Created:         %s\n", resp.CreatedAt)
+		fmt.Println()
+		fmt.Println("Use these credentials with any S3-compatible client:")
+		fmt.Printf("  aws s3 ls s3://%s/ --endpoint-url %s/api/s3\n", resp.Key, serverURL())
+		return nil
+	},
+}
+
+func init() {
+	bucketsCreateCmd.Flags().StringVar(&bucketCreateKey, "key", "", "Bucket key (name)")
+	bucketsCreateCmd.Flags().StringVar(&bucketCreateSources, "sources", "", "Comma-separated source IDs")
+	bucketsCmd.AddCommand(bucketsListCmd, bucketsCreateCmd)
+	rootCmd.AddCommand(bucketsCmd)
+}

--- a/api-go/cmd/sfree-cli/client.go
+++ b/api-go/cmd/sfree-cli/client.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"os"
+	"path/filepath"
+)
+
+func apiGet(path string, out interface{}) error {
+	auth, err := authHeader()
+	if err != nil {
+		return err
+	}
+	url := serverURL() + path
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Authorization", auth)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("server returned %d: %s", resp.StatusCode, string(body))
+	}
+	return json.NewDecoder(resp.Body).Decode(out)
+}
+
+func apiPost(path string, body interface{}, out interface{}) error {
+	auth, err := authHeader()
+	if err != nil {
+		return err
+	}
+	url := serverURL() + path
+	pr, pw := io.Pipe()
+	go func() {
+		pw.CloseWithError(json.NewEncoder(pw).Encode(body))
+	}()
+	req, err := http.NewRequest("POST", url, pr)
+	if err != nil {
+		return fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Authorization", auth)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("server returned %d: %s", resp.StatusCode, string(respBody))
+	}
+	if out != nil {
+		return json.NewDecoder(resp.Body).Decode(out)
+	}
+	return nil
+}
+
+func apiUpload(path string, filePath string, out interface{}) error {
+	auth, err := authHeader()
+	if err != nil {
+		return err
+	}
+	f, err := os.Open(filePath)
+	if err != nil {
+		return fmt.Errorf("opening file: %w", err)
+	}
+	defer f.Close()
+
+	pr, pw := io.Pipe()
+	writer := multipart.NewWriter(pw)
+	go func() {
+		part, err := writer.CreateFormFile("file", filepath.Base(filePath))
+		if err != nil {
+			pw.CloseWithError(err)
+			return
+		}
+		if _, err := io.Copy(part, f); err != nil {
+			pw.CloseWithError(err)
+			return
+		}
+		pw.CloseWithError(writer.Close())
+	}()
+
+	url := serverURL() + path
+	req, err := http.NewRequest("POST", url, pr)
+	if err != nil {
+		return fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Authorization", auth)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("server returned %d: %s", resp.StatusCode, string(body))
+	}
+	if out != nil {
+		return json.NewDecoder(resp.Body).Decode(out)
+	}
+	return nil
+}
+
+func apiDownload(path string, dest string) error {
+	auth, err := authHeader()
+	if err != nil {
+		return err
+	}
+	url := serverURL() + path
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Authorization", auth)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("server returned %d: %s", resp.StatusCode, string(body))
+	}
+	out, err := os.Create(dest)
+	if err != nil {
+		return fmt.Errorf("creating output file: %w", err)
+	}
+	defer out.Close()
+	if _, err := io.Copy(out, resp.Body); err != nil {
+		return fmt.Errorf("writing file: %w", err)
+	}
+	return nil
+}

--- a/api-go/cmd/sfree-cli/files.go
+++ b/api-go/cmd/sfree-cli/files.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+)
+
+type fileItem struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	Size      int64  `json:"size"`
+	CreatedAt string `json:"created_at"`
+}
+
+type uploadResp struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	CreatedAt string `json:"created_at"`
+}
+
+var uploadCmd = &cobra.Command{
+	Use:   "upload <bucket-id> <file-path>",
+	Short: "Upload a file to a bucket",
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		bucketID := args[0]
+		filePath := args[1]
+		var resp uploadResp
+		if err := apiUpload(fmt.Sprintf("/api/v1/buckets/%s/upload", bucketID), filePath, &resp); err != nil {
+			return err
+		}
+		fmt.Printf("Uploaded %s\n", resp.Name)
+		fmt.Printf("  File ID: %s\n", resp.ID)
+		return nil
+	},
+}
+
+var downloadCmd = &cobra.Command{
+	Use:   "download <bucket-id> <file-id> [output-path]",
+	Short: "Download a file from a bucket",
+	Args:  cobra.RangeArgs(2, 3),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		bucketID := args[0]
+		fileID := args[1]
+		output := fileID
+		if len(args) == 3 {
+			output = args[2]
+		}
+		path := fmt.Sprintf("/api/v1/buckets/%s/files/%s/download", bucketID, fileID)
+		if err := apiDownload(path, output); err != nil {
+			return err
+		}
+		fmt.Printf("Downloaded to %s\n", output)
+		return nil
+	},
+}
+
+var filesCmd = &cobra.Command{
+	Use:   "files",
+	Short: "Manage files in buckets",
+}
+
+var filesListCmd = &cobra.Command{
+	Use:   "list <bucket-id>",
+	Short: "List files in a bucket",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		bucketID := args[0]
+		var files []fileItem
+		if err := apiGet(fmt.Sprintf("/api/v1/buckets/%s/files", bucketID), &files); err != nil {
+			return err
+		}
+		if len(files) == 0 {
+			fmt.Println("No files in this bucket.")
+			return nil
+		}
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(w, "ID\tNAME\tSIZE\tCREATED")
+		for _, f := range files {
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", f.ID, f.Name, humanSize(f.Size), f.CreatedAt)
+		}
+		return w.Flush()
+	},
+}
+
+var filesDeleteCmd = &cobra.Command{
+	Use:   "delete <bucket-id> <file-id>",
+	Short: "Delete a file from a bucket",
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		bucketID := args[0]
+		fileID := args[1]
+		if err := apiDelete(fmt.Sprintf("/api/v1/buckets/%s/files/%s", bucketID, fileID)); err != nil {
+			return err
+		}
+		fmt.Println("File deleted.")
+		return nil
+	},
+}
+
+func init() {
+	filesCmd.AddCommand(filesListCmd, filesDeleteCmd)
+	rootCmd.AddCommand(uploadCmd, downloadCmd, filesCmd)
+}
+
+func humanSize(b int64) string {
+	const unit = 1024
+	if b < unit {
+		return fmt.Sprintf("%d B", b)
+	}
+	div, exp := int64(unit), 0
+	for n := b / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB", float64(b)/float64(div), "KMGTPE"[exp])
+}
+
+func apiDelete(path string) error {
+	auth, err := authHeader()
+	if err != nil {
+		return err
+	}
+	url := serverURL() + path
+	req, err := http.NewRequest("DELETE", url, nil)
+	if err != nil {
+		return fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Authorization", auth)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("server returned %d: %s", resp.StatusCode, string(body))
+	}
+	return nil
+}

--- a/api-go/cmd/sfree-cli/keys.go
+++ b/api-go/cmd/sfree-cli/keys.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var keysCmd = &cobra.Command{
+	Use:   "keys",
+	Short: "Manage S3-compatible access keys",
+}
+
+var (
+	keysCreateBucket  string
+	keysCreateSources string
+)
+
+var keysCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create S3 access keys by creating a new bucket",
+	Long: `Create a new bucket and display its S3-compatible access credentials.
+These credentials can be used with any S3-compatible client (aws-cli, mc, etc).`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if keysCreateBucket == "" {
+			return fmt.Errorf("--bucket is required")
+		}
+		if keysCreateSources == "" {
+			return fmt.Errorf("--sources is required (comma-separated source IDs)")
+		}
+		ids := strings.Split(keysCreateSources, ",")
+		var resp createBucketResp
+		if err := apiPost("/api/v1/buckets", createBucketReq{
+			Key:       keysCreateBucket,
+			SourceIDs: ids,
+		}, &resp); err != nil {
+			return err
+		}
+		fmt.Println("S3 credentials created:")
+		fmt.Println()
+		fmt.Printf("  Bucket:          %s\n", resp.Key)
+		fmt.Printf("  Access Key ID:   %s\n", resp.AccessKey)
+		fmt.Printf("  Secret Key:      %s\n", resp.AccessSecret)
+		fmt.Println()
+		fmt.Println("Example usage:")
+		fmt.Printf("  export AWS_ACCESS_KEY_ID=%s\n", resp.AccessKey)
+		fmt.Printf("  export AWS_SECRET_ACCESS_KEY=%s\n", resp.AccessSecret)
+		fmt.Printf("  aws s3 ls s3://%s/ --endpoint-url %s/api/s3\n", resp.Key, serverURL())
+		return nil
+	},
+}
+
+func init() {
+	keysCreateCmd.Flags().StringVar(&keysCreateBucket, "bucket", "", "Bucket key (name) to create")
+	keysCreateCmd.Flags().StringVar(&keysCreateSources, "sources", "", "Comma-separated source IDs")
+	keysCmd.AddCommand(keysCreateCmd)
+	rootCmd.AddCommand(keysCmd)
+}

--- a/api-go/cmd/sfree-cli/main.go
+++ b/api-go/cmd/sfree-cli/main.go
@@ -1,0 +1,67 @@
+// Package main implements the sfree CLI tool.
+package main
+
+import (
+	"encoding/base64"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	flagServer   string
+	flagUser     string
+	flagPassword string
+)
+
+func main() {
+	if err := rootCmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+}
+
+var rootCmd = &cobra.Command{
+	Use:   "sfree",
+	Short: "SFree CLI — manage storage sources, buckets, and files",
+	Long: `SFree CLI lets you interact with a SFree server from the terminal.
+
+Create storage sources, manage buckets, upload and download files,
+and generate S3-compatible access keys.
+
+Configuration via flags or environment variables:
+  --server / SFREE_SERVER   API base URL (default http://localhost:8080)
+  --user / SFREE_USER       Username for Basic Auth
+  --password / SFREE_PASSWORD  Password for Basic Auth`,
+}
+
+func init() {
+	rootCmd.PersistentFlags().StringVar(&flagServer, "server", "", "SFree API base URL (env: SFREE_SERVER)")
+	rootCmd.PersistentFlags().StringVar(&flagUser, "user", "", "Username (env: SFREE_USER)")
+	rootCmd.PersistentFlags().StringVar(&flagPassword, "password", "", "Password (env: SFREE_PASSWORD)")
+}
+
+func serverURL() string {
+	if flagServer != "" {
+		return flagServer
+	}
+	if v := os.Getenv("SFREE_SERVER"); v != "" {
+		return v
+	}
+	return "http://localhost:8080"
+}
+
+func authHeader() (string, error) {
+	user := flagUser
+	if user == "" {
+		user = os.Getenv("SFREE_USER")
+	}
+	pass := flagPassword
+	if pass == "" {
+		pass = os.Getenv("SFREE_PASSWORD")
+	}
+	if user == "" || pass == "" {
+		return "", fmt.Errorf("username and password required (use --user/--password or SFREE_USER/SFREE_PASSWORD)")
+	}
+	return "Basic " + base64.StdEncoding.EncodeToString([]byte(user+":"+pass)), nil
+}

--- a/api-go/cmd/sfree-cli/sources.go
+++ b/api-go/cmd/sfree-cli/sources.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+)
+
+type sourceItem struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	Type      string `json:"type"`
+	CreatedAt string `json:"created_at"`
+}
+
+var sourcesCmd = &cobra.Command{
+	Use:   "sources",
+	Short: "Manage storage sources",
+}
+
+var sourcesListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all configured storage sources",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		var sources []sourceItem
+		if err := apiGet("/api/v1/sources", &sources); err != nil {
+			return err
+		}
+		if len(sources) == 0 {
+			fmt.Println("No sources configured.")
+			return nil
+		}
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(w, "ID\tNAME\tTYPE\tCREATED")
+		for _, s := range sources {
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", s.ID, s.Name, s.Type, s.CreatedAt)
+		}
+		return w.Flush()
+	},
+}
+
+func init() {
+	sourcesCmd.AddCommand(sourcesListCmd)
+	rootCmd.AddCommand(sourcesCmd)
+}

--- a/api-go/go.mod
+++ b/api-go/go.mod
@@ -19,6 +19,12 @@ require (
 )
 
 require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/cobra v1.10.2 // indirect
+	github.com/spf13/pflag v1.0.9 // indirect
+)
+
+require (
 	cloud.google.com/go/auth v0.16.5 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
 	cloud.google.com/go/compute/metadata v0.8.0 // indirect

--- a/api-go/go.sum
+++ b/api-go/go.sum
@@ -60,6 +60,7 @@ github.com/cloudwego/base64x v0.1.4 h1:jwCgWpFanWmN8xoIUHa2rtzmkd5J2plF/dnLS6Xd/
 github.com/cloudwego/base64x v0.1.4/go.mod h1:0zlkT4Wn5C6NdauXdJRhSKRlJvmclQ1hhJgA0rcu/8w=
 github.com/cloudwego/iasm v0.2.0 h1:1KNIy1I1H9hNNFEEH3DVnI4UujN+1zjpuk6gwHLTssg=
 github.com/cloudwego/iasm v0.2.0/go.mod h1:8rXZaNYT2n95jn+zTI1sDr+IgcD2GVs0nlbbQPiEFhY=
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -118,6 +119,8 @@ github.com/googleapis/enterprise-certificate-proxy v0.3.6 h1:GW/XbdyBFQ8Qe+YAmFU
 github.com/googleapis/enterprise-certificate-proxy v0.3.6/go.mod h1:MkHOF77EYAE7qfSuSS9PU6g4Nt4e11cnsDUowfwewLA=
 github.com/googleapis/gax-go/v2 v2.15.0 h1:SyjDc1mGgZU5LncH8gimWo9lW1DtIfPibOG81vgd/bo=
 github.com/googleapis/gax-go/v2 v2.15.0/go.mod h1:zVVkkxAQHa1RQpg9z2AUCMnKhi0Qld9rcmyfL1OZhoc=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
@@ -169,6 +172,11 @@ github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0leargg
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
 github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
 github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
+github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
+github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
+github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
@@ -218,6 +226,7 @@ go.opentelemetry.io/otel/sdk/metric v1.36.0 h1:r0ntwwGosWGaa0CrSt8cuNuTcccMXERFw
 go.opentelemetry.io/otel/sdk/metric v1.36.0/go.mod h1:qTNOhFDfKRwX0yXOqJYegL5WRaW376QbB7P4Pb0qva4=
 go.opentelemetry.io/otel/trace v1.36.0 h1:ahxWNuqZjpdiFAyrIoQ4GIiAIhxAunQR6MUoKrsNd4w=
 go.opentelemetry.io/otel/trace v1.36.0/go.mod h1:gQ+OnDZzrybY4k4seLzPAWNwVBBVlF2szhehOBB/tGA=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/arch v0.0.0-20210923205945-b76863e36670/go.mod h1:5om86z9Hs0C8fWVUuoMHwpExlXzs5Tkyp9hOrfG7pp8=
 golang.org/x/arch v0.8.0 h1:3wRIsP3pM4yUptoR96otTUOXI367OS0+c9eeRi9doIc=
 golang.org/x/arch v0.8.0/go.mod h1:FEVrYAQjsQXMVJ1nsMoVVXPZg6p2JE2mx8psSWTDQys=


### PR DESCRIPTION
## Summary
- Adds a Go CLI binary (cmd/sfree-cli/) for terminal-based SFree management
- Commands: sources list, buckets list/create, upload, download, files list/delete, keys create
- Uses existing REST API with Basic Auth, configurable via flags or env vars
- Adds build-cli Makefile target and CLI section to README

## Test plan
- [x] go build and go vet pass
- [x] All existing tests pass
- [x] All --help commands display correctly
- [ ] Manual test against running SFree instance