### PR TITLE
Add file preview and inline download in bucket view

### DIFF
--- a/webui/src/features/bucket/ui/file-preview-modal.tsx
+++ b/webui/src/features/bucket/ui/file-preview-modal.tsx
@@ -1,0 +1,149 @@
+import {
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  Button,
+  Spinner,
+  Chip,
+} from "@heroui/react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { FileInfo } from "../../../shared/api/buckets";
+import { fetchFileBlob, downloadFile } from "../../../shared/api/buckets";
+import { DownloadIcon } from "../../../shared/icons";
+import { formatSize } from "../../../shared/lib/format";
+
+const IMAGE_EXTENSIONS = new Set(["jpg", "jpeg", "png", "gif", "webp", "svg", "bmp", "ico"]);
+const TEXT_EXTENSIONS = new Set(["txt", "json", "yaml", "yml", "md", "csv", "xml", "html", "css", "js", "ts", "tsx", "jsx", "go", "py", "sh", "toml", "ini", "cfg", "log", "env", "dockerfile"]);
+
+function getExtension(name: string): string {
+  const parts = name.toLowerCase().split(".");
+  return parts.length > 1 ? parts[parts.length - 1] : "";
+}
+
+type Props = {
+  isOpen: boolean;
+  onClose: () => void;
+  file: FileInfo | null;
+  bucketId: string;
+};
+
+export function FilePreviewModal({ isOpen, onClose, file, bucketId }: Props) {
+  const [blobUrl, setBlobUrl] = useState<string | null>(null);
+  const [textContent, setTextContent] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const blobUrlRef = useRef<string | null>(null);
+
+  const ext = file ? getExtension(file.name) : "";
+  const isImage = IMAGE_EXTENSIONS.has(ext);
+  const isText = TEXT_EXTENSIONS.has(ext);
+
+  const loadPreview = useCallback(async () => {
+    if (!file) return;
+    setIsLoading(true);
+    setError(null);
+    if (blobUrlRef.current) {
+      URL.revokeObjectURL(blobUrlRef.current);
+      blobUrlRef.current = null;
+    }
+    setBlobUrl(null);
+    setTextContent(null);
+    try {
+      const blob = await fetchFileBlob(bucketId, file.id);
+      if (isImage) {
+        const url = URL.createObjectURL(blob);
+        blobUrlRef.current = url;
+        setBlobUrl(url);
+      } else if (isText) {
+        const text = await blob.text();
+        setTextContent(text.length > 100_000 ? text.slice(0, 100_000) + "\n\n--- truncated ---" : text);
+      }
+    } catch {
+      setError("Failed to load file preview");
+    } finally {
+      setIsLoading(false);
+    }
+  }, [file, bucketId, isImage, isText]);
+
+  useEffect(() => {
+    if (isOpen && file && (isImage || isText)) {
+      loadPreview();
+    }
+    return () => {
+      if (blobUrlRef.current) {
+        URL.revokeObjectURL(blobUrlRef.current);
+        blobUrlRef.current = null;
+      }
+    };
+  }, [isOpen, file, isImage, isText, loadPreview]);
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} size="3xl" scrollBehavior="inside">
+      <ModalContent>
+        <ModalHeader className="flex flex-col gap-1">
+          <span className="truncate">{file?.name}</span>
+        </ModalHeader>
+        <ModalBody>
+          {file && (
+            <div className="flex flex-wrap gap-2 mb-4">
+              <Chip size="sm" variant="flat">{formatSize(file.size)}</Chip>
+              {ext && <Chip size="sm" variant="flat">.{ext}</Chip>}
+              <Chip size="sm" variant="flat">
+                {new Date(file.created_at).toLocaleString()}
+              </Chip>
+            </div>
+          )}
+
+          {isLoading && (
+            <div className="flex justify-center py-12">
+              <Spinner size="lg" />
+            </div>
+          )}
+
+          {error && (
+            <div className="text-center text-danger py-8">{error}</div>
+          )}
+
+          {!isLoading && !error && isImage && blobUrl && (
+            <div className="flex justify-center">
+              <img
+                src={blobUrl}
+                alt={file?.name}
+                className="max-w-full max-h-[60vh] object-contain rounded"
+              />
+            </div>
+          )}
+
+          {!isLoading && !error && isText && textContent !== null && (
+            <pre className="bg-default-100 rounded-lg p-4 overflow-auto max-h-[60vh] text-sm font-mono whitespace-pre-wrap break-words">
+              {textContent}
+            </pre>
+          )}
+
+          {!isLoading && !error && !isImage && !isText && file && (
+            <div className="text-center py-12 text-default-500">
+              <p className="text-lg mb-2">Preview not available for this file type</p>
+              <p>Click Download to save the file</p>
+            </div>
+          )}
+        </ModalBody>
+        <ModalFooter>
+          <Button variant="light" onPress={onClose}>
+            Close
+          </Button>
+          {file && (
+            <Button
+              color="primary"
+              startContent={<DownloadIcon className="w-4 h-4" />}
+              onPress={() => downloadFile(bucketId, file)}
+            >
+              Download
+            </Button>
+          )}
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/webui/src/pages/bucket/ui/bucket-page.tsx
+++ b/webui/src/pages/bucket/ui/bucket-page.tsx
@@ -13,6 +13,8 @@ import { DownloadIcon } from "../../../shared/icons";
 import { DeleteIcon } from "@heroui/shared-icons";
 import { ConfirmDialog } from "../../../shared/ui";
 import { ArrowLeftIcon } from "@heroui/shared-icons";
+import { FilePreviewModal } from "../../../features/bucket/ui/file-preview-modal";
+import { formatSize } from "../../../shared/lib/format";
 
 export function BucketPage() {
   const { id } = useParams<{ id: string }>();
@@ -24,6 +26,7 @@ export function BucketPage() {
   const confirm = useDisclosure();
   const [deleteId, setDeleteId] = useState<string | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
+  const [previewFile, setPreviewFile] = useState<FileInfo | null>(null);
 
   const load = useCallback(async () => {
     if (!id) return;
@@ -115,8 +118,16 @@ export function BucketPage() {
             <tbody>
               {files.map((f) => (
                 <tr key={f.id} className="border-t">
-                  <td className="py-2">{f.name}</td>
-                  <td className="py-2">{f.size}</td>
+                  <td className="py-2">
+                    <button
+                      type="button"
+                      className="text-left hover:text-primary transition-colors cursor-pointer"
+                      onClick={() => setPreviewFile(f)}
+                    >
+                      {f.name}
+                    </button>
+                  </td>
+                  <td className="py-2">{formatSize(f.size)}</td>
                   <td className="py-2">
                     {new Date(f.created_at).toLocaleString()}
                   </td>
@@ -159,6 +170,12 @@ export function BucketPage() {
         onConfirm={handleDelete}
         confirmLabel="Delete"
         isConfirmLoading={isDeleting}
+      />
+      <FilePreviewModal
+        isOpen={previewFile !== null}
+        onClose={() => setPreviewFile(null)}
+        file={previewFile}
+        bucketId={id!}
       />
     </div>
   );

--- a/webui/src/shared/api/buckets.ts
+++ b/webui/src/shared/api/buckets.ts
@@ -97,6 +97,20 @@ export async function downloadFile(
   window.URL.revokeObjectURL(url);
 }
 
+export async function fetchFileBlob(
+  bucketId: string,
+  fileId: string,
+): Promise<Blob> {
+  const res = await fetch(
+    `${API_BASE}/buckets/${bucketId}/files/${fileId}/download`,
+    {
+      headers: authHeader(),
+    },
+  );
+  if (!res.ok) throw new Error("failed to fetch file");
+  return res.blob();
+}
+
 export async function deleteFile(
   bucketId: string,
   fileId: string,

--- a/webui/src/shared/lib/format.ts
+++ b/webui/src/shared/lib/format.ts
@@ -1,0 +1,7 @@
+export function formatSize(bytes: number): string {
+  if (bytes === 0) return "0 B";
+  const units = ["B", "KB", "MB", "GB"];
+  const i = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+  const val = bytes / Math.pow(1024, i);
+  return `${val.toFixed(i === 0 ? 0 : 1)} ${units[i]}`;
+}


### PR DESCRIPTION
## Summary

- Clicking a file name in the bucket file list opens a preview modal
- Image files (jpg, png, gif, webp, svg, etc.) render inline with `<img>`
- Text files (json, yaml, md, go, py, etc.) display in a monospace `<pre>` block (truncated at 100KB)
- Other file types show metadata with a download-only prompt
- Modal shows file metadata chips (formatted size, extension, upload date)
- Download button in modal footer for one-click save
- File sizes in the table now display human-readable format (KB, MB, etc.)
- No new backend endpoints — uses existing download API
- Minimal bundle impact (~3KB), no heavy dependencies added

## New files

| File | Purpose |
| --- | --- |
| `webui/src/features/bucket/ui/file-preview-modal.tsx` | Preview modal component |
| `webui/src/shared/lib/format.ts` | `formatSize()` utility |
| `webui/src/shared/api/buckets.ts` | Added `fetchFileBlob()` helper |

## Test plan

- [ ] Upload an image file → click file name → verify image renders inline in modal
- [ ] Upload a .json or .md file → click file name → verify text renders in monospace
- [ ] Upload a .zip or .pdf → click file name → verify "preview not available" message + download button
- [ ] Verify download button in modal triggers file download
- [ ] Verify file sizes show as KB/MB in the table
- [ ] Verify lint (`npm run lint`) and build (`npm run build`) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)