### PR TITLE
Fix web UI contributor workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,13 +62,11 @@ Prerequisites:
 
 - Node.js 20+ with npm
 
-Install **all** dependencies (including dev tools like TypeScript and ESLint)
-and start the dev server:
+Install **all** dependencies (including dev tools like TypeScript and ESLint):
 
 ```bash
 cd webui
 npm ci
-npm run dev
 ```
 
 > **Why `npm ci` instead of `npm install`?** `npm ci` installs from the
@@ -76,9 +74,18 @@ npm run dev
 > Avoid running with `NODE_ENV=production`, which omits `devDependencies` and
 > breaks `npm run lint` and `npm run build` (they need `tsc` and `eslint`).
 
-The frontend reads `VITE_API_BASE` at build time (defaults to `/api/v1`).
-For local development against the Docker Compose stack no changes are needed;
-the webui container proxies API requests to the backend automatically.
+Start the Vite dev server:
+
+```bash
+npm run dev
+```
+
+The dev server proxies `/api` requests to `http://localhost:8080` automatically
+(configurable via `VITE_API_URL`). Make sure the Go API is running locally
+before starting the frontend. See `webui/.env.example` for available env vars.
+
+For development against the Docker Compose stack, no extra config is needed —
+the webui container proxies API requests via nginx.
 
 For standalone dev against a local Go API:
 

--- a/webui/.env.example
+++ b/webui/.env.example
@@ -1,0 +1,6 @@
+# API base path used at build time (default: /api/v1)
+# For standalone dev mode this is not needed — Vite proxies /api to the backend.
+# VITE_API_BASE=/api/v1
+
+# Backend URL for the Vite dev proxy (default: http://localhost:8080)
+# VITE_API_URL=http://localhost:8080

--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -14,11 +14,12 @@
         "next-themes": "^0.4.6",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
-        "react-router-dom": "^6.30.1"
+        "react-router-dom": "^6.30.3"
       },
       "devDependencies": {
         "@eslint/js": "^9.33.0",
         "@tailwindcss/postcss": "^4.1.12",
+        "@types/node": "^25.6.0",
         "@types/react": "^19.1.10",
         "@types/react-dom": "^19.1.7",
         "@vitejs/plugin-react": "^5.0.0",
@@ -4723,9 +4724,9 @@
       }
     },
     "node_modules/@remix-run/router": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
-      "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
+      "version": "1.23.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
+      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -5388,6 +5389,16 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
     },
     "node_modules/@types/react": {
       "version": "19.1.12",
@@ -7437,12 +7448,12 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.30.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.1.tgz",
-      "integrity": "sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==",
+      "version": "6.30.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
+      "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.0"
+        "@remix-run/router": "1.23.2"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -7452,13 +7463,13 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.30.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.1.tgz",
-      "integrity": "sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==",
+      "version": "6.30.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
+      "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.0",
-        "react-router": "6.30.1"
+        "@remix-run/router": "1.23.2",
+        "react-router": "6.30.3"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -7870,6 +7881,13 @@
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",

--- a/webui/package.json
+++ b/webui/package.json
@@ -16,11 +16,12 @@
     "next-themes": "^0.4.6",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
-    "react-router-dom": "^6.30.1"
+    "react-router-dom": "^6.30.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",
     "@tailwindcss/postcss": "^4.1.12",
+    "@types/node": "^25.6.0",
     "@types/react": "^19.1.10",
     "@types/react-dom": "^19.1.7",
     "@vitejs/plugin-react": "^5.0.0",

--- a/webui/vite.config.ts
+++ b/webui/vite.config.ts
@@ -4,4 +4,12 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      '/api': {
+        target: process.env.VITE_API_URL || 'http://localhost:8080',
+        changeOrigin: true,
+      },
+    },
+  },
 })


### PR DESCRIPTION
## Summary

- Add Vite dev server proxy so `npm run dev` routes `/api` to backend at `localhost:8080`
- Fix react-router-dom XSS vulnerability (GHSA-2w69) by updating to 6.30.3
- Add `@types/node` dev dependency to fix `process.env` TypeScript error in vite.config.ts
- Add `webui/.env.example` documenting available environment variables
- Update CONTRIBUTING.md with explicit frontend dev setup instructions, including NODE_ENV workaround

## Test plan

- [ ] Fresh `git clone && cd webui && npm install && npm run dev` starts without errors
- [ ] Dev server proxies API requests to `localhost:8080` (verify with backend running)
- [ ] `npm run lint` passes
- [ ] `npm run build` passes with no TypeScript errors
- [ ] `npm audit` reports 0 vulnerabilities
- [ ] CONTRIBUTING.md frontend section matches actual workflow

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)