### PR TITLE
Add public file sharing links

### DIFF
--- a/api-go/internal/app/router.go
+++ b/api-go/internal/app/router.go
@@ -29,11 +29,12 @@ func SetupRouter(m *db.Mongo, cfg *config.Config) *gin.Engine {
 	router.GET("/dbz", handlers.DBProbe(m))
 
 	var (
-		auth       gin.HandlerFunc
-		userRepo   *repository.UserRepository
-		bucketRepo *repository.BucketRepository
-		sourceRepo *repository.SourceRepository
-		fileRepo   *repository.FileRepository
+		auth          gin.HandlerFunc
+		userRepo      *repository.UserRepository
+		bucketRepo    *repository.BucketRepository
+		sourceRepo    *repository.SourceRepository
+		fileRepo      *repository.FileRepository
+		shareLinkRepo *repository.ShareLinkRepository
 	)
 
 	jwtSecret := ""
@@ -54,6 +55,7 @@ func SetupRouter(m *db.Mongo, cfg *config.Config) *gin.Engine {
 		bucketRepo, _ = repository.NewBucketRepository(m.DB)
 		sourceRepo, _ = repository.NewSourceRepository(m.DB)
 		fileRepo, _ = repository.NewFileRepository(m.DB)
+		shareLinkRepo, _ = repository.NewShareLinkRepository(m.DB)
 	}
 
 	// OAuth and auth utility routes.
@@ -84,6 +86,11 @@ func SetupRouter(m *db.Mongo, cfg *config.Config) *gin.Engine {
 			router.GET("/api/v1/buckets/:id/files", auth, handlers.ListFiles(bucketRepo, fileRepo))
 			router.GET("/api/v1/buckets/:id/files/:file_id/download", auth, handlers.DownloadFile(bucketRepo, sourceRepo, fileRepo))
 			router.DELETE("/api/v1/buckets/:id/files/:file_id", auth, handlers.DeleteFile(bucketRepo, sourceRepo, fileRepo))
+			if shareLinkRepo != nil {
+				router.POST("/api/v1/buckets/:id/files/:file_id/share", auth, handlers.CreateShareLink(bucketRepo, fileRepo, shareLinkRepo))
+				router.GET("/api/v1/buckets/:id/files/:file_id/shares", auth, handlers.ListShareLinks(bucketRepo, fileRepo, shareLinkRepo))
+				router.DELETE("/api/v1/shares/:id", auth, handlers.DeleteShareLink(shareLinkRepo))
+			}
 		}
 	}
 
@@ -95,6 +102,11 @@ func SetupRouter(m *db.Mongo, cfg *config.Config) *gin.Engine {
 		router.GET("/api/v1/sources/:id/info", auth, handlers.GetSourceInfo(sourceRepo))
 		router.GET("/api/v1/sources/:id/files/:file_id/download", auth, handlers.DownloadSourceFile(sourceRepo))
 		router.DELETE("/api/v1/sources/:id", auth, handlers.DeleteSource(sourceRepo, bucketRepo))
+	}
+
+	// Public share link route (no auth required).
+	if shareLinkRepo != nil && bucketRepo != nil && sourceRepo != nil && fileRepo != nil {
+		router.GET("/share/:token", handlers.GetSharedFile(shareLinkRepo, bucketRepo, sourceRepo, fileRepo))
 	}
 
 	router.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))

--- a/api-go/internal/handlers/sharelink.go
+++ b/api-go/internal/handlers/sharelink.go
@@ -1,0 +1,356 @@
+package handlers
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/example/sfree/api-go/internal/cryptoutil"
+	"github.com/example/sfree/api-go/internal/manager"
+	"github.com/example/sfree/api-go/internal/repository"
+	"github.com/gin-gonic/gin"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+const shareTokenLength = 32
+
+type createShareRequest struct {
+	ExpiresIn *int `json:"expires_in"` // seconds until expiry, optional
+}
+
+type shareLinkResponse struct {
+	ID        string     `json:"id"`
+	FileID    string     `json:"file_id"`
+	FileName  string     `json:"file_name"`
+	Token     string     `json:"token"`
+	URL       string     `json:"url"`
+	ExpiresAt *time.Time `json:"expires_at,omitempty"`
+	CreatedAt time.Time  `json:"created_at"`
+}
+
+// CreateShareLink godoc
+// @Summary Create a public share link for a file
+// @Tags shares
+// @Accept json
+// @Produce json
+// @Param id path string true "Bucket ID"
+// @Param file_id path string true "File ID"
+// @Param body body createShareRequest false "Share options"
+// @Success 200 {object} shareLinkResponse
+// @Failure 400 {string} string ""
+// @Failure 401 {string} string ""
+// @Failure 404 {string} string ""
+// @Failure 500 {string} string ""
+// @Security BasicAuth
+// @Router /api/v1/buckets/{id}/files/{file_id}/share [post]
+func CreateShareLink(bucketRepo *repository.BucketRepository, fileRepo *repository.FileRepository, shareLinkRepo *repository.ShareLinkRepository) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if bucketRepo == nil || fileRepo == nil || shareLinkRepo == nil {
+			log.Print("create share link: repository is nil")
+			c.Status(http.StatusServiceUnavailable)
+			return
+		}
+		bucketID, err := primitive.ObjectIDFromHex(c.Param("id"))
+		if err != nil {
+			c.Status(http.StatusBadRequest)
+			return
+		}
+		fileID, err := primitive.ObjectIDFromHex(c.Param("file_id"))
+		if err != nil {
+			c.Status(http.StatusBadRequest)
+			return
+		}
+		userIDHex := c.GetString("userID")
+		if userIDHex == "" {
+			c.Status(http.StatusUnauthorized)
+			return
+		}
+		userID, err := primitive.ObjectIDFromHex(userIDHex)
+		if err != nil {
+			c.Status(http.StatusUnauthorized)
+			return
+		}
+
+		// Verify bucket ownership.
+		bucketDoc, err := bucketRepo.GetByID(c.Request.Context(), bucketID)
+		if err != nil {
+			if err == mongo.ErrNoDocuments {
+				c.Status(http.StatusNotFound)
+				return
+			}
+			log.Printf("create share link: get bucket: %v", err)
+			c.Status(http.StatusInternalServerError)
+			return
+		}
+		if bucketDoc.UserID != userID {
+			c.Status(http.StatusNotFound)
+			return
+		}
+
+		// Verify file exists in bucket.
+		fileDoc, err := fileRepo.GetByID(c.Request.Context(), fileID)
+		if err != nil {
+			if err == mongo.ErrNoDocuments {
+				c.Status(http.StatusNotFound)
+				return
+			}
+			log.Printf("create share link: get file: %v", err)
+			c.Status(http.StatusInternalServerError)
+			return
+		}
+		if fileDoc.BucketID != bucketID {
+			c.Status(http.StatusNotFound)
+			return
+		}
+
+		var req createShareRequest
+		// Body is optional; ignore bind errors for empty body.
+		_ = c.ShouldBindJSON(&req)
+
+		token, err := cryptoutil.RandomString(shareTokenLength)
+		if err != nil {
+			log.Printf("create share link: generate token: %v", err)
+			c.Status(http.StatusInternalServerError)
+			return
+		}
+
+		now := time.Now().UTC()
+		sl := repository.ShareLink{
+			FileID:    fileID,
+			BucketID:  bucketID,
+			UserID:    userID,
+			Token:     token,
+			CreatedAt: now,
+		}
+		if req.ExpiresIn != nil && *req.ExpiresIn > 0 {
+			exp := now.Add(time.Duration(*req.ExpiresIn) * time.Second)
+			sl.ExpiresAt = &exp
+		}
+
+		created, err := shareLinkRepo.Create(c.Request.Context(), sl)
+		if err != nil {
+			log.Printf("create share link: save: %v", err)
+			c.Status(http.StatusInternalServerError)
+			return
+		}
+
+		c.JSON(http.StatusOK, shareLinkResponse{
+			ID:        created.ID.Hex(),
+			FileID:    created.FileID.Hex(),
+			FileName:  fileDoc.Name,
+			Token:     created.Token,
+			URL:       fmt.Sprintf("/share/%s", created.Token),
+			ExpiresAt: created.ExpiresAt,
+			CreatedAt: created.CreatedAt,
+		})
+	}
+}
+
+// GetSharedFile godoc
+// @Summary Download a publicly shared file
+// @Tags shares
+// @Produce octet-stream
+// @Param token path string true "Share token"
+// @Success 200 {file} file
+// @Failure 404 {string} string ""
+// @Failure 410 {string} string ""
+// @Failure 500 {string} string ""
+// @Router /share/{token} [get]
+func GetSharedFile(shareLinkRepo *repository.ShareLinkRepository, bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if shareLinkRepo == nil || bucketRepo == nil || sourceRepo == nil || fileRepo == nil {
+			log.Print("get shared file: repository is nil")
+			c.Status(http.StatusServiceUnavailable)
+			return
+		}
+		token := c.Param("token")
+		if token == "" {
+			c.Status(http.StatusNotFound)
+			return
+		}
+
+		sl, err := shareLinkRepo.GetByToken(c.Request.Context(), token)
+		if err != nil {
+			if err == mongo.ErrNoDocuments {
+				c.Status(http.StatusNotFound)
+				return
+			}
+			log.Printf("get shared file: lookup token: %v", err)
+			c.Status(http.StatusInternalServerError)
+			return
+		}
+
+		// Check expiry.
+		if sl.ExpiresAt != nil && time.Now().UTC().After(*sl.ExpiresAt) {
+			c.Status(http.StatusGone)
+			return
+		}
+
+		fileDoc, err := fileRepo.GetByID(c.Request.Context(), sl.FileID)
+		if err != nil {
+			if err == mongo.ErrNoDocuments {
+				c.Status(http.StatusNotFound)
+				return
+			}
+			log.Printf("get shared file: get file: %v", err)
+			c.Status(http.StatusInternalServerError)
+			return
+		}
+
+		var total int64
+		for _, ch := range fileDoc.Chunks {
+			total += ch.Size
+		}
+		c.Header("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s\"", fileDoc.Name))
+		c.Header("Content-Type", "application/octet-stream")
+		c.Header("Content-Length", strconv.FormatInt(total, 10))
+		c.Status(http.StatusOK)
+		if err := manager.StreamFile(c.Request.Context(), sourceRepo, fileDoc, c.Writer); err != nil {
+			log.Printf("get shared file: stream: %v", err)
+		}
+	}
+}
+
+// ListShareLinks godoc
+// @Summary List share links for a file
+// @Tags shares
+// @Produce json
+// @Param id path string true "Bucket ID"
+// @Param file_id path string true "File ID"
+// @Success 200 {array} shareLinkResponse
+// @Failure 400 {string} string ""
+// @Failure 401 {string} string ""
+// @Failure 404 {string} string ""
+// @Failure 500 {string} string ""
+// @Security BasicAuth
+// @Router /api/v1/buckets/{id}/files/{file_id}/shares [get]
+func ListShareLinks(bucketRepo *repository.BucketRepository, fileRepo *repository.FileRepository, shareLinkRepo *repository.ShareLinkRepository) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if bucketRepo == nil || fileRepo == nil || shareLinkRepo == nil {
+			log.Print("list share links: repository is nil")
+			c.Status(http.StatusServiceUnavailable)
+			return
+		}
+		bucketID, err := primitive.ObjectIDFromHex(c.Param("id"))
+		if err != nil {
+			c.Status(http.StatusBadRequest)
+			return
+		}
+		fileID, err := primitive.ObjectIDFromHex(c.Param("file_id"))
+		if err != nil {
+			c.Status(http.StatusBadRequest)
+			return
+		}
+		userIDHex := c.GetString("userID")
+		if userIDHex == "" {
+			c.Status(http.StatusUnauthorized)
+			return
+		}
+		userID, err := primitive.ObjectIDFromHex(userIDHex)
+		if err != nil {
+			c.Status(http.StatusUnauthorized)
+			return
+		}
+
+		bucketDoc, err := bucketRepo.GetByID(c.Request.Context(), bucketID)
+		if err != nil {
+			if err == mongo.ErrNoDocuments {
+				c.Status(http.StatusNotFound)
+				return
+			}
+			log.Printf("list share links: get bucket: %v", err)
+			c.Status(http.StatusInternalServerError)
+			return
+		}
+		if bucketDoc.UserID != userID {
+			c.Status(http.StatusNotFound)
+			return
+		}
+
+		fileDoc, err := fileRepo.GetByID(c.Request.Context(), fileID)
+		if err != nil {
+			if err == mongo.ErrNoDocuments {
+				c.Status(http.StatusNotFound)
+				return
+			}
+			log.Printf("list share links: get file: %v", err)
+			c.Status(http.StatusInternalServerError)
+			return
+		}
+		if fileDoc.BucketID != bucketID {
+			c.Status(http.StatusNotFound)
+			return
+		}
+
+		links, err := shareLinkRepo.ListByFile(c.Request.Context(), fileID)
+		if err != nil {
+			log.Printf("list share links: list: %v", err)
+			c.Status(http.StatusInternalServerError)
+			return
+		}
+
+		resp := make([]shareLinkResponse, 0, len(links))
+		for _, sl := range links {
+			resp = append(resp, shareLinkResponse{
+				ID:        sl.ID.Hex(),
+				FileID:    sl.FileID.Hex(),
+				FileName:  fileDoc.Name,
+				Token:     sl.Token,
+				URL:       fmt.Sprintf("/share/%s", sl.Token),
+				ExpiresAt: sl.ExpiresAt,
+				CreatedAt: sl.CreatedAt,
+			})
+		}
+		c.JSON(http.StatusOK, resp)
+	}
+}
+
+// DeleteShareLink godoc
+// @Summary Revoke a share link
+// @Tags shares
+// @Param id path string true "Share link ID"
+// @Success 200 {string} string ""
+// @Failure 400 {string} string ""
+// @Failure 401 {string} string ""
+// @Failure 404 {string} string ""
+// @Failure 500 {string} string ""
+// @Security BasicAuth
+// @Router /api/v1/shares/{id} [delete]
+func DeleteShareLink(shareLinkRepo *repository.ShareLinkRepository) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if shareLinkRepo == nil {
+			log.Print("delete share link: repository is nil")
+			c.Status(http.StatusServiceUnavailable)
+			return
+		}
+		id, err := primitive.ObjectIDFromHex(c.Param("id"))
+		if err != nil {
+			c.Status(http.StatusBadRequest)
+			return
+		}
+		userIDHex := c.GetString("userID")
+		if userIDHex == "" {
+			c.Status(http.StatusUnauthorized)
+			return
+		}
+		userID, err := primitive.ObjectIDFromHex(userIDHex)
+		if err != nil {
+			c.Status(http.StatusUnauthorized)
+			return
+		}
+
+		if err := shareLinkRepo.Delete(c.Request.Context(), id, userID); err != nil {
+			if err == mongo.ErrNoDocuments {
+				c.Status(http.StatusNotFound)
+				return
+			}
+			log.Printf("delete share link: %v", err)
+			c.Status(http.StatusInternalServerError)
+			return
+		}
+		c.Status(http.StatusOK)
+	}
+}

--- a/api-go/internal/repository/sharelink.go
+++ b/api-go/internal/repository/sharelink.go
@@ -1,0 +1,130 @@
+package repository
+
+import (
+	"context"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+type ShareLink struct {
+	ID        primitive.ObjectID `bson:"_id,omitempty"`
+	FileID    primitive.ObjectID `bson:"file_id"`
+	BucketID  primitive.ObjectID `bson:"bucket_id"`
+	UserID    primitive.ObjectID `bson:"user_id"`
+	Token     string             `bson:"token"`
+	ExpiresAt *time.Time         `bson:"expires_at,omitempty"`
+	CreatedAt time.Time          `bson:"created_at"`
+}
+
+type ShareLinkRepository struct {
+	coll *mongo.Collection
+}
+
+func NewShareLinkRepository(db *mongo.Database) (*ShareLinkRepository, error) {
+	coll := db.Collection("share_links")
+	_, err := coll.Indexes().CreateMany(context.Background(), []mongo.IndexModel{
+		{
+			Keys:    bson.D{{Key: "token", Value: 1}},
+			Options: options.Index().SetUnique(true),
+		},
+		{
+			Keys: bson.D{{Key: "file_id", Value: 1}},
+		},
+		{
+			Keys: bson.D{{Key: "user_id", Value: 1}},
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &ShareLinkRepository{coll: coll}, nil
+}
+
+func (r *ShareLinkRepository) Create(ctx context.Context, sl ShareLink) (*ShareLink, error) {
+	sl.CreatedAt = sl.CreatedAt.UTC()
+	if sl.ExpiresAt != nil {
+		t := sl.ExpiresAt.UTC()
+		sl.ExpiresAt = &t
+	}
+	res, err := r.coll.InsertOne(ctx, sl)
+	if err != nil {
+		return nil, err
+	}
+	if oid, ok := res.InsertedID.(primitive.ObjectID); ok {
+		sl.ID = oid
+	}
+	return &sl, nil
+}
+
+func (r *ShareLinkRepository) GetByToken(ctx context.Context, token string) (*ShareLink, error) {
+	var sl ShareLink
+	err := r.coll.FindOne(ctx, bson.M{"token": token}).Decode(&sl)
+	if err != nil {
+		return nil, err
+	}
+	return &sl, nil
+}
+
+func (r *ShareLinkRepository) GetByID(ctx context.Context, id primitive.ObjectID) (*ShareLink, error) {
+	var sl ShareLink
+	err := r.coll.FindOne(ctx, bson.M{"_id": id}).Decode(&sl)
+	if err != nil {
+		return nil, err
+	}
+	return &sl, nil
+}
+
+func (r *ShareLinkRepository) ListByUser(ctx context.Context, userID primitive.ObjectID) ([]ShareLink, error) {
+	cursor, err := r.coll.Find(ctx, bson.M{"user_id": userID})
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = cursor.Close(ctx) }()
+	var links []ShareLink
+	for cursor.Next(ctx) {
+		var sl ShareLink
+		if err := cursor.Decode(&sl); err != nil {
+			return nil, err
+		}
+		links = append(links, sl)
+	}
+	if err := cursor.Err(); err != nil {
+		return nil, err
+	}
+	return links, nil
+}
+
+func (r *ShareLinkRepository) ListByFile(ctx context.Context, fileID primitive.ObjectID) ([]ShareLink, error) {
+	cursor, err := r.coll.Find(ctx, bson.M{"file_id": fileID})
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = cursor.Close(ctx) }()
+	var links []ShareLink
+	for cursor.Next(ctx) {
+		var sl ShareLink
+		if err := cursor.Decode(&sl); err != nil {
+			return nil, err
+		}
+		links = append(links, sl)
+	}
+	if err := cursor.Err(); err != nil {
+		return nil, err
+	}
+	return links, nil
+}
+
+func (r *ShareLinkRepository) Delete(ctx context.Context, id primitive.ObjectID, userID primitive.ObjectID) error {
+	res, err := r.coll.DeleteOne(ctx, bson.M{"_id": id, "user_id": userID})
+	if err != nil {
+		return err
+	}
+	if res.DeletedCount == 0 {
+		return mongo.ErrNoDocuments
+	}
+	return nil
+}

--- a/webui/src/pages/bucket/ui/bucket-page.tsx
+++ b/webui/src/pages/bucket/ui/bucket-page.tsx
@@ -1,4 +1,13 @@
-import {Button, Spinner, useDisclosure} from "@heroui/react";
+import {
+  Button,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  Spinner,
+  useDisclosure,
+} from "@heroui/react";
 import {addToast} from "@heroui/toast";
 import {useCallback, useEffect, useRef, useState} from "react";
 import {useNavigate, useParams} from "react-router-dom";
@@ -10,7 +19,13 @@ import {
   uploadFile,
 } from "../../../shared/api/buckets";
 import type {Bucket, FileInfo} from "../../../shared/api/buckets";
-import {DownloadIcon} from "../../../shared/icons";
+import {
+  createShareLink,
+  deleteShareLink,
+  listShareLinks,
+} from "../../../shared/api/shares";
+import type {ShareLinkInfo} from "../../../shared/api/shares";
+import {DownloadIcon, ShareIcon} from "../../../shared/icons";
 import {DeleteIcon, ArrowLeftIcon} from "@heroui/shared-icons";
 import {ConfirmDialog, EmptyState} from "../../../shared/ui";
 import {FilePreviewModal} from "../../../features/bucket/ui/file-preview-modal";
@@ -29,6 +44,12 @@ export function BucketPage() {
   const [deleteId, setDeleteId] = useState<string | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
   const [previewFile, setPreviewFile] = useState<FileInfo | null>(null);
+
+  const shareModal = useDisclosure();
+  const [shareFile, setShareFile] = useState<FileInfo | null>(null);
+  const [shareLinks, setShareLinks] = useState<ShareLinkInfo[]>([]);
+  const [isCreatingShare, setIsCreatingShare] = useState(false);
+  const [copiedToken, setCopiedToken] = useState<string | null>(null);
 
   const load = useCallback(async () => {
     if (!id) return;
@@ -84,6 +105,45 @@ export function BucketPage() {
       setIsDeleting(false);
       confirm.onClose();
     }
+  }
+
+  async function openShareModal(file: FileInfo) {
+    if (!id) return;
+    setShareFile(file);
+    shareModal.onOpen();
+    try {
+      const links = await listShareLinks(id, file.id);
+      setShareLinks(links);
+    } catch {
+      setShareLinks([]);
+    }
+  }
+
+  async function handleCreateShare() {
+    if (!id || !shareFile) return;
+    setIsCreatingShare(true);
+    try {
+      const link = await createShareLink(id, shareFile.id);
+      setShareLinks((prev) => [...prev, link]);
+    } finally {
+      setIsCreatingShare(false);
+    }
+  }
+
+  async function handleDeleteShare(shareId: string) {
+    try {
+      await deleteShareLink(shareId);
+      setShareLinks((prev) => prev.filter((l) => l.id !== shareId));
+    } catch {
+      // ignore
+    }
+  }
+
+  function copyShareUrl(link: ShareLinkInfo) {
+    const url = `${window.location.origin}${link.url}`;
+    navigator.clipboard.writeText(url);
+    setCopiedToken(link.token);
+    setTimeout(() => setCopiedToken(null), 2000);
   }
 
   if (isLoading) {
@@ -192,6 +252,13 @@ export function BucketPage() {
                       <Button
                         isIconOnly
                         variant="light"
+                        onPress={() => openShareModal(f)}
+                      >
+                        <ShareIcon className="w-5 h-5" />
+                      </Button>
+                      <Button
+                        isIconOnly
+                        variant="light"
                         onPress={() => downloadFile(id!, f)}
                       >
                         <DownloadIcon className="w-5 h-5" />
@@ -233,6 +300,78 @@ export function BucketPage() {
         file={previewFile}
         bucketId={id!}
       />
+      <Modal
+        isOpen={shareModal.isOpen}
+        onOpenChange={(open) => {
+          if (!open) {
+            setShareFile(null);
+            setShareLinks([]);
+            setCopiedToken(null);
+          }
+          shareModal.onOpenChange();
+        }}
+        size="lg"
+      >
+        <ModalContent>
+          {(onClose) => (
+            <>
+              <ModalHeader>Share: {shareFile?.name}</ModalHeader>
+              <ModalBody>
+                {shareLinks.length === 0 ? (
+                  <p className="text-sm text-gray-500">
+                    No share links yet. Create one to share this file publicly.
+                  </p>
+                ) : (
+                  <div className="flex flex-col gap-2">
+                    {shareLinks.map((link) => (
+                      <div
+                        key={link.id}
+                        className="flex items-center gap-2 border rounded p-2 text-sm"
+                      >
+                        <code className="flex-1 truncate">
+                          {window.location.origin}{link.url}
+                        </code>
+                        <Button
+                          size="sm"
+                          variant="flat"
+                          onPress={() => copyShareUrl(link)}
+                        >
+                          {copiedToken === link.token ? "Copied!" : "Copy"}
+                        </Button>
+                        <Button
+                          size="sm"
+                          variant="flat"
+                          color="danger"
+                          onPress={() => handleDeleteShare(link.id)}
+                        >
+                          Revoke
+                        </Button>
+                        {link.expires_at && (
+                          <span className="text-xs text-gray-400">
+                            expires {new Date(link.expires_at).toLocaleString()}
+                          </span>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </ModalBody>
+              <ModalFooter>
+                <Button variant="light" onPress={onClose}>
+                  Close
+                </Button>
+                <Button
+                  color="primary"
+                  isLoading={isCreatingShare}
+                  onPress={handleCreateShare}
+                >
+                  Create Share Link
+                </Button>
+              </ModalFooter>
+            </>
+          )}
+        </ModalContent>
+      </Modal>
     </div>
   );
 }

--- a/webui/src/shared/api/shares.ts
+++ b/webui/src/shared/api/shares.ts
@@ -1,0 +1,59 @@
+const API_BASE = import.meta.env.VITE_API_BASE || "/api/v1";
+
+import { getAuthHeader } from "../lib/auth";
+
+function authHeader(): Record<string, string> {
+  return getAuthHeader();
+}
+
+export type ShareLinkInfo = {
+  id: string;
+  file_id: string;
+  file_name: string;
+  token: string;
+  url: string;
+  expires_at: string | null;
+  created_at: string;
+};
+
+export async function createShareLink(
+  bucketId: string,
+  fileId: string,
+  expiresIn?: number,
+): Promise<ShareLinkInfo> {
+  const res = await fetch(
+    `${API_BASE}/buckets/${bucketId}/files/${fileId}/share`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...authHeader(),
+      },
+      body: JSON.stringify(expiresIn ? { expires_in: expiresIn } : {}),
+    },
+  );
+  if (!res.ok) throw new Error("failed to create share link");
+  return res.json();
+}
+
+export async function listShareLinks(
+  bucketId: string,
+  fileId: string,
+): Promise<ShareLinkInfo[]> {
+  const res = await fetch(
+    `${API_BASE}/buckets/${bucketId}/files/${fileId}/shares`,
+    {
+      headers: authHeader(),
+    },
+  );
+  if (!res.ok) throw new Error("failed to list share links");
+  return res.json();
+}
+
+export async function deleteShareLink(id: string): Promise<void> {
+  const res = await fetch(`${API_BASE}/shares/${id}`, {
+    method: "DELETE",
+    headers: authHeader(),
+  });
+  if (!res.ok) throw new Error("failed to delete share link");
+}

--- a/webui/src/shared/icons/index.ts
+++ b/webui/src/shared/icons/index.ts
@@ -3,3 +3,4 @@ export {TelegramIcon} from "./telegram";
 export {S3Icon} from "./s3";
 export {DownloadIcon} from "./download";
 export {GitHubIcon} from "./github";
+export {ShareIcon} from "./share";

--- a/webui/src/shared/icons/share.tsx
+++ b/webui/src/shared/icons/share.tsx
@@ -1,0 +1,13 @@
+import type {SVGProps} from "react";
+
+export function ShareIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" {...props}>
+      <circle cx="18" cy="5" r="3" />
+      <circle cx="6" cy="12" r="3" />
+      <circle cx="18" cy="19" r="3" />
+      <line x1="8.59" y1="13.51" x2="15.42" y2="17.49" />
+      <line x1="15.41" y1="6.51" x2="8.59" y2="10.49" />
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary
- Add `POST /api/v1/buckets/:id/files/:file_id/share` to create share links with optional TTL
- Add `GET /share/:token` public endpoint to serve shared files without authentication
- Add `GET /api/v1/buckets/:id/files/:file_id/shares` and `DELETE /api/v1/shares/:id` for listing/revoking
- Add ShareLink MongoDB model with token uniqueness index
- Add Share button in bucket page UI with modal for creating, copying, and revoking links
- Expired links return 410 Gone

## Test plan
- [ ] Create a file, generate a share link, verify the public URL returns the file
- [ ] Create a share link with TTL, wait for expiry, verify 410 response
- [ ] Revoke a share link, verify 404 response
- [ ] Verify share links are scoped to the file owner
- [ ] Verify UI Share button opens modal, creates link, copy button works

Generated with Claude Code