### PR TITLE
Encrypt source credentials at rest in MongoDB

### DIFF
--- a/api-go/cmd/migrate-source-keys/main.go
+++ b/api-go/cmd/migrate-source-keys/main.go
@@ -1,0 +1,79 @@
+// Command migrate-source-keys encrypts existing plaintext source credentials
+// in MongoDB using AES-256-GCM. It reads the ACCESS_SECRET_KEY env var (or
+// config file) to derive the encryption key, then iterates over every document
+// in the sources collection. Records that are already encrypted (valid
+// base64 + successful AES-GCM open) are skipped.
+//
+// Usage:
+//
+//	ACCESS_SECRET_KEY=<key> go run ./cmd/migrate-source-keys
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/example/sfree/api-go/internal/config"
+	"github.com/example/sfree/api-go/internal/cryptoutil"
+	"github.com/example/sfree/api-go/internal/db"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+func main() {
+	cfg, err := config.Load()
+	if err != nil {
+		log.Fatalf("load config: %v", err)
+	}
+	secretKey := cfg.AccessSecretKey
+	if secretKey == "" {
+		fmt.Fprintln(os.Stderr, "ACCESS_SECRET_KEY is not configured")
+		os.Exit(1)
+	}
+
+	ctx := context.Background()
+	mongo, err := db.Connect(ctx, cfg.Mongo)
+	if err != nil {
+		log.Fatalf("connect mongo: %v", err)
+	}
+	defer func() { _ = mongo.Client.Disconnect(ctx) }()
+
+	coll := mongo.DB.Collection("sources")
+	cursor, err := coll.Find(ctx, bson.M{})
+	if err != nil {
+		log.Fatalf("find sources: %v", err)
+	}
+	defer func() { _ = cursor.Close(ctx) }()
+
+	var migrated, skipped, total int
+	for cursor.Next(ctx) {
+		total++
+		var doc struct {
+			ID  primitive.ObjectID `bson:"_id"`
+			Key string             `bson:"key"`
+		}
+		if err := cursor.Decode(&doc); err != nil {
+			log.Fatalf("decode source: %v", err)
+		}
+		// Try decrypting — if it succeeds, the record is already encrypted.
+		if _, err := cryptoutil.Decrypt(doc.Key, secretKey); err == nil {
+			skipped++
+			continue
+		}
+		encrypted, err := cryptoutil.Encrypt(doc.Key, secretKey)
+		if err != nil {
+			log.Fatalf("encrypt source %s: %v", doc.ID.Hex(), err)
+		}
+		_, err = coll.UpdateByID(ctx, doc.ID, bson.M{"$set": bson.M{"key": encrypted}})
+		if err != nil {
+			log.Fatalf("update source %s: %v", doc.ID.Hex(), err)
+		}
+		migrated++
+	}
+	if err := cursor.Err(); err != nil {
+		log.Fatalf("cursor error: %v", err)
+	}
+	fmt.Printf("migration complete: %d total, %d migrated, %d already encrypted\n", total, migrated, skipped)
+}

--- a/api-go/go.sum
+++ b/api-go/go.sum
@@ -235,9 +235,6 @@ go.opentelemetry.io/otel/sdk/metric v1.36.0 h1:r0ntwwGosWGaa0CrSt8cuNuTcccMXERFw
 go.opentelemetry.io/otel/sdk/metric v1.36.0/go.mod h1:qTNOhFDfKRwX0yXOqJYegL5WRaW376QbB7P4Pb0qva4=
 go.opentelemetry.io/otel/trace v1.36.0 h1:ahxWNuqZjpdiFAyrIoQ4GIiAIhxAunQR6MUoKrsNd4w=
 go.opentelemetry.io/otel/trace v1.36.0/go.mod h1:gQ+OnDZzrybY4k4seLzPAWNwVBBVlF2szhehOBB/tGA=
-<<<<<<< HEAD
-go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
-golang.org/x/arch v0.0.0-20210923205945-b76863e36670/go.mod h1:5om86z9Hs0C8fWVUuoMHwpExlXzs5Tkyp9hOrfG7pp8=
 go.opentelemetry.io/proto/otlp v1.6.0 h1:jQjP+AQyTf+Fe7OKj/MfkDrmK4MNVtw2NpXsf9fefDI=
 go.opentelemetry.io/proto/otlp v1.6.0/go.mod h1:cicgGehlFuNdgZkcALOCh3VE6K/u2tAjzlRhDwmVpZc=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=

--- a/api-go/internal/app/router.go
+++ b/api-go/internal/app/router.go
@@ -55,7 +55,11 @@ func SetupRouter(m *db.Mongo, cfg *config.Config) *gin.Engine {
 			router.POST("/api/v1/users", handlers.CreateUser(userRepo))
 		}
 		bucketRepo, _ = repository.NewBucketRepository(m.DB)
-		sourceRepo, _ = repository.NewSourceRepository(m.DB)
+		srcSecretKey := ""
+		if cfg != nil {
+			srcSecretKey = cfg.AccessSecretKey
+		}
+		sourceRepo, _ = repository.NewSourceRepository(m.DB, srcSecretKey)
 		fileRepo, _ = repository.NewFileRepository(m.DB)
 		shareLinkRepo, _ = repository.NewShareLinkRepository(m.DB)
 	}

--- a/api-go/internal/handlers/bucket.go
+++ b/api-go/internal/handlers/bucket.go
@@ -307,7 +307,7 @@ func UpdateBucketDistribution(repo *repository.BucketRepository) gin.HandlerFunc
 				c.Status(http.StatusNotFound)
 				return
 			}
-			log.Printf("update distribution: %v", err)
+			slog.ErrorContext(c.Request.Context(), "update distribution", slog.String("error", err.Error()))
 			c.Status(http.StatusInternalServerError)
 			return
 		}

--- a/api-go/internal/manager/file.go
+++ b/api-go/internal/manager/file.go
@@ -15,6 +15,7 @@ import (
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 )
 
 var ErrUnsupportedSourceType = errors.New("unsupported source type")
@@ -120,8 +121,10 @@ func NewSourceClient(ctx context.Context, src *repository.Source) (sourceClient,
 
 func StreamFile(ctx context.Context, srcRepo *repository.SourceRepository, f *repository.File, w io.Writer) error {
 	ctx, span := tracer.Start(ctx, "StreamFile",
-		attribute.String("file.id", f.ID.Hex()),
-		attribute.Int("file.chunks", len(f.Chunks)),
+		trace.WithAttributes(
+			attribute.String("file.id", f.ID.Hex()),
+			attribute.Int("file.chunks", len(f.Chunks)),
+		),
 	)
 	defer span.End()
 
@@ -145,8 +148,10 @@ func StreamFile(ctx context.Context, srcRepo *repository.SourceRepository, f *re
 		}
 
 		_, chunkSpan := tracer.Start(ctx, "DownloadChunk",
-			attribute.Int("chunk.order", i),
-			attribute.String("chunk.source_id", ch.SourceID.Hex()),
+			trace.WithAttributes(
+				attribute.Int("chunk.order", i),
+				attribute.String("chunk.source_id", ch.SourceID.Hex()),
+			),
 		)
 		rc, err := cli.Download(ctx, ch.Name)
 		if err != nil {
@@ -174,7 +179,9 @@ func StreamFile(ctx context.Context, srcRepo *repository.SourceRepository, f *re
 
 func DeleteFileChunks(ctx context.Context, srcRepo *repository.SourceRepository, chunks []repository.FileChunk) error {
 	ctx, span := tracer.Start(ctx, "DeleteFileChunks",
-		attribute.Int("chunks.count", len(chunks)),
+		trace.WithAttributes(
+			attribute.Int("chunks.count", len(chunks)),
+		),
 	)
 	defer span.End()
 
@@ -211,8 +218,10 @@ func UploadFileChunks(ctx context.Context, r io.Reader, sources []repository.Sou
 
 func UploadFileChunksWithStrategy(ctx context.Context, r io.Reader, sources []repository.Source, chunkSize int, factory SourceClientFactory, selector SourceSelector) ([]repository.FileChunk, error) {
 	ctx, span := tracer.Start(ctx, "UploadFileChunks",
-		attribute.Int("sources.count", len(sources)),
-		attribute.Int("chunk.size", chunkSize),
+		trace.WithAttributes(
+			attribute.Int("sources.count", len(sources)),
+			attribute.Int("chunk.size", chunkSize),
+		),
 	)
 	defer span.End()
 
@@ -260,9 +269,11 @@ func UploadFileChunksWithStrategy(ctx context.Context, r io.Reader, sources []re
 		}
 
 		_, chunkSpan := tracer.Start(ctx, "UploadChunk",
-			attribute.Int("chunk.order", idx),
-			attribute.String("chunk.source_type", src.Type),
-			attribute.Int("chunk.bytes", n),
+			trace.WithAttributes(
+				attribute.Int("chunk.order", idx),
+				attribute.String("chunk.source_type", string(src.Type)),
+				attribute.Int("chunk.bytes", n),
+			),
 		)
 		driveName := primitive.NewObjectID().Hex()
 		chunkName, err := cli.Upload(ctx, driveName, bytes.NewReader(buf[:n]))

--- a/api-go/internal/repository/source.go
+++ b/api-go/internal/repository/source.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/example/sfree/api-go/internal/cryptoutil"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
@@ -27,10 +28,11 @@ type Source struct {
 }
 
 type SourceRepository struct {
-	coll *mongo.Collection
+	coll      *mongo.Collection
+	secretKey string
 }
 
-func NewSourceRepository(db *mongo.Database) (*SourceRepository, error) {
+func NewSourceRepository(db *mongo.Database, secretKey ...string) (*SourceRepository, error) {
 	coll := db.Collection("sources")
 	_, err := coll.Indexes().CreateOne(context.Background(), mongo.IndexModel{
 		Keys: bson.D{{Key: "user_id", Value: 1}},
@@ -38,11 +40,40 @@ func NewSourceRepository(db *mongo.Database) (*SourceRepository, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &SourceRepository{coll: coll}, nil
+	key := ""
+	if len(secretKey) > 0 {
+		key = secretKey[0]
+	}
+	return &SourceRepository{coll: coll, secretKey: key}, nil
+}
+
+func (r *SourceRepository) encryptKey(plain string) (string, error) {
+	if r.secretKey == "" {
+		return plain, nil
+	}
+	return cryptoutil.Encrypt(plain, r.secretKey)
+}
+
+func (r *SourceRepository) decryptKey(cipher string) string {
+	if r.secretKey == "" || cipher == "" {
+		return cipher
+	}
+	plain, err := cryptoutil.Decrypt(cipher, r.secretKey)
+	if err != nil {
+		// Not encrypted (pre-migration data) — return as-is.
+		return cipher
+	}
+	return plain
 }
 
 func (r *SourceRepository) Create(ctx context.Context, s Source) (*Source, error) {
 	s.CreatedAt = s.CreatedAt.UTC()
+	enc, err := r.encryptKey(s.Key)
+	if err != nil {
+		return nil, err
+	}
+	plainKey := s.Key
+	s.Key = enc
 	res, err := r.coll.InsertOne(ctx, s)
 	if err != nil {
 		return nil, err
@@ -50,6 +81,7 @@ func (r *SourceRepository) Create(ctx context.Context, s Source) (*Source, error
 	if oid, ok := res.InsertedID.(primitive.ObjectID); ok {
 		s.ID = oid
 	}
+	s.Key = plainKey
 	return &s, nil
 }
 
@@ -59,6 +91,7 @@ func (r *SourceRepository) GetByID(ctx context.Context, id primitive.ObjectID) (
 	if err != nil {
 		return nil, err
 	}
+	s.Key = r.decryptKey(s.Key)
 	return &s, nil
 }
 
@@ -77,6 +110,7 @@ func (r *SourceRepository) ListByIDs(ctx context.Context, ids []primitive.Object
 		if err := cursor.Decode(&src); err != nil {
 			return nil, err
 		}
+		src.Key = r.decryptKey(src.Key)
 		byID[src.ID] = src
 	}
 	if err := cursor.Err(); err != nil {
@@ -105,6 +139,7 @@ func (r *SourceRepository) ListByUser(ctx context.Context, userID primitive.Obje
 		if err := cursor.Decode(&s); err != nil {
 			return nil, err
 		}
+		s.Key = r.decryptKey(s.Key)
 		sources = append(sources, s)
 	}
 	if err := cursor.Err(); err != nil {


### PR DESCRIPTION
## Summary
- Source credentials (GDrive OAuth, Telegram bot tokens, S3 secret keys) are now encrypted at rest using AES-256-GCM before being stored in the `sources` MongoDB collection
- Encryption/decryption is handled transparently at the `SourceRepository` level using the existing `cryptoutil` package and `ACCESS_SECRET_KEY` config, matching the pattern used for bucket access secrets
- Includes a one-time migration script (`cmd/migrate-source-keys`) to encrypt existing plaintext records, with idempotent skip for already-encrypted data
- Fixes pre-existing build errors: OpenTelemetry span attribute API (`trace.WithAttributes` wrapper) and stray `log.Printf` in bucket handler

## Test plan
- [x] All unit tests pass (`go test ./internal/...`)
- [x] Full build succeeds (`go build ./...`)
- [ ] Run migration script against staging DB before deploying: `ACCESS_SECRET_KEY=<key> go run ./cmd/migrate-source-keys`
- [ ] Verify source CRUD operations (create, list, info, download) work end-to-end with encrypted keys
- [ ] Verify existing sources still work during migration window (graceful plaintext fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)