### PR TITLE
Fix OAuth CSRF state cookie: add Secure flag and clear after use

### DIFF
--- a/api-go/internal/handlers/oauth.go
+++ b/api-go/internal/handlers/oauth.go
@@ -39,7 +39,7 @@ func GitHubLogin(cfg *config.Config) gin.HandlerFunc {
 			c.Status(http.StatusInternalServerError)
 			return
 		}
-		c.SetCookie("oauth_state", state, 600, "/", "", false, true)
+		c.SetCookie("oauth_state", state, 600, "/", "", true, true)
 		c.Redirect(http.StatusTemporaryRedirect, oauthCfg.AuthCodeURL(state))
 	}
 }
@@ -58,6 +58,8 @@ func GitHubCallback(cfg *config.Config, userRepo *repository.UserRepository) gin
 			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid oauth state"})
 			return
 		}
+		// Clear the state cookie immediately to prevent replay attacks.
+		c.SetCookie("oauth_state", "", -1, "/", "", true, true)
 
 		oauthCfg := newGitHubOAuthConfig(cfg)
 		token, err := oauthCfg.Exchange(c.Request.Context(), c.Query("code"))


### PR DESCRIPTION
## Summary
- Set `secure=true` on the `oauth_state` cookie so it is only transmitted over HTTPS, preventing network interception and state fixation
- Clear the `oauth_state` cookie (`max-age=-1`) immediately after successful state validation to prevent replay attacks

## Changes
**File:** `api-go/internal/handlers/oauth.go`
- Line 42: `secure` parameter changed from `false` to `true`
- After line 60: added `c.SetCookie("oauth_state", "", -1, "/", "", true, true)` to delete the cookie post-validation

## Test plan
- [x] Go build passes (`go build ./...`)
- [ ] Manual test: initiate GitHub OAuth flow, verify `oauth_state` cookie has `Secure` flag set
- [ ] Manual test: complete OAuth flow, verify `oauth_state` cookie is cleared after redirect

Fixes THE-74

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Paperclip <noreply@paperclip.ing>