### PR TITLE
Fix CORS config and Content-Disposition filename sanitization

### DIFF
--- a/api-go/internal/app/router.go
+++ b/api-go/internal/app/router.go
@@ -16,12 +16,19 @@ import (
 
 func SetupRouter(m *db.Mongo, cfg *config.Config) *gin.Engine {
 	router := gin.New()
-	router.Use(cors.New(cors.Config{
-		AllowAllOrigins:  true,
+
+	corsConfig := cors.Config{
 		AllowMethods:     []string{"GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"},
 		AllowHeaders:     []string{"Origin", "Content-Length", "Content-Type", "Authorization"},
 		AllowCredentials: true,
-	}))
+	}
+	if cfg != nil && cfg.FrontendURL != "" {
+		corsConfig.AllowOrigins = []string{cfg.FrontendURL}
+	} else {
+		corsConfig.AllowAllOrigins = true
+		corsConfig.AllowCredentials = false
+	}
+	router.Use(cors.New(corsConfig))
 	router.Use(gin.Recovery())
 	router.Use(observability.Middleware())
 	router.Use(otelgin.Middleware("sfree-api"))

--- a/api-go/internal/handlers/bucket.go
+++ b/api-go/internal/handlers/bucket.go
@@ -574,7 +574,7 @@ func DownloadFile(bucketRepo *repository.BucketRepository, sourceRepo *repositor
 		for _, ch := range fileDoc.Chunks {
 			total += ch.Size
 		}
-		c.Header("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s\"", fileDoc.Name))
+		c.Header("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s\"", sanitizeFilename(fileDoc.Name)))
 		c.Header("Content-Type", "application/octet-stream")
 		c.Header("Content-Length", strconv.FormatInt(total, 10))
 		c.Status(http.StatusOK)

--- a/api-go/internal/handlers/sanitize.go
+++ b/api-go/internal/handlers/sanitize.go
@@ -1,0 +1,13 @@
+package handlers
+
+import "strings"
+
+// contentDispositionReplacer strips characters that could inject into
+// a Content-Disposition header value: double-quotes and CRLF.
+var contentDispositionReplacer = strings.NewReplacer(`"`, "", "\r", "", "\n", "")
+
+// sanitizeFilename returns a filename safe for use in a Content-Disposition
+// header's filename="..." parameter (RFC 6266).
+func sanitizeFilename(name string) string {
+	return contentDispositionReplacer.Replace(name)
+}

--- a/api-go/internal/handlers/sanitize_test.go
+++ b/api-go/internal/handlers/sanitize_test.go
@@ -1,0 +1,27 @@
+package handlers
+
+import "testing"
+
+func TestSanitizeFilename(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"clean name", "report.pdf", "report.pdf"},
+		{"double quotes", `file"name.txt`, "filename.txt"},
+		{"CRLF injection", "file\r\nInjected-Header: val", "fileInjected-Header: val"},
+		{"CR only", "file\rname.txt", "filename.txt"},
+		{"LF only", "file\nname.txt", "filename.txt"},
+		{"combined", "a\"\r\nb", "ab"},
+		{"empty", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizeFilename(tt.in)
+			if got != tt.want {
+				t.Errorf("sanitizeFilename(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/api-go/internal/handlers/sharelink.go
+++ b/api-go/internal/handlers/sharelink.go
@@ -204,7 +204,7 @@ func GetSharedFile(shareLinkRepo *repository.ShareLinkRepository, bucketRepo *re
 		for _, ch := range fileDoc.Chunks {
 			total += ch.Size
 		}
-		c.Header("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s\"", fileDoc.Name))
+		c.Header("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s\"", sanitizeFilename(fileDoc.Name)))
 		c.Header("Content-Type", "application/octet-stream")
 		c.Header("Content-Length", strconv.FormatInt(total, 10))
 		c.Status(http.StatusOK)

--- a/api-go/internal/handlers/source.go
+++ b/api-go/internal/handlers/source.go
@@ -521,7 +521,7 @@ func DownloadSourceFile(sourceRepo *repository.SourceRepository) gin.HandlerFunc
 		}
 		defer func() { _ = body.Close() }()
 
-		c.Header("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s\"", filename))
+		c.Header("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s\"", sanitizeFilename(filename)))
 		c.Header("Content-Type", "application/octet-stream")
 		c.Status(http.StatusOK)
 		if _, err := io.Copy(c.Writer, body); err != nil {


### PR DESCRIPTION
## Summary
- **CORS**: Replace invalid `AllowAllOrigins + AllowCredentials` config (rejected by browsers per Fetch spec) with explicit origin allowlist from `FRONTEND_URL`. Falls back to `AllowAllOrigins` without credentials when no frontend URL is set.
- **Content-Disposition**: Sanitize filenames in all download endpoints (bucket, sharelink, source) by stripping `"`, `\r`, `\n` to prevent HTTP response header injection.
- Added `sanitizeFilename` helper with tests covering quotes, CRLF injection, and edge cases.

Fixes THE-75.

## Test plan
- [x] `TestSanitizeFilename` — 7 cases covering clean names, double quotes, CRLF, CR, LF, combined, empty
- [x] Full `go test ./...` passes
- [x] `go build ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)