### PR TITLE
Add product demo visuals and dashboard metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,19 @@
 **One object store across Google Drive, Telegram, and any S3-compatible
 service — with a REST API, S3-compatible endpoint, and browser UI.**
 
+### Screenshots
+
 <p align="center">
-  <img src="docs/assets/demo.gif" alt="SFree demo — create a source, upload a file, browse and download" width="720" />
+  <img src="docs/assets/screenshot-sources.svg" alt="Sources page — connect storage backends" width="720" />
+</p>
+<p align="center">
+  <img src="docs/assets/screenshot-create-bucket.svg" alt="Create a bucket backed by multiple sources" width="720" />
+</p>
+<p align="center">
+  <img src="docs/assets/screenshot-bucket-files.svg" alt="Browse, upload, download, and share files" width="720" />
+</p>
+<p align="center">
+  <img src="docs/assets/screenshot-share-link.svg" alt="Generate public share links for any file" width="720" />
 </p>
 
 ## Why SFree

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 **One object store across Google Drive, Telegram, and any S3-compatible
 service — with a REST API, S3-compatible endpoint, and browser UI.**
 
+<p align="center">
+  <img src="docs/assets/demo.gif" alt="SFree demo — create a source, upload a file, browse and download" width="720" />
+</p>
+
 ## Why SFree
 
 Cloud storage is cheap in pieces — a free Google Drive here, a Telegram bot

--- a/docs/assets/RECORDING_BRIEF.md
+++ b/docs/assets/RECORDING_BRIEF.md
@@ -65,6 +65,22 @@ logged in to avoid showing credentials on screen.
   and after each action for smooth playback.
 - Use a tool like `gifsicle` or `ffmpeg` to optimize the final GIF size.
 
+## Automated recording
+
+An automated Puppeteer script can record the demo with a mock API (no Docker
+required). It drives a real browser through the 5-scene sequence above and
+encodes the screenshots into a GIF.
+
+```bash
+cd scripts/record-demo
+npm install            # installs Puppeteer + Chrome + GIF encoder
+npm run record         # outputs docs/assets/demo.gif
+```
+
+Requirements: Node.js 20+ and a machine that can run headless Chrome (not a
+minimal container). The script starts its own mock API and Vite dev server
+automatically.
+
 ## Embed location
 
 README.md already references this file:

--- a/docs/assets/RECORDING_BRIEF.md
+++ b/docs/assets/RECORDING_BRIEF.md
@@ -1,0 +1,76 @@
+# Demo GIF Recording Brief
+
+Target file: `docs/assets/demo.gif`
+
+## Specs
+
+- Format: GIF (or MP4 converted to GIF)
+- Duration: 20-25 seconds
+- Resolution: 1280x720 (renders well on GitHub at `width="720"`)
+- File size: under 10 MB
+- Frame rate: 10-15 fps (keeps GIF size down)
+- Browser window: clean, no bookmarks bar, minimal chrome
+
+## Recording environment
+
+Run locally with Docker Compose (`docker compose up --build`).
+Frontend at `http://localhost:3000`, MinIO at `http://minio:9000` (internal).
+
+Pre-create the user account before recording. Start the recording already
+logged in to avoid showing credentials on screen.
+
+## Scene sequence
+
+### Scene 1 — Sources page (3s)
+
+1. Start on `/sources` showing one pre-created S3-compatible source named
+   "local-minio" (card visible with S3 chip).
+2. Pause briefly so the viewer sees the sources list.
+
+### Scene 2 — Create a bucket (6s)
+
+1. Navigate to `/buckets`.
+2. Click "Add Bucket".
+3. Type `demo-bucket` in the Key field.
+4. Check the "local-minio" source checkbox.
+5. Click "Create".
+6. Pause on the generated S3 credentials screen (1s), then close.
+
+### Scene 3 — Upload a file (5s)
+
+1. Click the new `demo-bucket` card to open it.
+2. Click "Upload File".
+3. Select a small sample file (e.g. `hello.txt`, ~100 bytes).
+4. Wait for upload to complete — file appears in the table.
+
+### Scene 4 — Browse files (3s)
+
+1. Pause on the file list showing the uploaded file with name, size, and date.
+
+### Scene 5 — Download (3s)
+
+1. Click the download icon next to the file.
+2. Brief pause to show the download initiated.
+
+### Scene 6 — End (2s)
+
+1. Hold on the bucket detail page for a moment to close cleanly.
+
+## Recording tips
+
+- Use a clean browser profile (no extensions visible).
+- Set browser to light mode for better GIF contrast.
+- Move the mouse deliberately and slowly — fast cursors look janky in GIFs.
+- If using `mcp__claude-in-chrome__gif_creator`, capture extra frames before
+  and after each action for smooth playback.
+- Use a tool like `gifsicle` or `ffmpeg` to optimize the final GIF size.
+
+## Embed location
+
+README.md already references this file:
+
+```html
+<p align="center">
+  <img src="docs/assets/demo.gif" alt="SFree demo — create a source, upload a file, browse and download" width="720" />
+</p>
+```

--- a/docs/assets/screenshot-bucket-files.svg
+++ b/docs/assets/screenshot-bucket-files.svg
@@ -67,30 +67,76 @@
   <text x="60" y="304" font-family="system-ui, -apple-system, sans-serif" font-size="14" fill="#1a1a2e">photo-album.zip</text>
   <text x="380" y="304" font-family="system-ui, -apple-system, sans-serif" font-size="13" fill="#666">18.5 MB</text>
   <text x="480" y="304" font-family="system-ui, -apple-system, sans-serif" font-size="13" fill="#666">Apr 13, 2026</text>
+  <!-- Share icon -->
   <rect x="650" y="288" width="28" height="28" rx="6" fill="#f4f4f5"/>
+  <circle cx="657" cy="296" r="2.5" fill="none" stroke="#555" stroke-width="1.5"/>
+  <circle cx="669" cy="300" r="2.5" fill="none" stroke="#555" stroke-width="1.5"/>
+  <circle cx="669" cy="308" r="2.5" fill="none" stroke="#555" stroke-width="1.5"/>
+  <line x1="659" y1="297" x2="667" y2="299" stroke="#555" stroke-width="1"/>
+  <line x1="659" y1="305" x2="667" y2="307" stroke="#555" stroke-width="1"/>
+  <!-- Download icon -->
   <rect x="684" y="288" width="28" height="28" rx="6" fill="#f4f4f5"/>
+  <line x1="698" y1="294" x2="698" y2="308" stroke="#555" stroke-width="1.5"/>
+  <polyline points="692,303 698,309 704,303" fill="none" stroke="#555" stroke-width="1.5"/>
+  <line x1="691" y1="311" x2="705" y2="311" stroke="#555" stroke-width="1.5"/>
+  <!-- Delete icon -->
   <rect x="718" y="288" width="28" height="28" rx="6" fill="#fff0f0"/>
+  <text x="732" y="308" font-family="system-ui, -apple-system, sans-serif" font-size="14" fill="#f31260" text-anchor="middle">&#x1f5d1;</text>
   <line x1="50" y1="320" x2="750" y2="320" stroke="#f0f0f0" stroke-width="1"/>
 
   <!-- File row 3 -->
   <text x="60" y="346" font-family="system-ui, -apple-system, sans-serif" font-size="14" fill="#1a1a2e">meeting-notes.pdf</text>
   <text x="380" y="346" font-family="system-ui, -apple-system, sans-serif" font-size="13" fill="#666">1.2 MB</text>
   <text x="480" y="346" font-family="system-ui, -apple-system, sans-serif" font-size="13" fill="#666">Apr 13, 2026</text>
+  <!-- Share icon -->
   <rect x="650" y="330" width="28" height="28" rx="6" fill="#f4f4f5"/>
+  <circle cx="657" cy="338" r="2.5" fill="none" stroke="#555" stroke-width="1.5"/>
+  <circle cx="669" cy="342" r="2.5" fill="none" stroke="#555" stroke-width="1.5"/>
+  <circle cx="669" cy="350" r="2.5" fill="none" stroke="#555" stroke-width="1.5"/>
+  <line x1="659" y1="339" x2="667" y2="341" stroke="#555" stroke-width="1"/>
+  <line x1="659" y1="347" x2="667" y2="349" stroke="#555" stroke-width="1"/>
+  <!-- Download icon -->
   <rect x="684" y="330" width="28" height="28" rx="6" fill="#f4f4f5"/>
+  <line x1="698" y1="336" x2="698" y2="350" stroke="#555" stroke-width="1.5"/>
+  <polyline points="692,345 698,351 704,345" fill="none" stroke="#555" stroke-width="1.5"/>
+  <line x1="691" y1="353" x2="705" y2="353" stroke="#555" stroke-width="1.5"/>
+  <!-- Delete icon -->
   <rect x="718" y="330" width="28" height="28" rx="6" fill="#fff0f0"/>
+  <text x="732" y="350" font-family="system-ui, -apple-system, sans-serif" font-size="14" fill="#f31260" text-anchor="middle">&#x1f5d1;</text>
   <line x1="50" y1="362" x2="750" y2="362" stroke="#f0f0f0" stroke-width="1"/>
 
   <!-- File row 4 -->
   <text x="60" y="388" font-family="system-ui, -apple-system, sans-serif" font-size="14" fill="#1a1a2e">readme.txt</text>
   <text x="380" y="388" font-family="system-ui, -apple-system, sans-serif" font-size="13" fill="#666">4.8 KB</text>
   <text x="480" y="388" font-family="system-ui, -apple-system, sans-serif" font-size="13" fill="#666">Apr 13, 2026</text>
+  <!-- Share icon -->
   <rect x="650" y="372" width="28" height="28" rx="6" fill="#f4f4f5"/>
+  <circle cx="657" cy="380" r="2.5" fill="none" stroke="#555" stroke-width="1.5"/>
+  <circle cx="669" cy="384" r="2.5" fill="none" stroke="#555" stroke-width="1.5"/>
+  <circle cx="669" cy="392" r="2.5" fill="none" stroke="#555" stroke-width="1.5"/>
+  <line x1="659" y1="381" x2="667" y2="383" stroke="#555" stroke-width="1"/>
+  <line x1="659" y1="389" x2="667" y2="391" stroke="#555" stroke-width="1"/>
+  <!-- Download icon -->
   <rect x="684" y="372" width="28" height="28" rx="6" fill="#f4f4f5"/>
+  <line x1="698" y1="378" x2="698" y2="392" stroke="#555" stroke-width="1.5"/>
+  <polyline points="692,387 698,393 704,387" fill="none" stroke="#555" stroke-width="1.5"/>
+  <line x1="691" y1="395" x2="705" y2="395" stroke="#555" stroke-width="1.5"/>
+  <!-- Delete icon -->
   <rect x="718" y="372" width="28" height="28" rx="6" fill="#fff0f0"/>
+  <text x="732" y="392" font-family="system-ui, -apple-system, sans-serif" font-size="14" fill="#f31260" text-anchor="middle">&#x1f5d1;</text>
 
-  <!-- Annotation callout -->
-  <rect x="50" y="440" width="700" height="20" rx="0" fill="transparent"/>
+  <!-- Annotation: upload callout -->
+  <rect x="454" y="108" width="172" height="32" rx="6" fill="#1a1a2e" opacity="0.92"/>
+  <text x="540" y="129" font-family="system-ui, -apple-system, sans-serif" font-size="12" font-weight="500" fill="#fff" text-anchor="middle">Drag-and-drop or click</text>
+  <!-- Arrow to upload button -->
+  <line x1="626" y1="124" x2="636" y2="124" stroke="#1a1a2e" stroke-width="2" opacity="0.7"/>
+  <polygon points="636,120 646,124 636,128" fill="#1a1a2e" opacity="0.7"/>
+
+  <!-- Annotation: actions callout -->
+  <rect x="540" y="440" width="220" height="20" rx="6" fill="#1a1a2e" opacity="0.92"/>
+  <text x="650" y="454" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="500" fill="#fff" text-anchor="middle">Share  &middot;  Download  &middot;  Delete</text>
+  <!-- Arrow to action icons -->
+  <line x1="650" y1="440" x2="650" y2="410" stroke="#1a1a2e" stroke-width="1.5" opacity="0.5"/>
 
   <!-- Caption bar -->
   <rect x="0" y="464" width="800" height="36" fill="#f8f9fa"/>

--- a/docs/assets/screenshot-bucket-files.svg
+++ b/docs/assets/screenshot-bucket-files.svg
@@ -1,0 +1,98 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 500" width="800" height="500">
+  <defs>
+    <filter id="shadow1" x="-2%" y="-2%" width="104%" height="108%">
+      <feDropShadow dx="0" dy="1" stdDeviation="3" flood-color="#000" flood-opacity="0.08"/>
+    </filter>
+  </defs>
+
+  <!-- Browser frame -->
+  <rect x="0" y="0" width="800" height="500" rx="8" fill="#f8f9fa" stroke="#e0e0e0" stroke-width="1"/>
+  <rect x="0" y="0" width="800" height="36" rx="8" fill="#f0f0f0"/>
+  <rect x="0" y="20" width="800" height="16" fill="#f0f0f0"/>
+  <circle cx="20" cy="18" r="5" fill="#ff5f57"/>
+  <circle cx="38" cy="18" r="5" fill="#ffbd2e"/>
+  <circle cx="56" cy="18" r="5" fill="#28c940"/>
+  <rect x="200" y="8" width="400" height="20" rx="10" fill="#fff" stroke="#ddd" stroke-width="1"/>
+  <text x="400" y="22" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#888" text-anchor="middle">localhost:3000/buckets/68f2a...</text>
+
+  <!-- Page content area -->
+  <rect x="0" y="36" width="800" height="464" fill="#ffffff"/>
+
+  <!-- Back button -->
+  <rect x="32" y="52" width="32" height="32" rx="8" fill="#f4f4f5"/>
+  <text x="48" y="73" font-family="system-ui, -apple-system, sans-serif" font-size="18" fill="#555" text-anchor="middle">&#x2190;</text>
+
+  <!-- Bucket title and details -->
+  <text x="40" y="116" font-family="system-ui, -apple-system, sans-serif" font-size="26" font-weight="bold" fill="#1a1a2e">my-files</text>
+  <text x="40" y="138" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#a0a0a0">ID: 68f2a9b1-c45d-4e8f-b1a2-3d4e5f6a7b8c</text>
+  <text x="40" y="156" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#a0a0a0">Access Key: sfree_ak_mYf1L3s...</text>
+  <text x="40" y="174" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#a0a0a0">Created: Apr 12, 2026, 10:30:00 AM</text>
+
+  <!-- Upload button -->
+  <rect x="640" y="108" width="120" height="36" rx="10" fill="#0070f3"/>
+  <text x="700" y="131" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="500" fill="#fff" text-anchor="middle">Upload File</text>
+
+  <!-- File table area with dashed border -->
+  <rect x="40" y="194" width="720" height="240" rx="8" fill="#fff" stroke="#d0d0d0" stroke-width="2" stroke-dasharray="8,4"/>
+
+  <!-- Table header -->
+  <text x="60" y="224" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="600" fill="#888">Name</text>
+  <text x="380" y="224" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="600" fill="#888">Size</text>
+  <text x="480" y="224" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="600" fill="#888">Created</text>
+  <text x="660" y="224" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="600" fill="#888">Actions</text>
+  <line x1="50" y1="234" x2="750" y2="234" stroke="#eee" stroke-width="1"/>
+
+  <!-- File row 1 -->
+  <text x="60" y="262" font-family="system-ui, -apple-system, sans-serif" font-size="14" fill="#1a1a2e">project-backup.tar.gz</text>
+  <text x="380" y="262" font-family="system-ui, -apple-system, sans-serif" font-size="13" fill="#666">245 MB</text>
+  <text x="480" y="262" font-family="system-ui, -apple-system, sans-serif" font-size="13" fill="#666">Apr 12, 2026</text>
+  <!-- Share icon -->
+  <rect x="650" y="246" width="28" height="28" rx="6" fill="#f4f4f5"/>
+  <circle cx="657" cy="254" r="2.5" fill="none" stroke="#555" stroke-width="1.5"/>
+  <circle cx="669" cy="258" r="2.5" fill="none" stroke="#555" stroke-width="1.5"/>
+  <circle cx="669" cy="266" r="2.5" fill="none" stroke="#555" stroke-width="1.5"/>
+  <line x1="659" y1="255" x2="667" y2="257" stroke="#555" stroke-width="1"/>
+  <line x1="659" y1="263" x2="667" y2="265" stroke="#555" stroke-width="1"/>
+  <!-- Download icon -->
+  <rect x="684" y="246" width="28" height="28" rx="6" fill="#f4f4f5"/>
+  <line x1="698" y1="252" x2="698" y2="266" stroke="#555" stroke-width="1.5"/>
+  <polyline points="692,261 698,267 704,261" fill="none" stroke="#555" stroke-width="1.5"/>
+  <line x1="691" y1="269" x2="705" y2="269" stroke="#555" stroke-width="1.5"/>
+  <!-- Delete icon -->
+  <rect x="718" y="246" width="28" height="28" rx="6" fill="#fff0f0"/>
+  <text x="732" y="266" font-family="system-ui, -apple-system, sans-serif" font-size="14" fill="#f31260" text-anchor="middle">&#x1f5d1;</text>
+  <line x1="50" y1="278" x2="750" y2="278" stroke="#f0f0f0" stroke-width="1"/>
+
+  <!-- File row 2 -->
+  <text x="60" y="304" font-family="system-ui, -apple-system, sans-serif" font-size="14" fill="#1a1a2e">photo-album.zip</text>
+  <text x="380" y="304" font-family="system-ui, -apple-system, sans-serif" font-size="13" fill="#666">18.5 MB</text>
+  <text x="480" y="304" font-family="system-ui, -apple-system, sans-serif" font-size="13" fill="#666">Apr 13, 2026</text>
+  <rect x="650" y="288" width="28" height="28" rx="6" fill="#f4f4f5"/>
+  <rect x="684" y="288" width="28" height="28" rx="6" fill="#f4f4f5"/>
+  <rect x="718" y="288" width="28" height="28" rx="6" fill="#fff0f0"/>
+  <line x1="50" y1="320" x2="750" y2="320" stroke="#f0f0f0" stroke-width="1"/>
+
+  <!-- File row 3 -->
+  <text x="60" y="346" font-family="system-ui, -apple-system, sans-serif" font-size="14" fill="#1a1a2e">meeting-notes.pdf</text>
+  <text x="380" y="346" font-family="system-ui, -apple-system, sans-serif" font-size="13" fill="#666">1.2 MB</text>
+  <text x="480" y="346" font-family="system-ui, -apple-system, sans-serif" font-size="13" fill="#666">Apr 13, 2026</text>
+  <rect x="650" y="330" width="28" height="28" rx="6" fill="#f4f4f5"/>
+  <rect x="684" y="330" width="28" height="28" rx="6" fill="#f4f4f5"/>
+  <rect x="718" y="330" width="28" height="28" rx="6" fill="#fff0f0"/>
+  <line x1="50" y1="362" x2="750" y2="362" stroke="#f0f0f0" stroke-width="1"/>
+
+  <!-- File row 4 -->
+  <text x="60" y="388" font-family="system-ui, -apple-system, sans-serif" font-size="14" fill="#1a1a2e">readme.txt</text>
+  <text x="380" y="388" font-family="system-ui, -apple-system, sans-serif" font-size="13" fill="#666">4.8 KB</text>
+  <text x="480" y="388" font-family="system-ui, -apple-system, sans-serif" font-size="13" fill="#666">Apr 13, 2026</text>
+  <rect x="650" y="372" width="28" height="28" rx="6" fill="#f4f4f5"/>
+  <rect x="684" y="372" width="28" height="28" rx="6" fill="#f4f4f5"/>
+  <rect x="718" y="372" width="28" height="28" rx="6" fill="#fff0f0"/>
+
+  <!-- Annotation callout -->
+  <rect x="50" y="440" width="700" height="20" rx="0" fill="transparent"/>
+
+  <!-- Caption bar -->
+  <rect x="0" y="464" width="800" height="36" fill="#f8f9fa"/>
+  <text x="400" y="487" font-family="system-ui, -apple-system, sans-serif" font-size="13" fill="#666" text-anchor="middle" font-style="italic">Bucket file browser — upload, download, share, and manage files</text>
+</svg>

--- a/docs/assets/screenshot-create-bucket.svg
+++ b/docs/assets/screenshot-create-bucket.svg
@@ -1,0 +1,79 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 480" width="800" height="480">
+  <defs>
+    <filter id="shadow1" x="-2%" y="-2%" width="104%" height="108%">
+      <feDropShadow dx="0" dy="1" stdDeviation="3" flood-color="#000" flood-opacity="0.08"/>
+    </filter>
+    <filter id="modal-shadow" x="-5%" y="-5%" width="110%" height="115%">
+      <feDropShadow dx="0" dy="4" stdDeviation="16" flood-color="#000" flood-opacity="0.2"/>
+    </filter>
+  </defs>
+
+  <!-- Browser frame -->
+  <rect x="0" y="0" width="800" height="480" rx="8" fill="#f8f9fa" stroke="#e0e0e0" stroke-width="1"/>
+  <rect x="0" y="0" width="800" height="36" rx="8" fill="#f0f0f0"/>
+  <rect x="0" y="20" width="800" height="16" fill="#f0f0f0"/>
+  <circle cx="20" cy="18" r="5" fill="#ff5f57"/>
+  <circle cx="38" cy="18" r="5" fill="#ffbd2e"/>
+  <circle cx="56" cy="18" r="5" fill="#28c940"/>
+  <rect x="200" y="8" width="400" height="20" rx="10" fill="#fff" stroke="#ddd" stroke-width="1"/>
+  <text x="400" y="22" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#888" text-anchor="middle">localhost:3000/buckets</text>
+
+  <!-- Page content (dimmed behind modal) -->
+  <rect x="0" y="36" width="800" height="444" fill="#ffffff"/>
+  <text x="40" y="82" font-family="system-ui, -apple-system, sans-serif" font-size="26" font-weight="bold" fill="#1a1a2e" opacity="0.3">Buckets</text>
+  <rect x="640" y="58" width="120" height="36" rx="10" fill="#0070f3" opacity="0.3"/>
+
+  <!-- Modal overlay -->
+  <rect x="0" y="36" width="800" height="444" fill="#000" opacity="0.4"/>
+
+  <!-- Modal dialog -->
+  <rect x="150" y="70" width="500" height="380" rx="14" fill="#fff" filter="url(#modal-shadow)"/>
+
+  <!-- Modal header -->
+  <text x="180" y="108" font-family="system-ui, -apple-system, sans-serif" font-size="20" font-weight="600" fill="#1a1a2e">Create Bucket</text>
+  <line x1="150" y1="120" x2="650" y2="120" stroke="#f0f0f0" stroke-width="1"/>
+
+  <!-- Key field -->
+  <text x="180" y="150" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="500" fill="#555">Key *</text>
+  <rect x="180" y="158" width="440" height="40" rx="8" fill="#f9f9f9" stroke="#e0e0e0" stroke-width="1"/>
+  <text x="196" y="183" font-family="system-ui, -apple-system, sans-serif" font-size="14" fill="#1a1a2e">my-files</text>
+
+  <!-- Allowed sources section -->
+  <text x="180" y="224" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="500" fill="#555">Allowed sources *</text>
+  <text x="180" y="242" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#a0a0a0">Choose which sources this bucket is allowed to use for uploads.</text>
+
+  <!-- Source checkboxes -->
+  <!-- Checkbox 1: checked -->
+  <rect x="180" y="256" width="18" height="18" rx="4" fill="#0070f3" stroke="#0070f3" stroke-width="1.5"/>
+  <polyline points="185,265 188,269 193,261" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <text x="206" y="270" font-family="system-ui, -apple-system, sans-serif" font-size="14" fill="#1a1a2e">personal-drive</text>
+  <text x="316" y="270" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#a0a0a0">(Google Drive)</text>
+
+  <!-- Checkbox 2: checked -->
+  <rect x="180" y="286" width="18" height="18" rx="4" fill="#0070f3" stroke="#0070f3" stroke-width="1.5"/>
+  <polyline points="185,295 188,299 193,291" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <text x="206" y="300" font-family="system-ui, -apple-system, sans-serif" font-size="14" fill="#1a1a2e">local-minio</text>
+  <text x="292" y="300" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#a0a0a0">(S3-Compatible)</text>
+
+  <!-- Checkbox 3: unchecked -->
+  <rect x="180" y="316" width="18" height="18" rx="4" fill="#fff" stroke="#d0d0d0" stroke-width="1.5"/>
+  <text x="206" y="330" font-family="system-ui, -apple-system, sans-serif" font-size="14" fill="#1a1a2e">backup-bot</text>
+  <text x="288" y="330" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#a0a0a0">(Telegram)</text>
+
+  <!-- Modal footer -->
+  <line x1="150" y1="370" x2="650" y2="370" stroke="#f0f0f0" stroke-width="1"/>
+  <!-- Cancel button -->
+  <rect x="440" y="386" width="80" height="36" rx="10" fill="#f4f4f5"/>
+  <text x="480" y="409" font-family="system-ui, -apple-system, sans-serif" font-size="14" fill="#555" text-anchor="middle">Cancel</text>
+  <!-- Create button -->
+  <rect x="530" y="386" width="90" height="36" rx="10" fill="#0070f3"/>
+  <text x="575" y="409" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="500" fill="#fff" text-anchor="middle">Create</text>
+
+  <!-- Annotation -->
+  <rect x="150" y="432" width="500" height="28" rx="6" fill="#1a1a2e" opacity="0.92"/>
+  <text x="400" y="451" font-family="system-ui, -apple-system, sans-serif" font-size="12" font-weight="500" fill="#fff" text-anchor="middle">Select which storage backends to distribute file chunks across</text>
+
+  <!-- Caption bar -->
+  <rect x="0" y="448" width="800" height="32" fill="#f8f9fa"/>
+  <text x="400" y="468" font-family="system-ui, -apple-system, sans-serif" font-size="13" fill="#666" text-anchor="middle" font-style="italic">Create a bucket — choose which sources back your storage</text>
+</svg>

--- a/docs/assets/screenshot-share-link.svg
+++ b/docs/assets/screenshot-share-link.svg
@@ -1,0 +1,72 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 440" width="800" height="440">
+  <defs>
+    <filter id="modal-shadow" x="-5%" y="-5%" width="110%" height="115%">
+      <feDropShadow dx="0" dy="4" stdDeviation="16" flood-color="#000" flood-opacity="0.2"/>
+    </filter>
+  </defs>
+
+  <!-- Browser frame -->
+  <rect x="0" y="0" width="800" height="440" rx="8" fill="#f8f9fa" stroke="#e0e0e0" stroke-width="1"/>
+  <rect x="0" y="0" width="800" height="36" rx="8" fill="#f0f0f0"/>
+  <rect x="0" y="20" width="800" height="16" fill="#f0f0f0"/>
+  <circle cx="20" cy="18" r="5" fill="#ff5f57"/>
+  <circle cx="38" cy="18" r="5" fill="#ffbd2e"/>
+  <circle cx="56" cy="18" r="5" fill="#28c940"/>
+  <rect x="200" y="8" width="400" height="20" rx="10" fill="#fff" stroke="#ddd" stroke-width="1"/>
+  <text x="400" y="22" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#888" text-anchor="middle">localhost:3000/buckets/68f2a...</text>
+
+  <!-- Page content (dimmed) -->
+  <rect x="0" y="36" width="800" height="404" fill="#ffffff"/>
+  <text x="40" y="82" font-family="system-ui, -apple-system, sans-serif" font-size="26" font-weight="bold" fill="#1a1a2e" opacity="0.2">my-files</text>
+
+  <!-- Modal overlay -->
+  <rect x="0" y="36" width="800" height="404" fill="#000" opacity="0.4"/>
+
+  <!-- Modal dialog -->
+  <rect x="120" y="60" width="560" height="340" rx="14" fill="#fff" filter="url(#modal-shadow)"/>
+
+  <!-- Modal header -->
+  <text x="150" y="98" font-family="system-ui, -apple-system, sans-serif" font-size="20" font-weight="600" fill="#1a1a2e">Share: photo-album.zip</text>
+  <line x1="120" y1="112" x2="680" y2="112" stroke="#f0f0f0" stroke-width="1"/>
+
+  <!-- Share link 1 -->
+  <rect x="150" y="130" width="480" height="60" rx="8" fill="#f8f9fb" stroke="#e8e8ec" stroke-width="1"/>
+  <!-- URL code block -->
+  <rect x="162" y="140" width="310" height="32" rx="6" fill="#f0f0f4"/>
+  <text x="174" y="161" font-family="monospace, 'Courier New'" font-size="12" fill="#333">localhost:3000/share/aB3xK9...</text>
+  <!-- Copy button -->
+  <rect x="484" y="142" width="60" height="28" rx="6" fill="#f4f4f5"/>
+  <text x="514" y="161" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#555" text-anchor="middle">Copy</text>
+  <!-- Revoke button -->
+  <rect x="552" y="142" width="66" height="28" rx="6" fill="#fff0f0"/>
+  <text x="585" y="161" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#f31260" text-anchor="middle">Revoke</text>
+  <text x="162" y="184" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#a0a0a0">expires May 13, 2026</text>
+
+  <!-- Share link 2 -->
+  <rect x="150" y="202" width="480" height="60" rx="8" fill="#f8f9fb" stroke="#e8e8ec" stroke-width="1"/>
+  <rect x="162" y="212" width="310" height="32" rx="6" fill="#f0f0f4"/>
+  <text x="174" y="233" font-family="monospace, 'Courier New'" font-size="12" fill="#333">localhost:3000/share/pQ7wM2...</text>
+  <rect x="484" y="214" width="60" height="28" rx="6" fill="#f4f4f5"/>
+  <text x="514" y="233" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#555" text-anchor="middle">Copy</text>
+  <rect x="552" y="214" width="66" height="28" rx="6" fill="#fff0f0"/>
+  <text x="585" y="233" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#f31260" text-anchor="middle">Revoke</text>
+  <text x="162" y="256" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#a0a0a0">no expiration</text>
+
+  <!-- Annotation -->
+  <rect x="150" y="278" width="480" height="40" rx="8" fill="#1a1a2e" opacity="0.92"/>
+  <text x="390" y="296" font-family="system-ui, -apple-system, sans-serif" font-size="12" font-weight="500" fill="#fff" text-anchor="middle">Generate public share links for any file — no account required to download.</text>
+  <text x="390" y="312" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#ccc" text-anchor="middle">Revoke access anytime.</text>
+
+  <!-- Modal footer -->
+  <line x1="120" y1="330" x2="680" y2="330" stroke="#f0f0f0" stroke-width="1"/>
+  <!-- Close button -->
+  <rect x="478" y="344" width="70" height="34" rx="10" fill="#f4f4f5"/>
+  <text x="513" y="366" font-family="system-ui, -apple-system, sans-serif" font-size="14" fill="#555" text-anchor="middle">Close</text>
+  <!-- Create Share Link button -->
+  <rect x="556" y="344" width="112" height="34" rx="10" fill="#0070f3"/>
+  <text x="612" y="366" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="500" fill="#fff" text-anchor="middle">+ Share Link</text>
+
+  <!-- Caption bar -->
+  <rect x="0" y="404" width="800" height="36" fill="#f8f9fa"/>
+  <text x="400" y="427" font-family="system-ui, -apple-system, sans-serif" font-size="13" fill="#666" text-anchor="middle" font-style="italic">Public share links — share files with anyone via a URL</text>
+</svg>

--- a/docs/assets/screenshot-sources.svg
+++ b/docs/assets/screenshot-sources.svg
@@ -1,0 +1,84 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 460" width="800" height="460">
+  <defs>
+    <filter id="shadow1" x="-2%" y="-2%" width="104%" height="108%">
+      <feDropShadow dx="0" dy="1" stdDeviation="3" flood-color="#000" flood-opacity="0.08"/>
+    </filter>
+    <filter id="shadow2" x="-2%" y="-2%" width="104%" height="110%">
+      <feDropShadow dx="0" dy="2" stdDeviation="6" flood-color="#000" flood-opacity="0.1"/>
+    </filter>
+  </defs>
+
+  <!-- Browser frame -->
+  <rect x="0" y="0" width="800" height="460" rx="8" fill="#f8f9fa" stroke="#e0e0e0" stroke-width="1"/>
+  <!-- Title bar -->
+  <rect x="0" y="0" width="800" height="36" rx="8" fill="#f0f0f0"/>
+  <rect x="0" y="20" width="800" height="16" fill="#f0f0f0"/>
+  <circle cx="20" cy="18" r="5" fill="#ff5f57"/>
+  <circle cx="38" cy="18" r="5" fill="#ffbd2e"/>
+  <circle cx="56" cy="18" r="5" fill="#28c940"/>
+  <rect x="200" y="8" width="400" height="20" rx="10" fill="#fff" stroke="#ddd" stroke-width="1"/>
+  <text x="400" y="22" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#888" text-anchor="middle">localhost:3000/sources</text>
+
+  <!-- Page content area -->
+  <rect x="0" y="36" width="800" height="424" fill="#ffffff"/>
+
+  <!-- Header row -->
+  <text x="40" y="82" font-family="system-ui, -apple-system, sans-serif" font-size="26" font-weight="bold" fill="#1a1a2e">Sources</text>
+  <!-- Add Source button -->
+  <rect x="640" y="58" width="120" height="36" rx="10" fill="#0070f3"/>
+  <text x="700" y="81" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="500" fill="#fff" text-anchor="middle">+ Add Source</text>
+
+  <!-- Source Card 1: Google Drive -->
+  <rect x="40" y="110" width="350" height="110" rx="12" fill="#fff" stroke="#e8e8e8" stroke-width="1" filter="url(#shadow1)"/>
+  <text x="60" y="140" font-family="system-ui, -apple-system, sans-serif" font-size="16" font-weight="600" fill="#1a1a2e">personal-drive</text>
+  <!-- Google Drive chip -->
+  <rect x="60" y="152" width="120" height="24" rx="12" fill="#f0f4ff"/>
+  <!-- Google Drive icon (simplified) -->
+  <polygon points="75,160 82,172 88,160" fill="#4285f4"/>
+  <polygon points="72,164 78,172 75,168" fill="#0f9d58"/>
+  <polygon points="85,164 88,168 82,172" fill="#f4b400"/>
+  <text x="95" y="169" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#4a5568">Google Drive</text>
+  <text x="60" y="200" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#a0a0a0">Created Apr 12, 2026</text>
+  <!-- Delete icon -->
+  <rect x="350" y="120" width="28" height="28" rx="6" fill="transparent"/>
+  <text x="364" y="140" font-family="system-ui, -apple-system, sans-serif" font-size="16" fill="#f31260" text-anchor="middle">×</text>
+
+  <!-- Source Card 2: S3-Compatible (MinIO) -->
+  <rect x="410" y="110" width="350" height="110" rx="12" fill="#fff" stroke="#e8e8e8" stroke-width="1" filter="url(#shadow1)"/>
+  <text x="430" y="140" font-family="system-ui, -apple-system, sans-serif" font-size="16" font-weight="600" fill="#1a1a2e">local-minio</text>
+  <!-- S3 chip -->
+  <rect x="430" y="152" width="120" height="24" rx="12" fill="#fff5f0"/>
+  <!-- S3 icon (simplified bucket) -->
+  <rect x="440" y="158" width="14" height="12" rx="2" fill="#e25d33" stroke="#c44d28" stroke-width="0.5"/>
+  <line x1="440" y1="162" x2="454" y2="162" stroke="#c44d28" stroke-width="0.5"/>
+  <text x="460" y="169" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#4a5568">S3-Compatible</text>
+  <text x="430" y="200" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#a0a0a0">Created Apr 12, 2026</text>
+  <!-- Delete icon -->
+  <rect x="720" y="120" width="28" height="28" rx="6" fill="transparent"/>
+  <text x="734" y="140" font-family="system-ui, -apple-system, sans-serif" font-size="16" fill="#f31260" text-anchor="middle">×</text>
+
+  <!-- Source Card 3: Telegram -->
+  <rect x="40" y="240" width="350" height="110" rx="12" fill="#fff" stroke="#e8e8e8" stroke-width="1" filter="url(#shadow1)"/>
+  <text x="60" y="270" font-family="system-ui, -apple-system, sans-serif" font-size="16" font-weight="600" fill="#1a1a2e">backup-bot</text>
+  <!-- Telegram chip -->
+  <rect x="60" y="282" width="100" height="24" rx="12" fill="#e8f4fd"/>
+  <!-- Telegram icon (simplified) -->
+  <polygon points="72,290 86,296 72,302 74,296" fill="#229ed9"/>
+  <text x="90" y="299" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#4a5568">Telegram</text>
+  <text x="60" y="330" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#a0a0a0">Created Apr 13, 2026</text>
+  <!-- Delete icon -->
+  <rect x="350" y="250" width="28" height="28" rx="6" fill="transparent"/>
+  <text x="364" y="270" font-family="system-ui, -apple-system, sans-serif" font-size="16" fill="#f31260" text-anchor="middle">×</text>
+
+  <!-- Annotation -->
+  <rect x="410" y="268" width="350" height="56" rx="8" fill="#1a1a2e" opacity="0.92"/>
+  <text x="430" y="290" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="500" fill="#fff">Connect Google Drive, Telegram, and</text>
+  <text x="430" y="310" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="500" fill="#fff">S3-compatible backends as storage sources.</text>
+  <!-- Arrow from annotation to cards -->
+  <line x1="410" y1="296" x2="396" y2="296" stroke="#1a1a2e" stroke-width="2" opacity="0.7"/>
+  <polygon points="396,292 386,296 396,300" fill="#1a1a2e" opacity="0.7"/>
+
+  <!-- Caption bar -->
+  <rect x="0" y="424" width="800" height="36" fill="#f8f9fa"/>
+  <text x="400" y="447" font-family="system-ui, -apple-system, sans-serif" font-size="13" fill="#666" text-anchor="middle" font-style="italic">Sources page — connect your free cloud storage accounts</text>
+</svg>

--- a/scripts/record-demo/.gitignore
+++ b/scripts/record-demo/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+hello.txt

--- a/scripts/record-demo/package.json
+++ b/scripts/record-demo/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "sfree-demo-recorder",
+  "private": true,
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "record": "node record.mjs"
+  },
+  "dependencies": {
+    "gifenc": "^1.0.3",
+    "pngjs": "^7.0.0",
+    "puppeteer": "^24.0.0"
+  }
+}

--- a/scripts/record-demo/record.mjs
+++ b/scripts/record-demo/record.mjs
@@ -1,0 +1,364 @@
+#!/usr/bin/env node
+/**
+ * SFree Demo GIF Recorder
+ *
+ * Records a product demo GIF by:
+ *   1. Starting a lightweight mock API (no database needed)
+ *   2. Starting the Vite dev server for the real frontend
+ *   3. Driving Chrome through the demo flow via Puppeteer
+ *   4. Encoding captured screenshots into an animated GIF
+ *
+ * Usage:
+ *   cd scripts/record-demo
+ *   npm install
+ *   npm run record
+ *
+ * The output lands at docs/assets/demo.gif (already referenced in README.md).
+ */
+
+import { execSync, spawn } from "node:child_process";
+import http from "node:http";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, "../..");
+const OUTPUT = path.join(ROOT, "docs/assets/demo.gif");
+
+const MOCK_PORT = 4050;
+const VITE_PORT = 3050;
+const WIDTH = 1280;
+const HEIGHT = 720;
+const FRAME_DELAY = 500; // ms per frame in GIF
+
+// ─── Mock API ──────────────────────────────────────────────────────────────────
+
+const sources = [
+  { id: "src-001", name: "local-minio", type: "s3", created_at: "2026-04-10T12:00:00Z" },
+];
+const sourceInfos = {
+  "src-001": {
+    id: "src-001", name: "local-minio", type: "s3",
+    files: [
+      { id: "sf-1", name: "backup-2026-04.tar.gz", size: 52428800 },
+      { id: "sf-2", name: "logs.json", size: 1048576 },
+    ],
+    storage_total: 10737418240, storage_used: 53477376, storage_free: 10683940864,
+  },
+};
+let buckets = [];
+const bucketFiles = {};
+let fileCounter = 0;
+
+function json(res, data, status = 200) {
+  res.writeHead(status, {
+    "Content-Type": "application/json",
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Headers": "*",
+    "Access-Control-Allow-Methods": "*",
+  });
+  res.end(JSON.stringify(data));
+}
+
+function readBody(req) {
+  return new Promise((resolve) => {
+    const chunks = [];
+    req.on("data", (c) => chunks.push(c));
+    req.on("end", () => resolve(Buffer.concat(chunks)));
+  });
+}
+
+function startMockApi() {
+  return new Promise((resolve) => {
+    const server = http.createServer(async (req, res) => {
+      const { method, url } = req;
+      if (method === "OPTIONS") {
+        res.writeHead(204, {
+          "Access-Control-Allow-Origin": "*",
+          "Access-Control-Allow-Headers": "*",
+          "Access-Control-Allow-Methods": "*",
+        });
+        return res.end();
+      }
+      if (method === "GET" && url === "/api/v1/sources") return json(res, sources);
+      const siMatch = url.match(/^\/api\/v1\/sources\/([^/]+)\/info$/);
+      if (method === "GET" && siMatch) return json(res, sourceInfos[siMatch[1]] || { error: "not found" }, sourceInfos[siMatch[1]] ? 200 : 404);
+      if (method === "GET" && url === "/api/v1/buckets") return json(res, buckets);
+      if (method === "POST" && url === "/api/v1/buckets") {
+        const body = JSON.parse(await readBody(req));
+        const b = {
+          id: "bkt-" + String(buckets.length + 1).padStart(3, "0"),
+          key: body.key, access_key: "AKSFREE7X9MQ2KPL",
+          created_at: new Date().toISOString(),
+        };
+        buckets.push(b);
+        bucketFiles[b.id] = [];
+        return json(res, { ...b, access_secret: "sfsec_d83ka1mxp7r2vn4t" }, 201);
+      }
+      const fMatch = url.match(/^\/api\/v1\/buckets\/([^/]+)\/files$/);
+      if (method === "GET" && fMatch) return json(res, bucketFiles[fMatch[1]] || []);
+      const uMatch = url.match(/^\/api\/v1\/buckets\/([^/]+)\/upload$/);
+      if (method === "POST" && uMatch) {
+        const raw = await readBody(req);
+        const nameMatch = raw.toString("latin1").match(/filename="([^"]+)"/);
+        const file = {
+          id: "file-" + String(++fileCounter).padStart(3, "0"),
+          name: nameMatch ? nameMatch[1] : "uploaded-file.txt",
+          size: 42, created_at: new Date().toISOString(),
+        };
+        const bId = uMatch[1];
+        if (!bucketFiles[bId]) bucketFiles[bId] = [];
+        bucketFiles[bId].push(file);
+        return json(res, file, 201);
+      }
+      const dMatch = url.match(/^\/api\/v1\/buckets\/([^/]+)\/files\/([^/]+)\/download$/);
+      if (method === "GET" && dMatch) {
+        res.writeHead(200, {
+          "Content-Type": "application/octet-stream",
+          "Content-Disposition": 'attachment; filename="hello.txt"',
+          "Access-Control-Allow-Origin": "*",
+        });
+        return res.end("Hello from SFree!\n");
+      }
+      if (method === "POST" && url === "/api/v1/users") {
+        const body = JSON.parse(await readBody(req));
+        return json(res, { username: body.username, password: "demo-password" }, 201);
+      }
+      if (method === "DELETE") return json(res, {});
+      json(res, { error: "not found" }, 404);
+    });
+    server.listen(MOCK_PORT, () => {
+      console.log(`Mock API on http://localhost:${MOCK_PORT}`);
+      resolve(server);
+    });
+  });
+}
+
+// ─── Vite dev server ───────────────────────────────────────────────────────────
+
+function startVite() {
+  return new Promise((resolve, reject) => {
+    const webuiDir = path.join(ROOT, "webui");
+    // Ensure webui deps are installed
+    if (!fs.existsSync(path.join(webuiDir, "node_modules/.bin/vite"))) {
+      console.log("Installing webui dependencies...");
+      execSync("npm install", { cwd: webuiDir, stdio: "inherit", env: { ...process.env, NODE_ENV: "development" } });
+    }
+    const vite = spawn(
+      path.join(webuiDir, "node_modules/.bin/vite"),
+      ["--host", "0.0.0.0", "--port", String(VITE_PORT)],
+      {
+        cwd: webuiDir,
+        env: { ...process.env, VITE_API_BASE: `http://localhost:${MOCK_PORT}/api/v1`, NODE_ENV: "development" },
+        stdio: ["ignore", "pipe", "pipe"],
+      }
+    );
+    let started = false;
+    vite.stdout.on("data", (d) => {
+      const line = d.toString();
+      if (!started && line.includes("Local:")) {
+        started = true;
+        console.log(`Vite dev server on http://localhost:${VITE_PORT}`);
+        resolve(vite);
+      }
+    });
+    vite.stderr.on("data", (d) => {
+      if (!started) console.error("  vite stderr:", d.toString().trim());
+    });
+    vite.on("exit", (code) => {
+      if (!started) reject(new Error(`Vite exited with code ${code}`));
+    });
+    setTimeout(() => {
+      if (!started) reject(new Error("Vite did not start within 30s"));
+    }, 30000);
+  });
+}
+
+// ─── Recording ─────────────────────────────────────────────────────────────────
+
+async function sleep(ms) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function record() {
+  const puppeteer = await import("puppeteer");
+  const gifenc = await import("gifenc");
+  const { PNG } = await import("pngjs");
+  const { GIFEncoder, quantize, applyPalette } = gifenc.default || gifenc;
+
+  console.log("\nLaunching Chrome...");
+  const browser = await puppeteer.default.launch({
+    headless: true,
+    args: ["--no-sandbox", "--disable-setuid-sandbox", "--disable-gpu", "--disable-dev-shm-usage", `--window-size=${WIDTH},${HEIGHT}`],
+  });
+  const page = await browser.newPage();
+  await page.setViewport({ width: WIDTH, height: HEIGHT });
+
+  const BASE = `http://localhost:${VITE_PORT}`;
+
+  // Set auth (start "logged in")
+  await page.goto(BASE, { waitUntil: "networkidle0", timeout: 30000 });
+  await page.evaluate(() => {
+    localStorage.setItem("auth", btoa("demo-user:demo-pass"));
+    localStorage.setItem("auth_type", "basic");
+    localStorage.setItem("username", "demo-user");
+  });
+
+  const frames = [];
+  async function capture(label, count = 1) {
+    for (let i = 0; i < count; i++) {
+      frames.push(await page.screenshot({ type: "png" }));
+    }
+    console.log(`  [${frames.length}] ${label}`);
+  }
+
+  async function clickButtonByText(text) {
+    const buttons = await page.$$("button");
+    for (const btn of buttons) {
+      const t = await page.evaluate((el) => el.textContent.trim(), btn);
+      if (t === text) { await btn.click(); return true; }
+    }
+    return false;
+  }
+
+  // ─── Scene 1: Sources page (pause 3s worth of frames) ───
+  console.log("\n--- Scene 1: Sources page ---");
+  await page.goto(`${BASE}/sources`, { waitUntil: "networkidle0" });
+  await sleep(1000);
+  await capture("Sources page showing local-minio", 6);
+
+  // ─── Scene 2: Create a bucket ───
+  console.log("\n--- Scene 2: Create bucket ---");
+  await page.goto(`${BASE}/buckets`, { waitUntil: "networkidle0" });
+  await sleep(500);
+  await capture("Buckets page (empty)", 3);
+
+  await clickButtonByText("Add Bucket");
+  await sleep(1000);
+  await capture("Create Bucket dialog", 3);
+
+  // Type bucket name into the Key input
+  const keyInput = await page.$("input");
+  if (keyInput) {
+    await keyInput.click();
+    await keyInput.type("demo-bucket", { delay: 60 });
+  }
+  await sleep(400);
+  await capture("Typed bucket key", 3);
+
+  // Select the local-minio checkbox
+  const labels = await page.$$("[data-slot='label'], label");
+  for (const lbl of labels) {
+    const t = await page.evaluate((el) => el.textContent, lbl);
+    if (t && t.includes("local-minio")) { await lbl.click(); break; }
+  }
+  await sleep(300);
+  await capture("Source selected", 2);
+
+  await clickButtonByText("Create");
+  await sleep(1500);
+  await capture("Credentials shown", 6);
+
+  // Close dialog
+  await clickButtonByText("Close");
+  await sleep(500);
+
+  // Reload to see bucket
+  await page.goto(`${BASE}/buckets`, { waitUntil: "networkidle0" });
+  await sleep(500);
+  await capture("Buckets list with new bucket", 4);
+
+  // ─── Scene 3: Upload a file ───
+  console.log("\n--- Scene 3: Upload file ---");
+  // Click the bucket card (pressable Card)
+  const cards = await page.$$("[data-slot='base']");
+  for (const card of cards) {
+    const t = await page.evaluate((el) => el.textContent, card);
+    if (t && t.includes("demo-bucket")) { await card.click(); break; }
+  }
+  await sleep(1000);
+  await capture("Bucket detail (empty)", 3);
+
+  // Upload via hidden file input
+  const tmpFile = path.join(__dirname, "hello.txt");
+  fs.writeFileSync(tmpFile, "Hello from SFree! This is a demo file.\n");
+  const fileInput = await page.$('input[type="file"]');
+  if (fileInput) {
+    await fileInput.uploadFile(tmpFile);
+    await sleep(1500);
+  }
+  await capture("File uploaded successfully", 5);
+
+  // ─── Scene 4: Browse files ───
+  console.log("\n--- Scene 4: Browse files ---");
+  await capture("File list with uploaded file", 5);
+
+  // ─── Scene 5: Download ───
+  console.log("\n--- Scene 5: Download ---");
+  // Find and click the download button (first icon button in the file row)
+  const iconBtns = await page.$$("button");
+  for (const btn of iconBtns) {
+    const hasDownloadIcon = await page.evaluate((el) => {
+      return el.querySelector("svg") !== null &&
+        el.closest("tr") !== null &&
+        !el.className.includes("danger");
+    }, btn);
+    if (hasDownloadIcon) { await btn.click(); break; }
+  }
+  await sleep(500);
+  await capture("Download initiated", 4);
+
+  // ─── Scene 6: End hold ───
+  console.log("\n--- Scene 6: End ---");
+  await capture("Final hold", 4);
+
+  // ─── Encode GIF ───
+  console.log(`\nEncoding ${frames.length} frames...`);
+  const gif = GIFEncoder();
+
+  for (let i = 0; i < frames.length; i++) {
+    const png = PNG.sync.read(frames[i]);
+    const palette = quantize(png.data, 256);
+    const index = applyPalette(png.data, palette);
+    gif.writeFrame(index, png.width, png.height, { palette, delay: FRAME_DELAY });
+    if ((i + 1) % 10 === 0) console.log(`  ${i + 1}/${frames.length}`);
+  }
+  gif.finish();
+
+  fs.mkdirSync(path.dirname(OUTPUT), { recursive: true });
+  fs.writeFileSync(OUTPUT, Buffer.from(gif.bytes()));
+  const sizeMB = (fs.statSync(OUTPUT).size / 1024 / 1024).toFixed(2);
+  console.log(`\nGIF saved: ${OUTPUT} (${sizeMB} MB)`);
+
+  // Cleanup
+  fs.unlinkSync(tmpFile);
+  await browser.close();
+  return sizeMB;
+}
+
+// ─── Main ──────────────────────────────────────────────────────────────────────
+
+async function main() {
+  console.log("SFree Demo GIF Recorder\n");
+
+  const mockServer = await startMockApi();
+  const viteProc = await startVite();
+
+  try {
+    const sizeMB = await record();
+    console.log(`\nDone! GIF is ${sizeMB} MB.`);
+    if (parseFloat(sizeMB) > 10) {
+      console.log("Warning: GIF exceeds 10 MB target. Consider optimizing with gifsicle:");
+      console.log("  gifsicle -O3 --lossy=80 docs/assets/demo.gif -o docs/assets/demo.gif");
+    }
+  } finally {
+    viteProc.kill();
+    mockServer.close();
+  }
+}
+
+main().catch((err) => {
+  console.error("\nFailed:", err.message);
+  process.exit(1);
+});

--- a/webui/src/pages/dashboard/ui/dashboard-page.tsx
+++ b/webui/src/pages/dashboard/ui/dashboard-page.tsx
@@ -1,27 +1,181 @@
-import {Card, CardHeader, CardBody, CardFooter, Button} from "@heroui/react";
-import {Link} from "react-router-dom";
+import {Card, CardBody, CardHeader, Button, CircularProgress} from "@heroui/react";
+import {useEffect, useState} from "react";
+import {Link, useNavigate} from "react-router-dom";
+import {listSources, getSourceInfo} from "../../../shared/api/sources";
+import {listBuckets} from "../../../shared/api/buckets";
+import {SourceTypeChip} from "../../../entities/source";
+import type {Source, SourceInfo} from "../../../shared/api/sources";
+import type {Bucket} from "../../../shared/api/buckets";
 
-const features = [
-  {title: "Buckets", description: "Manage storage buckets", href: "/buckets"},
-  {title: "Sources", description: "Configure data sources", href: "/sources"},
-];
+function formatBytes(bytes: number): string {
+  if (bytes === 0) return "0 B";
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  const i = Math.floor(Math.log(bytes) / Math.log(1024));
+  const value = bytes / Math.pow(1024, i);
+  return `${value.toFixed(i === 0 ? 0 : 1)} ${units[i]}`;
+}
+
+type SourceWithInfo = Source & {info: SourceInfo | null};
 
 export function DashboardPage() {
+  const navigate = useNavigate();
+  const [sources, setSources] = useState<SourceWithInfo[]>([]);
+  const [buckets, setBuckets] = useState<Bucket[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    async function load() {
+      setIsLoading(true);
+      try {
+        const [srcList, bucketList] = await Promise.all([
+          listSources(),
+          listBuckets(),
+        ]);
+        setBuckets(bucketList);
+
+        const withInfo = await Promise.all(
+          srcList.map(async (s) => {
+            try {
+              const info = await getSourceInfo(s.id);
+              return {...s, info};
+            } catch {
+              return {...s, info: null};
+            }
+          }),
+        );
+        setSources(withInfo);
+      } catch {
+        // keep empty state
+      } finally {
+        setIsLoading(false);
+      }
+    }
+    load();
+  }, []);
+
+  const totalFiles = sources.reduce(
+    (sum, s) => sum + (s.info?.files.length ?? 0),
+    0,
+  );
+  const totalStorageUsed = sources.reduce(
+    (sum, s) => sum + (s.info?.storage_used ?? 0),
+    0,
+  );
+
+  if (isLoading) {
+    return (
+      <div className="p-8 flex flex-col gap-8">
+        <h1 className="text-3xl font-bold">Dashboard</h1>
+        <p className="text-default-500">Loading...</p>
+      </div>
+    );
+  }
+
   return (
     <div className="p-8 flex flex-col gap-8">
       <h1 className="text-3xl font-bold">Dashboard</h1>
-      <div className="grid gap-6 sm:grid-cols-2">
-        {features.map((feature) => (
-          <Card key={feature.title}>
-            <CardHeader>{feature.title}</CardHeader>
-            <CardBody>{feature.description}</CardBody>
-            <CardFooter>
-              <Button as={Link} color="primary" to={feature.href}>
-                Open
+
+      {/* Summary stat cards */}
+      <div className="grid gap-4 grid-cols-2 lg:grid-cols-4">
+        <Card>
+          <CardBody className="text-center py-6">
+            <p className="text-4xl font-bold">{sources.length}</p>
+            <p className="text-sm text-default-500 mt-1">Sources</p>
+          </CardBody>
+        </Card>
+        <Card>
+          <CardBody className="text-center py-6">
+            <p className="text-4xl font-bold">{buckets.length}</p>
+            <p className="text-sm text-default-500 mt-1">Buckets</p>
+          </CardBody>
+        </Card>
+        <Card>
+          <CardBody className="text-center py-6">
+            <p className="text-4xl font-bold">{totalFiles}</p>
+            <p className="text-sm text-default-500 mt-1">Files</p>
+          </CardBody>
+        </Card>
+        <Card>
+          <CardBody className="text-center py-6">
+            <p className="text-4xl font-bold">{formatBytes(totalStorageUsed)}</p>
+            <p className="text-sm text-default-500 mt-1">Storage Used</p>
+          </CardBody>
+        </Card>
+      </div>
+
+      {/* Sources breakdown */}
+      <div>
+        <h2 className="text-xl font-semibold mb-4">Sources</h2>
+        {sources.length === 0 ? (
+          <Card>
+            <CardBody className="text-center py-8">
+              <p className="text-default-500 mb-4">No sources configured yet.</p>
+              <Button as={Link} color="primary" to="/sources">
+                Add a Source
               </Button>
-            </CardFooter>
+            </CardBody>
           </Card>
-        ))}
+        ) : (
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {sources.map((s) => {
+              const fileCount = s.info?.files.length ?? 0;
+              const percent =
+                s.info && s.info.storage_total
+                  ? (s.info.storage_used / s.info.storage_total) * 100
+                  : 0;
+              const used = s.info?.storage_used ?? 0;
+              const total = s.info?.storage_total ?? 0;
+
+              return (
+                <Card
+                  key={s.id}
+                  isPressable
+                  onPress={() => navigate(`/sources/${s.id}`)}
+                >
+                  <CardHeader className="flex justify-between items-center">
+                    <div className="flex flex-col gap-1">
+                      <span className="font-bold">{s.name}</span>
+                      <SourceTypeChip type={s.type} />
+                    </div>
+                    {total > 0 && (
+                      <CircularProgress
+                        classNames={{
+                          svg: "w-16 h-16",
+                          indicator: "stroke-primary",
+                          track: "stroke-default-200",
+                          value: "text-xs font-semibold",
+                        }}
+                        showValueLabel
+                        strokeWidth={4}
+                        value={percent}
+                      />
+                    )}
+                  </CardHeader>
+                  <CardBody className="pt-0">
+                    <div className="flex justify-between text-sm text-default-500">
+                      <span>{fileCount} {fileCount === 1 ? "file" : "files"}</span>
+                      {total > 0 && (
+                        <span>
+                          {formatBytes(used)} / {formatBytes(total)}
+                        </span>
+                      )}
+                    </div>
+                  </CardBody>
+                </Card>
+              );
+            })}
+          </div>
+        )}
+      </div>
+
+      {/* Quick actions */}
+      <div className="flex gap-4">
+        <Button as={Link} variant="flat" to="/sources">
+          Manage Sources
+        </Button>
+        <Button as={Link} variant="flat" to="/buckets">
+          Manage Buckets
+        </Button>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Add annotated SVG screenshots for README (sources, bucket creation, file browser, share links)
- Add automated demo GIF recording script (Puppeteer-based, no Docker needed)
- Replace placeholder dashboard with usage metrics overview (sources, buckets, files, storage)
- Add demo GIF embed and recording brief in docs/assets

Rebased from stale branch — task THE-52 was marked done but PR never created.

## Test plan
- [ ] Verify SVG screenshots render correctly in README
- [ ] Verify dashboard page shows usage metrics
- [ ] Verify recording script runs with `npm install && npm run record`

🤖 Generated with [Claude Code](https://claude.com/claude-code)