### PR TITLE
Add Playwright E2E test suite for web UI critical flows

### DIFF
--- a/.woodpecker/webui.yml
+++ b/.woodpecker/webui.yml
@@ -21,6 +21,15 @@ steps:
       - npm run lint
       - npm run build
 
+  - name: e2e tests
+    image: node:20
+    commands:
+      - cd webui
+      - npm ci --include=dev
+      - npm run build
+      - npx playwright install --with-deps chromium
+      - npm run test:e2e
+
   - name: build and push
     image: woodpeckerci/plugin-docker-buildx
     when:

--- a/webui/e2e/buckets.spec.ts
+++ b/webui/e2e/buckets.spec.ts
@@ -1,0 +1,115 @@
+/**
+ * Flow 3: Bucket creation and file upload.
+ *
+ * Covers:
+ * - Buckets page renders with empty state
+ * - "Add Bucket" dialog loads available sources
+ * - Selecting a source and submitting creates a bucket and shows credentials
+ * - Upload File button is present on the bucket detail page
+ */
+
+import { test, expect } from "@playwright/test";
+import { injectAuth, mockGet, mockPost } from "./helpers";
+
+const MOCK_SOURCE = {
+  id: "src-1",
+  name: "My Drive",
+  type: "gdrive",
+  key: "k",
+  created_at: "2024-01-15T10:00:00Z",
+};
+
+const MOCK_BUCKET = {
+  id: "bkt-1",
+  key: "my-bucket",
+  access_key: "AK123",
+  created_at: "2024-01-15T11:00:00Z",
+};
+
+const MOCK_BUCKET_CREDS = {
+  key: "my-bucket",
+  access_key: "AK123",
+  access_secret: "SK456",
+  created_at: "2024-01-15T11:00:00Z",
+};
+
+test.describe("Bucket creation flow", () => {
+  test("buckets page shows empty state when no buckets exist", async ({
+    page,
+  }) => {
+    await injectAuth(page);
+    await mockGet(page, "/buckets", []);
+    await page.goto("/buckets");
+    await expect(page.getByRole("heading", { name: "Buckets" })).toBeVisible();
+    await expect(page.getByText("No buckets yet")).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Add Bucket" }),
+    ).toBeVisible();
+  });
+
+  test("Add Bucket dialog loads available sources", async ({ page }) => {
+    await injectAuth(page);
+    await mockGet(page, "/buckets", []);
+    await mockGet(page, "/sources", [MOCK_SOURCE]);
+    await page.goto("/buckets");
+
+    await page.getByRole("button", { name: "Add Bucket" }).click();
+    await expect(page.getByRole("dialog")).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Create Bucket" }),
+    ).toBeVisible();
+    await expect(page.getByLabel("Key")).toBeVisible();
+
+    // Source checkbox should appear after sources load
+    await expect(page.getByText("My Drive")).toBeVisible();
+  });
+
+  test("creating a bucket shows S3 credentials", async ({ page }) => {
+    await injectAuth(page);
+    await mockGet(page, "/buckets", []);
+    await mockGet(page, "/sources", [MOCK_SOURCE]);
+    await mockPost(page, "/buckets", MOCK_BUCKET_CREDS);
+
+    await page.goto("/buckets");
+    await page.getByRole("button", { name: "Add Bucket" }).click();
+
+    // Wait for sources to load in dialog
+    await expect(page.getByText("My Drive")).toBeVisible();
+
+    // Fill key
+    await page.getByLabel("Key").fill("my-bucket");
+
+    // Select the source checkbox
+    await page.getByLabel("My Drive").check();
+
+    // Submit
+    await page
+      .getByRole("dialog")
+      .getByRole("button", { name: "Create" })
+      .click();
+
+    // Credentials screen: access key and secret should be visible
+    await expect(page.getByText("AK123")).toBeVisible();
+    await expect(page.getByText("SK456")).toBeVisible();
+    await expect(
+      page.getByText(/copy these credentials/i),
+    ).toBeVisible();
+
+    // Close button dismisses the dialog
+    await page
+      .getByRole("dialog")
+      .getByRole("button", { name: "Close" })
+      .click();
+    await expect(page.getByRole("dialog")).not.toBeVisible();
+  });
+
+  test("Upload File button is present on bucket detail page", async ({
+    page,
+  }) => {
+    await injectAuth(page);
+    await mockGet(page, "/buckets", [MOCK_BUCKET]);
+    await mockGet(page, "/buckets/bkt-1/files", []);
+    await page.goto("/buckets/bkt-1");
+    await expect(page.getByRole("button", { name: "Upload File" })).toBeVisible();
+  });
+});

--- a/webui/e2e/dashboard.spec.ts
+++ b/webui/e2e/dashboard.spec.ts
@@ -1,0 +1,64 @@
+/**
+ * Flow 1: Dashboard loads correctly.
+ *
+ * Covers:
+ * - Authenticated user at "/" redirects to "/dashboard"
+ * - Dashboard heading and navigation cards render
+ * - "Open" buttons navigate to /buckets and /sources
+ * - Unauthenticated user at "/" sees the landing page
+ */
+
+import { test, expect } from "@playwright/test";
+import { injectAuth, mockGet, API_GLOB } from "./helpers";
+
+test.describe("Dashboard", () => {
+  test("authenticated user at / redirects to /dashboard", async ({ page }) => {
+    await injectAuth(page);
+    await page.goto("/");
+    await expect(page).toHaveURL("/dashboard");
+    await expect(page.getByRole("heading", { name: "Dashboard" })).toBeVisible();
+  });
+
+  test("dashboard shows Buckets and Sources cards", async ({ page }) => {
+    await injectAuth(page);
+    await page.goto("/dashboard");
+    await expect(page.getByRole("heading", { name: "Dashboard" })).toBeVisible();
+    await expect(page.getByText("Buckets")).toBeVisible();
+    await expect(page.getByText("Sources")).toBeVisible();
+    await expect(page.getByText("Manage storage buckets")).toBeVisible();
+    await expect(page.getByText("Configure data sources")).toBeVisible();
+  });
+
+  test("Buckets Open button navigates to /buckets", async ({ page }) => {
+    await injectAuth(page);
+    await mockGet(page, "/buckets", []);
+    await page.goto("/dashboard");
+    // Two "Open" links; first is Buckets
+    await page.getByRole("link", { name: "Open" }).first().click();
+    await expect(page).toHaveURL("/buckets");
+    await expect(page.getByRole("heading", { name: "Buckets" })).toBeVisible();
+  });
+
+  test("Sources Open button navigates to /sources", async ({ page }) => {
+    await injectAuth(page);
+    await mockGet(page, "/sources", []);
+    await page.goto("/dashboard");
+    // Second "Open" link is Sources
+    await page.getByRole("link", { name: "Open" }).nth(1).click();
+    await expect(page).toHaveURL("/sources");
+    await expect(page.getByRole("heading", { name: "Sources" })).toBeVisible();
+  });
+
+  test("unauthenticated user at / sees landing page", async ({ page }) => {
+    // No injectAuth — localStorage is empty
+    await page.route(`${API_GLOB}/**`, (route) => route.abort());
+    await page.goto("/");
+    await expect(page.getByRole("heading", { name: "S3aaS" })).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Sign Up" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Log In" }),
+    ).toBeVisible();
+  });
+});

--- a/webui/e2e/error-states.spec.ts
+++ b/webui/e2e/error-states.spec.ts
@@ -1,0 +1,118 @@
+/**
+ * Flow 5: Error states render correctly.
+ *
+ * Covers:
+ * - "Bucket not found" when navigating to a non-existent bucket ID
+ * - Landing page auth dialogs open and close without crashing
+ * - Register flow shows password after API call
+ * - Login flow closes dialog and persists auth
+ */
+
+import { test, expect } from "@playwright/test";
+import { injectAuth, mockGet, mockPost, API_GLOB } from "./helpers";
+
+test.describe("Error states", () => {
+  test("navigating to a non-existent bucket shows Bucket not found", async ({
+    page,
+  }) => {
+    await injectAuth(page);
+    // API returns empty bucket list — bucket ID won't match
+    await mockGet(page, "/buckets", []);
+    await mockGet(page, "/buckets/does-not-exist/files", []);
+    await page.goto("/buckets/does-not-exist");
+
+    await expect(page.getByText("Bucket not found")).toBeVisible();
+  });
+
+  test("Register dialog opens, creates user, and displays password", async ({
+    page,
+  }) => {
+    // No auth — unauthenticated landing page
+    await page.route(`${API_GLOB}/**`, (route) => route.abort());
+    await mockPost(page, "/users", {
+      id: "u-new",
+      created_at: "2024-01-01T00:00:00Z",
+      password: "generated-secret-pw",
+    });
+
+    await page.goto("/");
+    await page.getByRole("button", { name: "Sign Up" }).click();
+
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+    await expect(
+      dialog.getByRole("heading", { name: "Sign Up" }),
+    ).toBeVisible();
+
+    await dialog.getByLabel("Username").fill("newuser");
+    await dialog.getByRole("button", { name: "Sign Up" }).click();
+
+    // Generated password is shown via Snippet
+    await expect(page.getByText("generated-secret-pw")).toBeVisible();
+
+    // Close button dismisses
+    await dialog.getByRole("button", { name: "Close" }).click();
+    await expect(dialog).not.toBeVisible();
+  });
+
+  test("Login dialog opens and closes, storing credentials", async ({
+    page,
+  }) => {
+    // Login is purely client-side — saves btoa(user:pass) to localStorage
+    await page.route(`${API_GLOB}/**`, (route) => route.abort());
+
+    await page.goto("/");
+    await page.getByRole("button", { name: "Log In" }).click();
+
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+
+    await dialog.getByLabel("Username").fill("alice");
+    await dialog.getByLabel("Password").fill("secret");
+    await dialog.getByRole("button", { name: "Log In" }).click();
+
+    // Dialog closes after login
+    await expect(dialog).not.toBeVisible();
+
+    // localStorage should now have auth set
+    const auth = await page.evaluate(() => localStorage.getItem("auth"));
+    expect(auth).toBe(btoa("alice:secret"));
+  });
+
+  test("sources page renders without crashing when API returns error", async ({
+    page,
+  }) => {
+    await injectAuth(page);
+    // API fails — app catches the error and shows empty state
+    await page.route("**/api/v1/sources", (route) =>
+      route.fulfill({ status: 500, json: { error: "internal server error" } }),
+    );
+
+    await page.goto("/sources");
+
+    // Page must not crash — heading and Add Source button should still be present
+    await expect(page.getByRole("heading", { name: "Sources" })).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Add Source" }),
+    ).toBeVisible();
+    // Shows empty state (error silently results in empty list)
+    await expect(page.getByText("No sources yet")).toBeVisible();
+  });
+
+  test("buckets page renders without crashing when API returns error", async ({
+    page,
+  }) => {
+    await injectAuth(page);
+    await page.route("**/api/v1/buckets", (route) =>
+      route.fulfill({ status: 500, json: { error: "internal server error" } }),
+    );
+
+    await page.goto("/buckets");
+
+    await expect(page.getByRole("heading", { name: "Buckets" })).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Add Bucket" }),
+    ).toBeVisible();
+    await expect(page.getByText("No buckets yet")).toBeVisible();
+  });
+});

--- a/webui/e2e/files.spec.ts
+++ b/webui/e2e/files.spec.ts
@@ -1,0 +1,138 @@
+/**
+ * Flow 4: File listing and download.
+ *
+ * Covers:
+ * - Bucket detail page shows file list with name, size, and date columns
+ * - Download button is present for each file
+ * - Empty file state renders correctly
+ * - Back navigation button is present
+ */
+
+import { test, expect } from "@playwright/test";
+import { injectAuth, mockGet } from "./helpers";
+
+const MOCK_BUCKET = {
+  id: "bkt-1",
+  key: "my-bucket",
+  access_key: "AK123",
+  created_at: "2024-01-15T11:00:00Z",
+};
+
+const MOCK_FILES = [
+  {
+    id: "file-1",
+    name: "report.pdf",
+    size: 204800,
+    created_at: "2024-01-20T09:00:00Z",
+  },
+  {
+    id: "file-2",
+    name: "data.csv",
+    size: 1024,
+    created_at: "2024-01-21T14:30:00Z",
+  },
+];
+
+test.describe("File listing and download", () => {
+  test("bucket detail shows bucket info", async ({ page }) => {
+    await injectAuth(page);
+    await mockGet(page, "/buckets", [MOCK_BUCKET]);
+    await mockGet(page, "/buckets/bkt-1/files", []);
+    await page.goto("/buckets/bkt-1");
+
+    await expect(page.getByRole("heading", { name: "my-bucket" })).toBeVisible();
+    await expect(page.getByText(/AK123/)).toBeVisible();
+  });
+
+  test("bucket detail shows empty state when no files", async ({ page }) => {
+    await injectAuth(page);
+    await mockGet(page, "/buckets", [MOCK_BUCKET]);
+    await mockGet(page, "/buckets/bkt-1/files", []);
+    await page.goto("/buckets/bkt-1");
+
+    await expect(page.getByText("No files")).toBeVisible();
+  });
+
+  test("bucket detail lists files with name, size, and date columns", async ({
+    page,
+  }) => {
+    await injectAuth(page);
+    await mockGet(page, "/buckets", [MOCK_BUCKET]);
+    await mockGet(page, "/buckets/bkt-1/files", MOCK_FILES);
+    await page.goto("/buckets/bkt-1");
+
+    // Table headers
+    await expect(page.getByRole("columnheader", { name: "Name" })).toBeVisible();
+    await expect(page.getByRole("columnheader", { name: "Size" })).toBeVisible();
+    await expect(
+      page.getByRole("columnheader", { name: "Created" }),
+    ).toBeVisible();
+
+    // File rows
+    await expect(page.getByText("report.pdf")).toBeVisible();
+    await expect(page.getByText("data.csv")).toBeVisible();
+  });
+
+  test("each file row has a download button", async ({ page }) => {
+    await injectAuth(page);
+    await mockGet(page, "/buckets", [MOCK_BUCKET]);
+    await mockGet(page, "/buckets/bkt-1/files", MOCK_FILES);
+    await page.goto("/buckets/bkt-1");
+
+    // There should be one download button per file row (icon buttons)
+    // We verify at least one is visible
+    const rows = page.getByRole("row");
+    // header + 2 file rows
+    await expect(rows).toHaveCount(3);
+
+    // Download buttons are icon-only buttons in each file row
+    // The download button uses DownloadIcon; we check via aria-label or button count
+    const fileRows = page.locator("tbody tr");
+    await expect(fileRows).toHaveCount(2);
+
+    // Each row should have exactly 2 icon buttons (download + delete)
+    const firstRowButtons = fileRows.first().getByRole("button");
+    await expect(firstRowButtons).toHaveCount(2);
+  });
+
+  test("clicking download triggers a fetch to the download endpoint", async ({
+    page,
+  }) => {
+    await injectAuth(page);
+    await mockGet(page, "/buckets", [MOCK_BUCKET]);
+    await mockGet(page, "/buckets/bkt-1/files", [MOCK_FILES[0]]);
+
+    // Intercept download call and fulfill with a blob
+    let downloadCalled = false;
+    await page.route("**/api/v1/buckets/bkt-1/files/file-1/download", async (route) => {
+      downloadCalled = true;
+      await route.fulfill({
+        status: 200,
+        headers: { "Content-Type": "application/octet-stream" },
+        body: Buffer.from("fake-content"),
+      });
+    });
+
+    await page.goto("/buckets/bkt-1");
+    await expect(page.getByText("report.pdf")).toBeVisible();
+
+    // Click the first icon button in the first file row (download)
+    const firstRow = page.locator("tbody tr").first();
+    await firstRow.getByRole("button").first().click();
+
+    await expect.poll(() => downloadCalled).toBe(true);
+  });
+
+  test("back button is present and navigates back", async ({ page }) => {
+    await injectAuth(page);
+    await mockGet(page, "/buckets", [MOCK_BUCKET]);
+    await mockGet(page, "/buckets/bkt-1/files", []);
+    await page.goto("/buckets");
+    // Navigate to bucket detail
+    await page.goto("/buckets/bkt-1");
+
+    // Back button (isIconOnly with ArrowLeftIcon) is present
+    const backButton = page.getByRole("button").first();
+    await expect(backButton).toBeVisible();
+  });
+});

--- a/webui/e2e/helpers.ts
+++ b/webui/e2e/helpers.ts
@@ -1,0 +1,54 @@
+import type { Page } from "@playwright/test";
+
+export const API_GLOB = "**/api/v1";
+
+/**
+ * Inject Basic auth credentials into localStorage before the page loads.
+ * Must be called before page.goto().
+ */
+export async function injectAuth(
+  page: Page,
+  username = "testuser",
+  password = "testpass",
+) {
+  await page.addInitScript(
+    ({ u, p }) => localStorage.setItem("auth", btoa(`${u}:${p}`)),
+    { u: username, p: password },
+  );
+}
+
+/**
+ * Mock a GET endpoint. Glob pattern: API_GLOB + path, e.g. "**/api/v1/sources".
+ */
+export async function mockGet(
+  page: Page,
+  path: string,
+  body: unknown,
+  status = 200,
+) {
+  await page.route(`${API_GLOB}${path}`, async (route) => {
+    if (route.request().method() !== "GET") {
+      await route.continue();
+      return;
+    }
+    await route.fulfill({ status, json: body });
+  });
+}
+
+/**
+ * Mock a POST endpoint.
+ */
+export async function mockPost(
+  page: Page,
+  path: string,
+  body: unknown,
+  status = 200,
+) {
+  await page.route(`${API_GLOB}${path}`, async (route) => {
+    if (route.request().method() !== "POST") {
+      await route.continue();
+      return;
+    }
+    await route.fulfill({ status, json: body });
+  });
+}

--- a/webui/e2e/sources.spec.ts
+++ b/webui/e2e/sources.spec.ts
@@ -1,0 +1,96 @@
+/**
+ * Flow 2: Source creation flow.
+ *
+ * Covers:
+ * - Sources page renders with empty state
+ * - "Add Source" button opens the create-source dialog
+ * - Filling the form and submitting calls the API and refreshes the list
+ * - Newly created source appears in the list
+ */
+
+import { test, expect } from "@playwright/test";
+import { injectAuth, mockGet, mockPost } from "./helpers";
+
+const MOCK_SOURCE = {
+  id: "src-1",
+  name: "My Drive",
+  type: "gdrive",
+  key: "service-account-key",
+  created_at: "2024-01-15T10:00:00Z",
+};
+
+test.describe("Source creation flow", () => {
+  test("sources page shows empty state when no sources exist", async ({
+    page,
+  }) => {
+    await injectAuth(page);
+    await mockGet(page, "/sources", []);
+    await page.goto("/sources");
+    await expect(page.getByRole("heading", { name: "Sources" })).toBeVisible();
+    await expect(page.getByText("No sources yet")).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Add Source" }),
+    ).toBeVisible();
+  });
+
+  test("Add Source button opens the create source dialog", async ({ page }) => {
+    await injectAuth(page);
+    await mockGet(page, "/sources", []);
+    await page.goto("/sources");
+    await page.getByRole("button", { name: "Add Source" }).click();
+    await expect(page.getByRole("dialog")).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Create Source" }),
+    ).toBeVisible();
+    await expect(page.getByLabel("Name")).toBeVisible();
+    await expect(page.getByLabel("Key")).toBeVisible();
+  });
+
+  test("submitting the dialog creates a source and refreshes the list", async ({
+    page,
+  }) => {
+    await injectAuth(page);
+
+    // Before creation: empty list
+    let listCallCount = 0;
+    await page.route("**/api/v1/sources", async (route) => {
+      if (route.request().method() === "GET") {
+        // First call returns empty; subsequent calls return the new source
+        const body = listCallCount === 0 ? [] : [MOCK_SOURCE];
+        listCallCount++;
+        await route.fulfill({ json: body });
+      } else {
+        await route.continue();
+      }
+    });
+    await mockPost(page, "/sources/gdrive", MOCK_SOURCE);
+
+    await page.goto("/sources");
+    await expect(page.getByText("No sources yet")).toBeVisible();
+
+    // Open dialog
+    await page.getByRole("button", { name: "Add Source" }).click();
+    await expect(page.getByRole("dialog")).toBeVisible();
+
+    // Fill form
+    await page.getByLabel("Name").fill("My Drive");
+    await page.getByLabel("Key").fill("service-account-key");
+
+    // Submit
+    await page
+      .getByRole("dialog")
+      .getByRole("button", { name: "Create" })
+      .click();
+
+    // Dialog should close and source should appear
+    await expect(page.getByRole("dialog")).not.toBeVisible();
+    await expect(page.getByText("My Drive")).toBeVisible();
+  });
+
+  test("sources page shows existing sources", async ({ page }) => {
+    await injectAuth(page);
+    await mockGet(page, "/sources", [MOCK_SOURCE]);
+    await page.goto("/sources");
+    await expect(page.getByText("My Drive")).toBeVisible();
+  });
+});

--- a/webui/package.json
+++ b/webui/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@heroui/react": "^2.8.2",
@@ -19,6 +20,7 @@
     "react-router-dom": "^6.30.3"
   },
   "devDependencies": {
+    "@playwright/test": "^1.48.0",
     "@eslint/js": "^9.33.0",
     "@tailwindcss/postcss": "^4.1.12",
     "@types/node": "^25.6.0",

--- a/webui/playwright.config.ts
+++ b/webui/playwright.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? "list" : "html",
+  use: {
+    baseURL: "http://localhost:4173",
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    command: "npm run preview",
+    url: "http://localhost:4173",
+    reuseExistingServer: !process.env.CI,
+  },
+});


### PR DESCRIPTION
## Summary
- Add Playwright E2E tests for 5 critical user paths (dashboard, sources, buckets, files, error states)
- Tests use API mocking (no real backend needed)
- Add Woodpecker CI step to run E2E tests after validate step
- Cherry-picked from stale feat/the-36-e2e-web-ui branch (skipped stale README commit)

Task THE-36 was marked done but PR never created/merged.

## Test plan
- [ ] Verify Playwright tests pass locally with `npx playwright test`
- [ ] Verify Woodpecker CI step runs tests correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)