### PR TITLE
Fix OAuth auth: cookie fallback and credentials include

### DIFF
--- a/api-go/internal/handlers/auth.go
+++ b/api-go/internal/handlers/auth.go
@@ -20,11 +20,16 @@ func Auth(repo *repository.UserRepository, jwtSecret string) gin.HandlerFunc {
 		authHeader := c.GetHeader("Authorization")
 
 		// Resolve JWT: prefer Authorization header, fall back to auth_token cookie.
+		// Only fall back to cookie when no Authorization header is present at all;
+		// otherwise a Basic auth request with an existing OAuth cookie would
+		// silently authenticate via cookie instead of the provided credentials.
 		tokenStr := ""
 		if strings.HasPrefix(authHeader, "Bearer ") {
 			tokenStr = strings.TrimPrefix(authHeader, "Bearer ")
-		} else if cookieToken, err := c.Cookie("auth_token"); err == nil && cookieToken != "" {
-			tokenStr = cookieToken
+		} else if authHeader == "" {
+			if cookieToken, err := c.Cookie("auth_token"); err == nil && cookieToken != "" {
+				tokenStr = cookieToken
+			}
 		}
 
 		if tokenStr != "" {

--- a/webui/src/shared/api/buckets.ts
+++ b/webui/src/shared/api/buckets.ts
@@ -16,15 +16,20 @@ export type FileInfo = {
   size: number;
 };
 
-import { getAuthHeader } from "../lib/auth";
+import { getAuthHeader, getCredentialsOption } from "../lib/auth";
 
 function authHeader(): Record<string, string> {
   return getAuthHeader();
 }
 
+function credentials(): RequestCredentials | undefined {
+  return getCredentialsOption();
+}
+
 export async function listBuckets(): Promise<Bucket[]> {
   const res = await fetch(`${API_BASE}/buckets`, {
     headers: authHeader(),
+    credentials: credentials(),
   });
   await throwIfNotOk(res, "Failed to list buckets");
   return res.json();
@@ -42,6 +47,7 @@ export async function createBucket(key: string, sourceIds: string[]): Promise<{
       "Content-Type": "application/json",
       ...authHeader(),
     },
+    credentials: credentials(),
     body: JSON.stringify({key, source_ids: sourceIds}),
   });
   await throwIfNotOk(res, "Failed to create bucket");
@@ -51,6 +57,7 @@ export async function createBucket(key: string, sourceIds: string[]): Promise<{
 export async function listFiles(bucketId: string): Promise<FileInfo[]> {
   const res = await fetch(`${API_BASE}/buckets/${bucketId}/files`, {
     headers: authHeader(),
+    credentials: credentials(),
   });
   await throwIfNotOk(res, "Failed to list files");
   return res.json();
@@ -65,6 +72,7 @@ export async function uploadFile(
   const res = await fetch(`${API_BASE}/buckets/${bucketId}/upload`, {
     method: "POST",
     headers: authHeader(),
+    credentials: credentials(),
     body: form,
   });
   await throwIfNotOk(res, "Failed to upload file");
@@ -75,6 +83,7 @@ export async function deleteBucket(id: string): Promise<void> {
   const res = await fetch(`${API_BASE}/buckets/${id}`, {
     method: "DELETE",
     headers: authHeader(),
+    credentials: credentials(),
   });
   await throwIfNotOk(res, "Failed to delete bucket");
 }
@@ -87,6 +96,7 @@ export async function downloadFile(
     `${API_BASE}/buckets/${bucketId}/files/${file.id}/download`,
     {
       headers: authHeader(),
+      credentials: credentials(),
     },
   );
   await throwIfNotOk(res, "Failed to download file");
@@ -107,6 +117,7 @@ export async function fetchFileBlob(
     `${API_BASE}/buckets/${bucketId}/files/${fileId}/download`,
     {
       headers: authHeader(),
+      credentials: credentials(),
     },
   );
   if (!res.ok) throw new Error("failed to fetch file");
@@ -120,6 +131,7 @@ export async function deleteFile(
   const res = await fetch(`${API_BASE}/buckets/${bucketId}/files/${fileId}`, {
     method: "DELETE",
     headers: authHeader(),
+    credentials: credentials(),
   });
   await throwIfNotOk(res, "Failed to delete file");
 }

--- a/webui/src/shared/api/shares.ts
+++ b/webui/src/shared/api/shares.ts
@@ -1,9 +1,13 @@
 const API_BASE = import.meta.env.VITE_API_BASE || "/api/v1";
 
-import { getAuthHeader } from "../lib/auth";
+import { getAuthHeader, getCredentialsOption } from "../lib/auth";
 
 function authHeader(): Record<string, string> {
   return getAuthHeader();
+}
+
+function credentials(): RequestCredentials | undefined {
+  return getCredentialsOption();
 }
 
 export type ShareLinkInfo = {
@@ -29,6 +33,7 @@ export async function createShareLink(
         "Content-Type": "application/json",
         ...authHeader(),
       },
+      credentials: credentials(),
       body: JSON.stringify(expiresIn ? { expires_in: expiresIn } : {}),
     },
   );
@@ -44,6 +49,7 @@ export async function listShareLinks(
     `${API_BASE}/buckets/${bucketId}/files/${fileId}/shares`,
     {
       headers: authHeader(),
+      credentials: credentials(),
     },
   );
   if (!res.ok) throw new Error("failed to list share links");
@@ -54,6 +60,7 @@ export async function deleteShareLink(id: string): Promise<void> {
   const res = await fetch(`${API_BASE}/shares/${id}`, {
     method: "DELETE",
     headers: authHeader(),
+    credentials: credentials(),
   });
   if (!res.ok) throw new Error("failed to delete share link");
 }

--- a/webui/src/shared/api/sources.ts
+++ b/webui/src/shared/api/sources.ts
@@ -16,15 +16,20 @@ export type SourceInfo = {
   storage_free: number;
 };
 
-import { getAuthHeader } from "../lib/auth";
+import { getAuthHeader, getCredentialsOption } from "../lib/auth";
 
 function authHeader(): Record<string, string> {
   return getAuthHeader();
 }
 
+function credentials(): RequestCredentials | undefined {
+  return getCredentialsOption();
+}
+
 export async function listSources(): Promise<Source[]> {
   const res = await fetch(`${API_BASE}/sources`, {
     headers: authHeader(),
+    credentials: credentials(),
   });
   await throwIfNotOk(res, "Failed to list sources");
   return res.json() as Promise<Source[]>;
@@ -34,6 +39,7 @@ export async function createGDriveSource(name: string, key: string): Promise<Sou
   const res = await fetch(`${API_BASE}/sources/gdrive`, {
     method: "POST",
     headers: {"Content-Type": "application/json", ...authHeader()},
+    credentials: credentials(),
     body: JSON.stringify({name, key}),
   });
   await throwIfNotOk(res, "Failed to create source");
@@ -44,6 +50,7 @@ export async function createTelegramSource(name: string, token: string, chatId: 
   const res = await fetch(`${API_BASE}/sources/telegram`, {
     method: "POST",
     headers: {"Content-Type": "application/json", ...authHeader()},
+    credentials: credentials(),
     body: JSON.stringify({name, token, chat_id: chatId}),
   });
   await throwIfNotOk(res, "Failed to create source");
@@ -64,6 +71,7 @@ export async function createS3Source(params: CreateS3SourceParams): Promise<Sour
   const res = await fetch(`${API_BASE}/sources/s3`, {
     method: "POST",
     headers: {"Content-Type": "application/json", ...authHeader()},
+    credentials: credentials(),
     body: JSON.stringify(params),
   });
   await throwIfNotOk(res, "Failed to create source");
@@ -73,6 +81,7 @@ export async function createS3Source(params: CreateS3SourceParams): Promise<Sour
 export async function getSourceInfo(id: string): Promise<SourceInfo> {
   const res = await fetch(`${API_BASE}/sources/${id}/info`, {
     headers: authHeader(),
+    credentials: credentials(),
   });
   await throwIfNotOk(res, "Failed to get source info");
   return res.json();
@@ -82,6 +91,7 @@ export async function deleteSource(id: string): Promise<void> {
   const res = await fetch(`${API_BASE}/sources/${id}`, {
     method: "DELETE",
     headers: authHeader(),
+    credentials: credentials(),
   });
   await throwIfNotOk(res, "Failed to delete source");
 }
@@ -89,6 +99,7 @@ export async function deleteSource(id: string): Promise<void> {
 export async function downloadFile(sourceId: string, file: SourceFile): Promise<void> {
   const res = await fetch(`${API_BASE}/sources/${sourceId}/files/${file.id}/download`, {
     headers: authHeader(),
+    credentials: credentials(),
   });
   await throwIfNotOk(res, "Failed to download file");
   const blob = await res.blob();

--- a/webui/src/shared/lib/auth.ts
+++ b/webui/src/shared/lib/auth.ts
@@ -27,6 +27,11 @@ export function getAuthHeader(): Record<string, string> {
   return { Authorization: `Basic ${auth}` };
 }
 
+export function getCredentialsOption(): RequestCredentials | undefined {
+  const type = localStorage.getItem("auth_type");
+  return type === "cookie" ? "include" : undefined;
+}
+
 export function isAuthenticated(): boolean {
   const type = localStorage.getItem("auth_type");
   if (type === "cookie") return true;


### PR DESCRIPTION
## Summary
- **Backend fix:** Auth middleware cookie fallback now only runs when no `Authorization` header is present. Previously, `Authorization: Basic ...` requests with an existing OAuth cookie would silently authenticate via cookie instead of the provided credentials (wrong-user bug).
- **Frontend fix:** All API fetch calls now include `credentials: "include"` when `auth_type=cookie`, ensuring cookies are sent on cross-origin requests for OAuth sessions.

Fixes THE-93. Ref: PR #139 review comments.

## Test plan
- [ ] OAuth login flow works end-to-end (cookie set, subsequent requests authenticated)
- [ ] Basic auth still works when no OAuth cookie exists
- [ ] Basic auth takes precedence over existing OAuth cookie (no wrong-user bug)
- [ ] Cross-origin cookie-based requests include credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)