### PR TITLE
Fix credential encryption: error on decrypt failure, guard double-encrypt

### DIFF
--- a/api-go/cmd/migrate-source-keys/main.go
+++ b/api-go/cmd/migrate-source-keys/main.go
@@ -7,10 +7,15 @@
 // Usage:
 //
 //	ACCESS_SECRET_KEY=<key> go run ./cmd/migrate-source-keys
+//
+// If the key was rotated, pass the old key via OLD_SECRET_KEY to re-encrypt:
+//
+//	ACCESS_SECRET_KEY=<new> OLD_SECRET_KEY=<old> go run ./cmd/migrate-source-keys
 package main
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"log"
 	"os"
@@ -22,6 +27,20 @@ import (
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
+// looksLikeCiphertext checks whether a value looks structurally like
+// AES-GCM ciphertext (valid base64, at least nonce+1 bytes). This is
+// used to avoid encrypting data that might already be encrypted with a
+// different key, which would produce permanently unusable double-encrypted
+// values.
+func looksLikeCiphertext(s string) bool {
+	data, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		return false
+	}
+	// AES-GCM nonce is 12 bytes; ciphertext must be at least nonce + 1 byte.
+	return len(data) > 12
+}
+
 func main() {
 	cfg, err := config.Load()
 	if err != nil {
@@ -32,6 +51,9 @@ func main() {
 		fmt.Fprintln(os.Stderr, "ACCESS_SECRET_KEY is not configured")
 		os.Exit(1)
 	}
+
+	// Optional: old key for key-rotation re-encryption.
+	oldKey := os.Getenv("OLD_SECRET_KEY")
 
 	ctx := context.Background()
 	mongo, err := db.Connect(ctx, cfg.Mongo)
@@ -47,7 +69,7 @@ func main() {
 	}
 	defer func() { _ = cursor.Close(ctx) }()
 
-	var migrated, skipped, total int
+	var migrated, reencrypted, skipped, errored, total int
 	for cursor.Next(ctx) {
 		total++
 		var doc struct {
@@ -57,11 +79,39 @@ func main() {
 		if err := cursor.Decode(&doc); err != nil {
 			log.Fatalf("decode source: %v", err)
 		}
-		// Try decrypting — if it succeeds, the record is already encrypted.
+
+		// Already encrypted with current key — skip.
 		if _, err := cryptoutil.Decrypt(doc.Key, secretKey); err == nil {
 			skipped++
 			continue
 		}
+
+		// Try old key for re-encryption (key rotation).
+		if oldKey != "" {
+			if plain, err := cryptoutil.Decrypt(doc.Key, oldKey); err == nil {
+				enc, err := cryptoutil.Encrypt(plain, secretKey)
+				if err != nil {
+					log.Fatalf("re-encrypt source %s: %v", doc.ID.Hex(), err)
+				}
+				if _, err := coll.UpdateByID(ctx, doc.ID, bson.M{"$set": bson.M{"key": enc}}); err != nil {
+					log.Fatalf("update source %s: %v", doc.ID.Hex(), err)
+				}
+				reencrypted++
+				continue
+			}
+		}
+
+		// Guard against double-encryption: if the value looks like
+		// ciphertext but could not be decrypted with any known key,
+		// refuse to encrypt it — it may be encrypted with a rotated
+		// key that was not provided.
+		if looksLikeCiphertext(doc.Key) {
+			log.Printf("WARNING: source %s has ciphertext-like data that cannot be decrypted; skipping to avoid double-encryption (provide OLD_SECRET_KEY if key was rotated)", doc.ID.Hex())
+			errored++
+			continue
+		}
+
+		// Plaintext — encrypt it.
 		encrypted, err := cryptoutil.Encrypt(doc.Key, secretKey)
 		if err != nil {
 			log.Fatalf("encrypt source %s: %v", doc.ID.Hex(), err)
@@ -75,5 +125,6 @@ func main() {
 	if err := cursor.Err(); err != nil {
 		log.Fatalf("cursor error: %v", err)
 	}
-	fmt.Printf("migration complete: %d total, %d migrated, %d already encrypted\n", total, migrated, skipped)
+	fmt.Printf("migration complete: %d total, %d migrated, %d re-encrypted, %d already encrypted, %d skipped (undecryptable)\n",
+		total, migrated, reencrypted, skipped, errored)
 }

--- a/api-go/internal/repository/source.go
+++ b/api-go/internal/repository/source.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/example/sfree/api-go/internal/cryptoutil"
@@ -54,16 +55,15 @@ func (r *SourceRepository) encryptKey(plain string) (string, error) {
 	return cryptoutil.Encrypt(plain, r.secretKey)
 }
 
-func (r *SourceRepository) decryptKey(cipher string) string {
+func (r *SourceRepository) decryptKey(cipher string) (string, error) {
 	if r.secretKey == "" || cipher == "" {
-		return cipher
+		return cipher, nil
 	}
 	plain, err := cryptoutil.Decrypt(cipher, r.secretKey)
 	if err != nil {
-		// Not encrypted (pre-migration data) — return as-is.
-		return cipher
+		return "", fmt.Errorf("decrypt source key: %w", err)
 	}
-	return plain
+	return plain, nil
 }
 
 func (r *SourceRepository) Create(ctx context.Context, s Source) (*Source, error) {
@@ -91,7 +91,10 @@ func (r *SourceRepository) GetByID(ctx context.Context, id primitive.ObjectID) (
 	if err != nil {
 		return nil, err
 	}
-	s.Key = r.decryptKey(s.Key)
+	s.Key, err = r.decryptKey(s.Key)
+	if err != nil {
+		return nil, err
+	}
 	return &s, nil
 }
 
@@ -110,7 +113,10 @@ func (r *SourceRepository) ListByIDs(ctx context.Context, ids []primitive.Object
 		if err := cursor.Decode(&src); err != nil {
 			return nil, err
 		}
-		src.Key = r.decryptKey(src.Key)
+		src.Key, err = r.decryptKey(src.Key)
+		if err != nil {
+			return nil, err
+		}
 		byID[src.ID] = src
 	}
 	if err := cursor.Err(); err != nil {
@@ -139,7 +145,10 @@ func (r *SourceRepository) ListByUser(ctx context.Context, userID primitive.Obje
 		if err := cursor.Decode(&s); err != nil {
 			return nil, err
 		}
-		s.Key = r.decryptKey(s.Key)
+		s.Key, err = r.decryptKey(s.Key)
+		if err != nil {
+			return nil, err
+		}
 		sources = append(sources, s)
 	}
 	if err := cursor.Err(); err != nil {


### PR DESCRIPTION
## Summary
- **`decryptKey()` now returns an error** instead of silently returning ciphertext as plaintext when decryption fails. Surfaces misconfigured `ACCESS_SECRET_KEY` immediately.
- **Migration guards against double-encryption**: ciphertext-like data that can't be decrypted is skipped with a warning.
- **Key rotation support**: `OLD_SECRET_KEY` env var for safe re-encryption.

Fixes THE-92.

## Test plan
- [ ] Verify source retrieval errors when ACCESS_SECRET_KEY is wrong
- [ ] Verify migration skips already-encrypted and undecryptable records
- [ ] Verify OLD_SECRET_KEY re-encryption works

🤖 Generated with [Claude Code](https://claude.com/claude-code)