### PR TITLE
Add connection timeouts and circuit breakers to source clients

### DIFF
--- a/api-go/cmd/server/main.go
+++ b/api-go/cmd/server/main.go
@@ -11,11 +11,15 @@ import (
 	"log/slog"
 	"os"
 
+	"time"
+
 	"github.com/example/sfree/api-go/internal/app"
 	"github.com/example/sfree/api-go/internal/config"
 	"github.com/example/sfree/api-go/internal/db"
 	_ "github.com/example/sfree/api-go/internal/docs"
+	"github.com/example/sfree/api-go/internal/manager"
 	"github.com/example/sfree/api-go/internal/observability"
+	"github.com/example/sfree/api-go/internal/resilience"
 	"github.com/example/sfree/api-go/internal/telemetry"
 )
 
@@ -39,6 +43,19 @@ func main() {
 			slog.Error("failed to shutdown tracer", slog.String("error", err.Error()))
 		}
 	}()
+
+	// Apply source client resilience settings from config.
+	rcfg := resilience.DefaultWrapperConfig()
+	if cfg.SourceClient.TimeoutSeconds > 0 {
+		rcfg.Timeout = time.Duration(cfg.SourceClient.TimeoutSeconds) * time.Second
+	}
+	if cfg.SourceClient.FailureThreshold > 0 {
+		rcfg.FailureThreshold = cfg.SourceClient.FailureThreshold
+	}
+	if cfg.SourceClient.RecoverySeconds > 0 {
+		rcfg.RecoveryTimeout = time.Duration(cfg.SourceClient.RecoverySeconds) * time.Second
+	}
+	manager.ResilienceConfig = rcfg
 
 	mongoConn, err := db.Connect(ctx, cfg.Mongo)
 	if err != nil {

--- a/api-go/internal/config/config.go
+++ b/api-go/internal/config/config.go
@@ -33,14 +33,21 @@ type RateLimitConfig struct {
 	PerKey int `yaml:"per_key"` // requests per minute for authenticated (default 600)
 }
 
+type SourceClientConfig struct {
+	TimeoutSeconds   int `yaml:"timeout_seconds"`   // per-request timeout (default 30)
+	FailureThreshold int `yaml:"failure_threshold"`  // consecutive failures before circuit opens (default 5)
+	RecoverySeconds  int `yaml:"recovery_seconds"`   // seconds before half-open probe (default 30)
+}
+
 type Config struct {
-	Mongo           MongoConfig       `yaml:"mongo"`
-	Upload          UploadConfig      `yaml:"upload"`
-	RateLimit       RateLimitConfig   `yaml:"rate_limit"`
-	AccessSecretKey string            `yaml:"access_secret_key"`
-	JWTSecret       string            `yaml:"jwt_secret"`
-	GitHubOAuth     GitHubOAuthConfig `yaml:"github_oauth"`
-	FrontendURL     string            `yaml:"frontend_url"`
+	Mongo           MongoConfig        `yaml:"mongo"`
+	Upload          UploadConfig       `yaml:"upload"`
+	RateLimit       RateLimitConfig    `yaml:"rate_limit"`
+	SourceClient    SourceClientConfig `yaml:"source_client"`
+	AccessSecretKey string             `yaml:"access_secret_key"`
+	JWTSecret       string             `yaml:"jwt_secret"`
+	GitHubOAuth     GitHubOAuthConfig  `yaml:"github_oauth"`
+	FrontendURL     string             `yaml:"frontend_url"`
 }
 
 func Load() (*Config, error) {
@@ -112,6 +119,21 @@ func overrideEnv(cfg *Config) {
 	if v := os.Getenv("RATE_LIMIT_PER_KEY"); v != "" {
 		if n, err := strconv.Atoi(v); err == nil {
 			cfg.RateLimit.PerKey = n
+		}
+	}
+	if v := os.Getenv("SOURCE_TIMEOUT_SECONDS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			cfg.SourceClient.TimeoutSeconds = n
+		}
+	}
+	if v := os.Getenv("SOURCE_FAILURE_THRESHOLD"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			cfg.SourceClient.FailureThreshold = n
+		}
+	}
+	if v := os.Getenv("SOURCE_RECOVERY_SECONDS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			cfg.SourceClient.RecoverySeconds = n
 		}
 	}
 }

--- a/api-go/internal/manager/file.go
+++ b/api-go/internal/manager/file.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/example/sfree/api-go/internal/gdrive"
 	"github.com/example/sfree/api-go/internal/repository"
+	"github.com/example/sfree/api-go/internal/resilience"
 	"github.com/example/sfree/api-go/internal/s3compat"
 	"github.com/example/sfree/api-go/internal/telegram"
 	"github.com/example/sfree/api-go/internal/telemetry"
@@ -95,28 +96,43 @@ func SelectorForBucket(bucket *repository.Bucket, sources []repository.Source) S
 	}
 }
 
+// ResilienceConfig holds the timeout and circuit breaker settings applied
+// to every source client. Zero values use sensible defaults (30s timeout,
+// 5-failure threshold, 30s recovery).
+var ResilienceConfig = resilience.DefaultWrapperConfig()
+
 func NewSourceClient(ctx context.Context, src *repository.Source) (sourceClient, error) {
 	if src == nil {
 		return nil, errors.New("nil source")
 	}
+	var (
+		cli sourceClient
+		err error
+	)
 	switch src.Type {
 	case repository.SourceTypeGDrive:
-		return gdrive.NewClient(ctx, []byte(src.Key))
+		cli, err = gdrive.NewClient(ctx, []byte(src.Key))
 	case repository.SourceTypeTelegram:
-		cfg, err := telegram.ParseConfig(src.Key)
+		var tcfg telegram.Config
+		tcfg, err = telegram.ParseConfig(src.Key)
 		if err != nil {
 			return nil, err
 		}
-		return telegram.NewClient(cfg)
+		cli, err = telegram.NewClient(tcfg)
 	case repository.SourceTypeS3:
-		cfg, err := s3compat.ParseConfig(src.Key)
+		var scfg s3compat.Config
+		scfg, err = s3compat.ParseConfig(src.Key)
 		if err != nil {
 			return nil, err
 		}
-		return s3compat.NewClient(ctx, cfg)
+		cli, err = s3compat.NewClient(ctx, scfg)
 	default:
 		return nil, ErrUnsupportedSourceType
 	}
+	if err != nil {
+		return nil, err
+	}
+	return resilience.Wrap(cli, ResilienceConfig), nil
 }
 
 func StreamFile(ctx context.Context, srcRepo *repository.SourceRepository, f *repository.File, w io.Writer) error {

--- a/api-go/internal/resilience/circuitbreaker.go
+++ b/api-go/internal/resilience/circuitbreaker.go
@@ -1,0 +1,91 @@
+package resilience
+
+import (
+	"errors"
+	"sync"
+	"time"
+)
+
+// ErrCircuitOpen is returned when the circuit breaker is open.
+var ErrCircuitOpen = errors.New("circuit breaker is open")
+
+type state int
+
+const (
+	stateClosed state = iota
+	stateOpen
+	stateHalfOpen
+)
+
+// CircuitBreaker implements a simple circuit breaker pattern.
+// After FailureThreshold consecutive failures, the circuit opens and
+// rejects requests for RecoveryTimeout. After that period, one probe
+// request is allowed (half-open). If it succeeds, the circuit closes;
+// if it fails, the circuit re-opens.
+type CircuitBreaker struct {
+	mu               sync.Mutex
+	state            state
+	failures         int
+	failureThreshold int
+	recoveryTimeout  time.Duration
+	openedAt         time.Time
+}
+
+// NewCircuitBreaker creates a circuit breaker with the given parameters.
+// failureThreshold is the number of consecutive failures before opening.
+// recoveryTimeout is how long the circuit stays open before allowing a probe.
+func NewCircuitBreaker(failureThreshold int, recoveryTimeout time.Duration) *CircuitBreaker {
+	if failureThreshold <= 0 {
+		failureThreshold = 5
+	}
+	if recoveryTimeout <= 0 {
+		recoveryTimeout = 30 * time.Second
+	}
+	return &CircuitBreaker{
+		state:            stateClosed,
+		failureThreshold: failureThreshold,
+		recoveryTimeout:  recoveryTimeout,
+	}
+}
+
+// Allow checks whether a request is allowed. Returns an error if the
+// circuit is open.
+func (cb *CircuitBreaker) Allow() error {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+
+	switch cb.state {
+	case stateClosed:
+		return nil
+	case stateOpen:
+		if time.Since(cb.openedAt) >= cb.recoveryTimeout {
+			cb.state = stateHalfOpen
+			return nil
+		}
+		return ErrCircuitOpen
+	case stateHalfOpen:
+		// Only one probe at a time in half-open; reject additional requests.
+		return ErrCircuitOpen
+	}
+	return nil
+}
+
+// RecordSuccess records a successful request. Resets the circuit to closed.
+func (cb *CircuitBreaker) RecordSuccess() {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+	cb.failures = 0
+	cb.state = stateClosed
+}
+
+// RecordFailure records a failed request. If the failure threshold is
+// reached, the circuit opens.
+func (cb *CircuitBreaker) RecordFailure() {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+	cb.failures++
+	if cb.failures >= cb.failureThreshold {
+		cb.state = stateOpen
+		cb.openedAt = time.Now()
+	}
+}

--- a/api-go/internal/resilience/circuitbreaker_test.go
+++ b/api-go/internal/resilience/circuitbreaker_test.go
@@ -1,0 +1,112 @@
+package resilience
+
+import (
+	"testing"
+	"time"
+)
+
+func TestCircuitBreakerStartsClosed(t *testing.T) {
+	cb := NewCircuitBreaker(3, 100*time.Millisecond)
+	if err := cb.Allow(); err != nil {
+		t.Fatalf("expected closed circuit to allow, got %v", err)
+	}
+}
+
+func TestCircuitBreakerOpensAfterThreshold(t *testing.T) {
+	cb := NewCircuitBreaker(3, 100*time.Millisecond)
+
+	for i := 0; i < 3; i++ {
+		cb.RecordFailure()
+	}
+
+	if err := cb.Allow(); err != ErrCircuitOpen {
+		t.Fatalf("expected ErrCircuitOpen, got %v", err)
+	}
+}
+
+func TestCircuitBreakerDoesNotOpenBelowThreshold(t *testing.T) {
+	cb := NewCircuitBreaker(3, 100*time.Millisecond)
+
+	cb.RecordFailure()
+	cb.RecordFailure()
+
+	if err := cb.Allow(); err != nil {
+		t.Fatalf("expected circuit to still be closed, got %v", err)
+	}
+}
+
+func TestCircuitBreakerResetOnSuccess(t *testing.T) {
+	cb := NewCircuitBreaker(3, 100*time.Millisecond)
+
+	cb.RecordFailure()
+	cb.RecordFailure()
+	cb.RecordSuccess()
+	cb.RecordFailure()
+	cb.RecordFailure()
+
+	// Only 2 consecutive failures since last success, should be open=false.
+	if err := cb.Allow(); err != nil {
+		t.Fatalf("expected circuit to be closed after reset, got %v", err)
+	}
+}
+
+func TestCircuitBreakerHalfOpen(t *testing.T) {
+	cb := NewCircuitBreaker(2, 50*time.Millisecond)
+
+	cb.RecordFailure()
+	cb.RecordFailure()
+
+	// Circuit is open.
+	if err := cb.Allow(); err != ErrCircuitOpen {
+		t.Fatalf("expected ErrCircuitOpen, got %v", err)
+	}
+
+	// Wait for recovery timeout.
+	time.Sleep(60 * time.Millisecond)
+
+	// First call should be allowed (half-open probe).
+	if err := cb.Allow(); err != nil {
+		t.Fatalf("expected half-open to allow probe, got %v", err)
+	}
+
+	// Second call during half-open should be rejected.
+	if err := cb.Allow(); err != ErrCircuitOpen {
+		t.Fatalf("expected half-open to reject additional requests, got %v", err)
+	}
+}
+
+func TestCircuitBreakerClosesAfterHalfOpenSuccess(t *testing.T) {
+	cb := NewCircuitBreaker(2, 50*time.Millisecond)
+
+	cb.RecordFailure()
+	cb.RecordFailure()
+
+	time.Sleep(60 * time.Millisecond)
+
+	// Half-open probe.
+	_ = cb.Allow()
+	cb.RecordSuccess()
+
+	// Circuit should be closed again.
+	if err := cb.Allow(); err != nil {
+		t.Fatalf("expected circuit to be closed after successful probe, got %v", err)
+	}
+}
+
+func TestCircuitBreakerReopensAfterHalfOpenFailure(t *testing.T) {
+	cb := NewCircuitBreaker(2, 50*time.Millisecond)
+
+	cb.RecordFailure()
+	cb.RecordFailure()
+
+	time.Sleep(60 * time.Millisecond)
+
+	// Half-open probe.
+	_ = cb.Allow()
+	cb.RecordFailure()
+
+	// Circuit should be open again.
+	if err := cb.Allow(); err != ErrCircuitOpen {
+		t.Fatalf("expected circuit to reopen after failed probe, got %v", err)
+	}
+}

--- a/api-go/internal/resilience/wrapper.go
+++ b/api-go/internal/resilience/wrapper.go
@@ -1,0 +1,92 @@
+package resilience
+
+import (
+	"context"
+	"io"
+	"time"
+)
+
+// Client mirrors the source client interface (Upload, Download, Delete).
+type Client interface {
+	Upload(ctx context.Context, name string, r io.Reader) (string, error)
+	Download(ctx context.Context, name string) (io.ReadCloser, error)
+	Delete(ctx context.Context, name string) error
+}
+
+// WrapperConfig holds timeout and circuit breaker settings.
+type WrapperConfig struct {
+	Timeout          time.Duration // per-request timeout (default 30s)
+	FailureThreshold int           // consecutive failures before circuit opens (default 5)
+	RecoveryTimeout  time.Duration // time before half-open probe (default 30s)
+}
+
+// DefaultWrapperConfig returns sensible defaults.
+func DefaultWrapperConfig() WrapperConfig {
+	return WrapperConfig{
+		Timeout:          30 * time.Second,
+		FailureThreshold: 5,
+		RecoveryTimeout:  30 * time.Second,
+	}
+}
+
+// Wrap wraps a source client with timeout and circuit breaker behavior.
+func Wrap(c Client, cfg WrapperConfig) Client {
+	if cfg.Timeout <= 0 {
+		cfg.Timeout = 30 * time.Second
+	}
+	return &wrapper{
+		inner: c,
+		cb:    NewCircuitBreaker(cfg.FailureThreshold, cfg.RecoveryTimeout),
+		cfg:   cfg,
+	}
+}
+
+type wrapper struct {
+	inner Client
+	cb    *CircuitBreaker
+	cfg   WrapperConfig
+}
+
+func (w *wrapper) Upload(ctx context.Context, name string, r io.Reader) (string, error) {
+	if err := w.cb.Allow(); err != nil {
+		return "", err
+	}
+	ctx, cancel := context.WithTimeout(ctx, w.cfg.Timeout)
+	defer cancel()
+	result, err := w.inner.Upload(ctx, name, r)
+	if err != nil {
+		w.cb.RecordFailure()
+		return "", err
+	}
+	w.cb.RecordSuccess()
+	return result, nil
+}
+
+func (w *wrapper) Download(ctx context.Context, name string) (io.ReadCloser, error) {
+	if err := w.cb.Allow(); err != nil {
+		return nil, err
+	}
+	ctx, cancel := context.WithTimeout(ctx, w.cfg.Timeout)
+	defer cancel()
+	rc, err := w.inner.Download(ctx, name)
+	if err != nil {
+		w.cb.RecordFailure()
+		return nil, err
+	}
+	w.cb.RecordSuccess()
+	return rc, nil
+}
+
+func (w *wrapper) Delete(ctx context.Context, name string) error {
+	if err := w.cb.Allow(); err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(ctx, w.cfg.Timeout)
+	defer cancel()
+	if err := w.inner.Delete(ctx, name); err != nil {
+		w.cb.RecordFailure()
+		return err
+	}
+	w.cb.RecordSuccess()
+	return nil
+}

--- a/api-go/internal/resilience/wrapper_test.go
+++ b/api-go/internal/resilience/wrapper_test.go
@@ -1,0 +1,142 @@
+package resilience
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+	"time"
+)
+
+// mockClient is a test double for the source client interface.
+type mockClient struct {
+	uploadErr   error
+	downloadErr error
+	deleteErr   error
+	delay       time.Duration
+}
+
+func (m *mockClient) Upload(ctx context.Context, name string, r io.Reader) (string, error) {
+	if m.delay > 0 {
+		select {
+		case <-time.After(m.delay):
+		case <-ctx.Done():
+			return "", ctx.Err()
+		}
+	}
+	return "uploaded-" + name, m.uploadErr
+}
+
+func (m *mockClient) Download(ctx context.Context, name string) (io.ReadCloser, error) {
+	if m.delay > 0 {
+		select {
+		case <-time.After(m.delay):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	if m.downloadErr != nil {
+		return nil, m.downloadErr
+	}
+	return io.NopCloser(strings.NewReader("data")), nil
+}
+
+func (m *mockClient) Delete(ctx context.Context, name string) error {
+	if m.delay > 0 {
+		select {
+		case <-time.After(m.delay):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return m.deleteErr
+}
+
+func TestWrapperPassesThrough(t *testing.T) {
+	inner := &mockClient{}
+	w := Wrap(inner, DefaultWrapperConfig())
+
+	ctx := context.Background()
+	name, err := w.Upload(ctx, "file.txt", strings.NewReader("hello"))
+	if err != nil {
+		t.Fatalf("upload: %v", err)
+	}
+	if name != "uploaded-file.txt" {
+		t.Fatalf("expected uploaded-file.txt, got %s", name)
+	}
+
+	rc, err := w.Download(ctx, "file.txt")
+	if err != nil {
+		t.Fatalf("download: %v", err)
+	}
+	_ = rc.Close()
+
+	if err := w.Delete(ctx, "file.txt"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+}
+
+func TestWrapperTimeout(t *testing.T) {
+	inner := &mockClient{delay: 200 * time.Millisecond}
+	cfg := WrapperConfig{Timeout: 50 * time.Millisecond, FailureThreshold: 100, RecoveryTimeout: time.Second}
+	w := Wrap(inner, cfg)
+
+	_, err := w.Upload(context.Background(), "slow.txt", strings.NewReader("data"))
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected DeadlineExceeded, got %v", err)
+	}
+}
+
+func TestWrapperCircuitBreakerTrips(t *testing.T) {
+	inner := &mockClient{uploadErr: errors.New("backend down")}
+	cfg := WrapperConfig{Timeout: time.Second, FailureThreshold: 3, RecoveryTimeout: time.Second}
+	w := Wrap(inner, cfg)
+
+	ctx := context.Background()
+	for i := 0; i < 3; i++ {
+		_, err := w.Upload(ctx, "fail.txt", strings.NewReader("data"))
+		if err == nil {
+			t.Fatalf("request %d: expected error", i+1)
+		}
+	}
+
+	// 4th request should get circuit breaker error, not backend error.
+	_, err := w.Upload(ctx, "fail.txt", strings.NewReader("data"))
+	if !errors.Is(err, ErrCircuitOpen) {
+		t.Fatalf("expected ErrCircuitOpen, got %v", err)
+	}
+}
+
+func TestWrapperCircuitBreakerRecovers(t *testing.T) {
+	inner := &mockClient{uploadErr: errors.New("backend down")}
+	cfg := WrapperConfig{Timeout: time.Second, FailureThreshold: 2, RecoveryTimeout: 50 * time.Millisecond}
+	w := Wrap(inner, cfg)
+
+	ctx := context.Background()
+	for i := 0; i < 2; i++ {
+		w.Upload(ctx, "fail.txt", strings.NewReader("data"))
+	}
+
+	// Circuit is open.
+	_, err := w.Upload(ctx, "fail.txt", strings.NewReader("data"))
+	if !errors.Is(err, ErrCircuitOpen) {
+		t.Fatalf("expected ErrCircuitOpen, got %v", err)
+	}
+
+	// Fix the backend.
+	inner.uploadErr = nil
+	time.Sleep(60 * time.Millisecond)
+
+	// Should succeed (half-open probe).
+	name, err := w.Upload(ctx, "ok.txt", strings.NewReader("data"))
+	if err != nil {
+		t.Fatalf("expected recovery, got %v", err)
+	}
+	if name != "uploaded-ok.txt" {
+		t.Fatalf("expected uploaded-ok.txt, got %s", name)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `internal/resilience` package with circuit breaker and timeout wrapper
- All source clients (GDrive, Telegram, S3) are automatically wrapped with configurable timeout (30s default) and circuit breaker (5-failure threshold, 30s recovery)
- When a circuit is open, requests fail fast with `ErrCircuitOpen` instead of hanging
- Configurable via `SOURCE_TIMEOUT_SECONDS`, `SOURCE_FAILURE_THRESHOLD`, `SOURCE_RECOVERY_SECONDS` env vars
- Does not change the source client interface — wraps at the `NewSourceClient` layer

Fixes THE-87. GitHub issue: #135.

## Test plan
- [ ] Circuit breaker unit tests pass
- [ ] Wrapper timeout and circuit breaker integration tests pass
- [ ] Existing E2E tests still pass
- [ ] Verify timeout triggers on slow backends
- [ ] Verify circuit opens after consecutive failures and recovers

🤖 Generated with [Claude Code](https://claude.com/claude-code)