### PR TITLE
Add source failover and retry logic for file operations

### DIFF
--- a/api-go/cmd/server/main.go
+++ b/api-go/cmd/server/main.go
@@ -55,6 +55,15 @@ func main() {
 	if cfg.SourceClient.RecoverySeconds > 0 {
 		rcfg.RecoveryTimeout = time.Duration(cfg.SourceClient.RecoverySeconds) * time.Second
 	}
+	if cfg.SourceClient.MaxRetries > 0 {
+		rcfg.MaxRetries = cfg.SourceClient.MaxRetries
+	}
+	if cfg.SourceClient.RetryBaseDelayMs > 0 {
+		rcfg.RetryBaseDelay = time.Duration(cfg.SourceClient.RetryBaseDelayMs) * time.Millisecond
+	}
+	if cfg.SourceClient.RetryMaxDelayMs > 0 {
+		rcfg.RetryMaxDelay = time.Duration(cfg.SourceClient.RetryMaxDelayMs) * time.Millisecond
+	}
 	manager.ResilienceConfig = rcfg
 
 	mongoConn, err := db.Connect(ctx, cfg.Mongo)

--- a/api-go/internal/config/config.go
+++ b/api-go/internal/config/config.go
@@ -34,9 +34,12 @@ type RateLimitConfig struct {
 }
 
 type SourceClientConfig struct {
-	TimeoutSeconds   int `yaml:"timeout_seconds"`   // per-request timeout (default 30)
-	FailureThreshold int `yaml:"failure_threshold"`  // consecutive failures before circuit opens (default 5)
-	RecoverySeconds  int `yaml:"recovery_seconds"`   // seconds before half-open probe (default 30)
+	TimeoutSeconds   int `yaml:"timeout_seconds"`    // per-request timeout (default 30)
+	FailureThreshold int `yaml:"failure_threshold"`   // consecutive failures before circuit opens (default 5)
+	RecoverySeconds  int `yaml:"recovery_seconds"`    // seconds before half-open probe (default 30)
+	MaxRetries       int `yaml:"max_retries"`          // retry attempts after first call (default 3)
+	RetryBaseDelayMs int `yaml:"retry_base_delay_ms"`  // initial backoff in ms (default 100)
+	RetryMaxDelayMs  int `yaml:"retry_max_delay_ms"`   // max backoff cap in ms (default 5000)
 }
 
 type Config struct {
@@ -134,6 +137,21 @@ func overrideEnv(cfg *Config) {
 	if v := os.Getenv("SOURCE_RECOVERY_SECONDS"); v != "" {
 		if n, err := strconv.Atoi(v); err == nil {
 			cfg.SourceClient.RecoverySeconds = n
+		}
+	}
+	if v := os.Getenv("SOURCE_MAX_RETRIES"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			cfg.SourceClient.MaxRetries = n
+		}
+	}
+	if v := os.Getenv("SOURCE_RETRY_BASE_DELAY_MS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			cfg.SourceClient.RetryBaseDelayMs = n
+		}
+	}
+	if v := os.Getenv("SOURCE_RETRY_MAX_DELAY_MS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			cfg.SourceClient.RetryMaxDelayMs = n
 		}
 	}
 }

--- a/api-go/internal/manager/file.go
+++ b/api-go/internal/manager/file.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 
 	"github.com/example/sfree/api-go/internal/gdrive"
 	"github.com/example/sfree/api-go/internal/repository"
@@ -257,31 +258,26 @@ func UploadFileChunksWithStrategy(ctx context.Context, r io.Reader, sources []re
 	chunks := make([]repository.FileChunk, 0)
 	buf := make([]byte, chunkSize)
 	idx := 0
+	failoverCount := 0
 	for {
-		n, err := r.Read(buf)
-		if err != nil && err != io.EOF {
-			span.RecordError(err)
+		n, readErr := r.Read(buf)
+		if readErr != nil && readErr != io.EOF {
+			span.RecordError(readErr)
 			span.SetStatus(codes.Error, "read failed")
-			return nil, err
+			return nil, readErr
 		}
 		if n == 0 {
 			break
 		}
-		_, src, err := selector.NextSource(sources)
+
+		chunkData := make([]byte, n)
+		copy(chunkData, buf[:n])
+
+		src, cli, err := pickSourceClient(ctx, sources, selector, clients, factory)
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, "source selection failed")
 			return nil, err
-		}
-		cli, ok := clients[src.ID]
-		if !ok {
-			cli, err = factory(ctx, &src)
-			if err != nil {
-				span.RecordError(err)
-				span.SetStatus(codes.Error, "client creation failed")
-				return nil, err
-			}
-			clients[src.ID] = cli
 		}
 
 		_, chunkSpan := tracer.Start(ctx, "UploadChunk",
@@ -292,23 +288,83 @@ func UploadFileChunksWithStrategy(ctx context.Context, r io.Reader, sources []re
 			),
 		)
 		driveName := primitive.NewObjectID().Hex()
-		chunkName, err := cli.Upload(ctx, driveName, bytes.NewReader(buf[:n]))
-		if err != nil {
-			chunkSpan.RecordError(err)
+		chunkName, uploadErr := cli.Upload(ctx, driveName, bytes.NewReader(chunkData))
+
+		// Failover: on upload failure, try other sources.
+		if uploadErr != nil && len(sources) > 1 {
+			chunkSpan.RecordError(uploadErr)
+			tried := map[primitive.ObjectID]bool{src.ID: true}
+			for attempt := 0; attempt < len(sources)-1; attempt++ {
+				altSrc, altCli, altErr := pickSourceClient(ctx, sources, selector, clients, factory)
+				if altErr != nil {
+					continue
+				}
+				if tried[altSrc.ID] {
+					continue
+				}
+				tried[altSrc.ID] = true
+				failoverCount++
+				slog.WarnContext(ctx, "upload failover",
+					slog.Int("chunk.order", idx),
+					slog.String("failed_source", src.ID.Hex()),
+					slog.String("failover_source", altSrc.ID.Hex()),
+					slog.String("last_error", uploadErr.Error()),
+				)
+				chunkSpan.AddEvent("failover",
+					trace.WithAttributes(
+						attribute.String("failover.from", src.ID.Hex()),
+						attribute.String("failover.to", altSrc.ID.Hex()),
+					),
+				)
+				altDriveName := primitive.NewObjectID().Hex()
+				altName, altUpErr := altCli.Upload(ctx, altDriveName, bytes.NewReader(chunkData))
+				if altUpErr == nil {
+					src = altSrc
+					chunkName = altName
+					uploadErr = nil
+					break
+				}
+				uploadErr = altUpErr
+			}
+		}
+
+		if uploadErr != nil {
+			chunkSpan.RecordError(uploadErr)
 			chunkSpan.SetStatus(codes.Error, "upload failed")
 			chunkSpan.End()
-			span.RecordError(err)
-			span.SetStatus(codes.Error, fmt.Sprintf("chunk %d upload failed", idx))
-			return nil, err
+			span.RecordError(uploadErr)
+			span.SetStatus(codes.Error, fmt.Sprintf("chunk %d upload failed on all sources", idx))
+			return nil, uploadErr
 		}
 		chunkSpan.End()
 
 		chunks = append(chunks, repository.FileChunk{SourceID: src.ID, Name: chunkName, Order: idx, Size: int64(n)})
 		idx++
-		if err == io.EOF {
+		if readErr == io.EOF {
 			break
 		}
 	}
-	span.SetAttributes(attribute.Int("chunks.uploaded", len(chunks)))
+	span.SetAttributes(
+		attribute.Int("chunks.uploaded", len(chunks)),
+		attribute.Int("chunks.failovers", failoverCount),
+	)
 	return chunks, nil
+}
+
+// pickSourceClient selects the next source and returns its client, creating
+// the client if needed. It uses the provided selector, client cache, and factory.
+func pickSourceClient(ctx context.Context, sources []repository.Source, selector SourceSelector, clients map[primitive.ObjectID]sourceClient, factory SourceClientFactory) (repository.Source, sourceClient, error) {
+	_, src, err := selector.NextSource(sources)
+	if err != nil {
+		return repository.Source{}, nil, err
+	}
+	cli, ok := clients[src.ID]
+	if !ok {
+		cli, err = factory(ctx, &src)
+		if err != nil {
+			return repository.Source{}, nil, err
+		}
+		clients[src.ID] = cli
+	}
+	return src, cli, nil
 }

--- a/api-go/internal/manager/file_test.go
+++ b/api-go/internal/manager/file_test.go
@@ -268,6 +268,68 @@ func TestSelectorForBucketDefault(t *testing.T) {
 	}
 }
 
+func TestUploadFileChunksFailoverToAlternateSource(t *testing.T) {
+	t.Parallel()
+	s1 := repository.Source{ID: primitive.NewObjectID(), Type: repository.SourceTypeTelegram}
+	s2 := repository.Source{ID: primitive.NewObjectID(), Type: repository.SourceTypeTelegram}
+	sources := []repository.Source{s1, s2}
+
+	failingStub := &stubSourceClient{uploadErr: errors.New("source down")}
+	workingStub := &stubSourceClient{}
+	factory := func(_ context.Context, src *repository.Source) (sourceClient, error) {
+		if src.ID == s1.ID {
+			return failingStub, nil
+		}
+		return workingStub, nil
+	}
+
+	payload := []byte("abcdef")
+	chunks, err := UploadFileChunksWithStrategy(context.Background(), bytes.NewReader(payload), sources, 6, factory, &RoundRobinSelector{})
+	if err != nil {
+		t.Fatalf("expected failover to succeed, got %v", err)
+	}
+	if len(chunks) != 1 {
+		t.Fatalf("expected 1 chunk, got %d", len(chunks))
+	}
+	// Chunk should have been placed on s2 after s1 failed.
+	if chunks[0].SourceID != s2.ID {
+		t.Fatalf("expected chunk on s2 after failover, got source %s", chunks[0].SourceID.Hex())
+	}
+}
+
+func TestUploadFileChunksAllSourcesFail(t *testing.T) {
+	t.Parallel()
+	s1 := repository.Source{ID: primitive.NewObjectID(), Type: repository.SourceTypeTelegram}
+	s2 := repository.Source{ID: primitive.NewObjectID(), Type: repository.SourceTypeTelegram}
+	sources := []repository.Source{s1, s2}
+
+	factory := func(_ context.Context, src *repository.Source) (sourceClient, error) {
+		return &stubSourceClient{uploadErr: errors.New("source down")}, nil
+	}
+
+	payload := []byte("abcdef")
+	_, err := UploadFileChunksWithStrategy(context.Background(), bytes.NewReader(payload), sources, 6, factory, &RoundRobinSelector{})
+	if err == nil {
+		t.Fatal("expected error when all sources fail")
+	}
+}
+
+func TestUploadFileChunksSingleSourceNoFailover(t *testing.T) {
+	t.Parallel()
+	s1 := repository.Source{ID: primitive.NewObjectID(), Type: repository.SourceTypeTelegram}
+	sources := []repository.Source{s1}
+
+	factory := func(_ context.Context, src *repository.Source) (sourceClient, error) {
+		return &stubSourceClient{uploadErr: errors.New("source down")}, nil
+	}
+
+	payload := []byte("abc")
+	_, err := UploadFileChunksWithStrategy(context.Background(), bytes.NewReader(payload), sources, 3, factory, &RoundRobinSelector{})
+	if err == nil {
+		t.Fatal("expected error with single source and no failover possible")
+	}
+}
+
 func TestNewSourceClientNilSource(t *testing.T) {
 	t.Parallel()
 	_, err := NewSourceClient(context.Background(), nil)

--- a/api-go/internal/resilience/retry.go
+++ b/api-go/internal/resilience/retry.go
@@ -1,0 +1,55 @@
+package resilience
+
+import (
+	"errors"
+	"math"
+	"time"
+)
+
+// RetryConfig holds settings for retry with exponential backoff.
+type RetryConfig struct {
+	MaxRetries int           // max retry attempts after the first call (default 3)
+	BaseDelay  time.Duration // initial backoff delay (default 100ms)
+	MaxDelay   time.Duration // maximum backoff delay cap (default 5s)
+}
+
+// DefaultRetryConfig returns sensible retry defaults.
+func DefaultRetryConfig() RetryConfig {
+	return RetryConfig{
+		MaxRetries: 3,
+		BaseDelay:  100 * time.Millisecond,
+		MaxDelay:   5 * time.Second,
+	}
+}
+
+// Backoff calculates the exponential backoff duration for the given attempt
+// (0-indexed). The delay is BaseDelay * 2^attempt, capped at MaxDelay.
+func Backoff(attempt int, cfg RetryConfig) time.Duration {
+	if cfg.BaseDelay <= 0 {
+		cfg.BaseDelay = 100 * time.Millisecond
+	}
+	if cfg.MaxDelay <= 0 {
+		cfg.MaxDelay = 5 * time.Second
+	}
+	delay := time.Duration(float64(cfg.BaseDelay) * math.Pow(2, float64(attempt)))
+	if delay > cfg.MaxDelay {
+		delay = cfg.MaxDelay
+	}
+	return delay
+}
+
+// IsCircuitOpen returns true if the error is ErrCircuitOpen.
+// Useful for callers deciding whether to failover to another source.
+func IsCircuitOpen(err error) bool {
+	return errors.Is(err, ErrCircuitOpen)
+}
+
+// isRetryable returns true for errors that should trigger a retry.
+// Circuit-open errors are not retryable (they indicate the source is
+// degraded and should be skipped for failover instead).
+func isRetryable(err error) bool {
+	if err == nil {
+		return false
+	}
+	return !errors.Is(err, ErrCircuitOpen)
+}

--- a/api-go/internal/resilience/retry_test.go
+++ b/api-go/internal/resilience/retry_test.go
@@ -1,0 +1,81 @@
+package resilience
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestBackoffExponential(t *testing.T) {
+	t.Parallel()
+	cfg := RetryConfig{BaseDelay: 100 * time.Millisecond, MaxDelay: 5 * time.Second}
+
+	cases := []struct {
+		attempt  int
+		expected time.Duration
+	}{
+		{0, 100 * time.Millisecond},
+		{1, 200 * time.Millisecond},
+		{2, 400 * time.Millisecond},
+		{3, 800 * time.Millisecond},
+		{4, 1600 * time.Millisecond},
+		{5, 3200 * time.Millisecond},
+		{6, 5 * time.Second}, // capped
+		{10, 5 * time.Second},
+	}
+	for _, tc := range cases {
+		got := Backoff(tc.attempt, cfg)
+		if got != tc.expected {
+			t.Errorf("Backoff(%d): got %v, want %v", tc.attempt, got, tc.expected)
+		}
+	}
+}
+
+func TestBackoffDefaultValues(t *testing.T) {
+	t.Parallel()
+	cfg := RetryConfig{} // zero values
+	d := Backoff(0, cfg)
+	if d != 100*time.Millisecond {
+		t.Errorf("expected default base delay 100ms, got %v", d)
+	}
+}
+
+func TestIsCircuitOpen(t *testing.T) {
+	t.Parallel()
+	if !IsCircuitOpen(ErrCircuitOpen) {
+		t.Fatal("expected true for ErrCircuitOpen")
+	}
+	if IsCircuitOpen(errors.New("other error")) {
+		t.Fatal("expected false for other error")
+	}
+	if IsCircuitOpen(nil) {
+		t.Fatal("expected false for nil")
+	}
+}
+
+func TestIsRetryable(t *testing.T) {
+	t.Parallel()
+	if isRetryable(nil) {
+		t.Fatal("nil should not be retryable")
+	}
+	if isRetryable(ErrCircuitOpen) {
+		t.Fatal("ErrCircuitOpen should not be retryable")
+	}
+	if !isRetryable(errors.New("timeout")) {
+		t.Fatal("transient error should be retryable")
+	}
+}
+
+func TestDefaultRetryConfig(t *testing.T) {
+	t.Parallel()
+	cfg := DefaultRetryConfig()
+	if cfg.MaxRetries != 3 {
+		t.Errorf("expected MaxRetries 3, got %d", cfg.MaxRetries)
+	}
+	if cfg.BaseDelay != 100*time.Millisecond {
+		t.Errorf("expected BaseDelay 100ms, got %v", cfg.BaseDelay)
+	}
+	if cfg.MaxDelay != 5*time.Second {
+		t.Errorf("expected MaxDelay 5s, got %v", cfg.MaxDelay)
+	}
+}

--- a/api-go/internal/resilience/wrapper.go
+++ b/api-go/internal/resilience/wrapper.go
@@ -3,6 +3,7 @@ package resilience
 import (
 	"context"
 	"io"
+	"log/slog"
 	"time"
 )
 
@@ -13,80 +14,186 @@ type Client interface {
 	Delete(ctx context.Context, name string) error
 }
 
-// WrapperConfig holds timeout and circuit breaker settings.
+// WrapperConfig holds timeout, circuit breaker, and retry settings.
 type WrapperConfig struct {
 	Timeout          time.Duration // per-request timeout (default 30s)
 	FailureThreshold int           // consecutive failures before circuit opens (default 5)
 	RecoveryTimeout  time.Duration // time before half-open probe (default 30s)
+	MaxRetries       int           // retry attempts after first call (default 3)
+	RetryBaseDelay   time.Duration // initial backoff delay (default 100ms)
+	RetryMaxDelay    time.Duration // max backoff delay cap (default 5s)
 }
 
 // DefaultWrapperConfig returns sensible defaults.
 func DefaultWrapperConfig() WrapperConfig {
+	rc := DefaultRetryConfig()
 	return WrapperConfig{
 		Timeout:          30 * time.Second,
 		FailureThreshold: 5,
 		RecoveryTimeout:  30 * time.Second,
+		MaxRetries:       rc.MaxRetries,
+		RetryBaseDelay:   rc.BaseDelay,
+		RetryMaxDelay:    rc.MaxDelay,
 	}
 }
 
-// Wrap wraps a source client with timeout and circuit breaker behavior.
+// Wrap wraps a source client with timeout, circuit breaker, and retry behavior.
 func Wrap(c Client, cfg WrapperConfig) Client {
 	if cfg.Timeout <= 0 {
 		cfg.Timeout = 30 * time.Second
 	}
+	rc := RetryConfig{
+		MaxRetries: cfg.MaxRetries,
+		BaseDelay:  cfg.RetryBaseDelay,
+		MaxDelay:   cfg.RetryMaxDelay,
+	}
+	if rc.MaxRetries < 0 {
+		rc.MaxRetries = 0
+	}
 	return &wrapper{
-		inner: c,
-		cb:    NewCircuitBreaker(cfg.FailureThreshold, cfg.RecoveryTimeout),
-		cfg:   cfg,
+		inner:    c,
+		cb:       NewCircuitBreaker(cfg.FailureThreshold, cfg.RecoveryTimeout),
+		cfg:      cfg,
+		retryCfg: rc,
 	}
 }
 
 type wrapper struct {
-	inner Client
-	cb    *CircuitBreaker
-	cfg   WrapperConfig
+	inner    Client
+	cb       *CircuitBreaker
+	cfg      WrapperConfig
+	retryCfg RetryConfig
 }
 
 func (w *wrapper) Upload(ctx context.Context, name string, r io.Reader) (string, error) {
 	if err := w.cb.Allow(); err != nil {
 		return "", err
 	}
-	ctx, cancel := context.WithTimeout(ctx, w.cfg.Timeout)
-	defer cancel()
-	result, err := w.inner.Upload(ctx, name, r)
-	if err != nil {
-		w.cb.RecordFailure()
-		return "", err
+
+	var lastErr error
+	for attempt := 0; attempt <= w.retryCfg.MaxRetries; attempt++ {
+		if attempt > 0 {
+			delay := Backoff(attempt-1, w.retryCfg)
+			slog.WarnContext(ctx, "retrying upload",
+				slog.String("name", name),
+				slog.Int("attempt", attempt),
+				slog.Duration("backoff", delay),
+				slog.String("last_error", lastErr.Error()),
+			)
+			select {
+			case <-time.After(delay):
+			case <-ctx.Done():
+				w.cb.RecordFailure()
+				return "", ctx.Err()
+			}
+			// Re-check circuit before retry.
+			if err := w.cb.Allow(); err != nil {
+				return "", err
+			}
+		}
+
+		reqCtx, cancel := context.WithTimeout(ctx, w.cfg.Timeout)
+		result, err := w.inner.Upload(reqCtx, name, r)
+		cancel()
+
+		if err == nil {
+			w.cb.RecordSuccess()
+			return result, nil
+		}
+		lastErr = err
+		if !isRetryable(err) {
+			break
+		}
 	}
-	w.cb.RecordSuccess()
-	return result, nil
+
+	w.cb.RecordFailure()
+	return "", lastErr
 }
 
 func (w *wrapper) Download(ctx context.Context, name string) (io.ReadCloser, error) {
 	if err := w.cb.Allow(); err != nil {
 		return nil, err
 	}
-	ctx, cancel := context.WithTimeout(ctx, w.cfg.Timeout)
-	defer cancel()
-	rc, err := w.inner.Download(ctx, name)
-	if err != nil {
-		w.cb.RecordFailure()
-		return nil, err
+
+	var lastErr error
+	for attempt := 0; attempt <= w.retryCfg.MaxRetries; attempt++ {
+		if attempt > 0 {
+			delay := Backoff(attempt-1, w.retryCfg)
+			slog.WarnContext(ctx, "retrying download",
+				slog.String("name", name),
+				slog.Int("attempt", attempt),
+				slog.Duration("backoff", delay),
+				slog.String("last_error", lastErr.Error()),
+			)
+			select {
+			case <-time.After(delay):
+			case <-ctx.Done():
+				w.cb.RecordFailure()
+				return nil, ctx.Err()
+			}
+			if err := w.cb.Allow(); err != nil {
+				return nil, err
+			}
+		}
+
+		reqCtx, cancel := context.WithTimeout(ctx, w.cfg.Timeout)
+		rc, err := w.inner.Download(reqCtx, name)
+		cancel()
+
+		if err == nil {
+			w.cb.RecordSuccess()
+			return rc, nil
+		}
+		lastErr = err
+		if !isRetryable(err) {
+			break
+		}
 	}
-	w.cb.RecordSuccess()
-	return rc, nil
+
+	w.cb.RecordFailure()
+	return nil, lastErr
 }
 
 func (w *wrapper) Delete(ctx context.Context, name string) error {
 	if err := w.cb.Allow(); err != nil {
 		return err
 	}
-	ctx, cancel := context.WithTimeout(ctx, w.cfg.Timeout)
-	defer cancel()
-	if err := w.inner.Delete(ctx, name); err != nil {
-		w.cb.RecordFailure()
-		return err
+
+	var lastErr error
+	for attempt := 0; attempt <= w.retryCfg.MaxRetries; attempt++ {
+		if attempt > 0 {
+			delay := Backoff(attempt-1, w.retryCfg)
+			slog.WarnContext(ctx, "retrying delete",
+				slog.String("name", name),
+				slog.Int("attempt", attempt),
+				slog.Duration("backoff", delay),
+				slog.String("last_error", lastErr.Error()),
+			)
+			select {
+			case <-time.After(delay):
+			case <-ctx.Done():
+				w.cb.RecordFailure()
+				return ctx.Err()
+			}
+			if err := w.cb.Allow(); err != nil {
+				return err
+			}
+		}
+
+		reqCtx, cancel := context.WithTimeout(ctx, w.cfg.Timeout)
+		err := w.inner.Delete(reqCtx, name)
+		cancel()
+
+		if err == nil {
+			w.cb.RecordSuccess()
+			return nil
+		}
+		lastErr = err
+		if !isRetryable(err) {
+			break
+		}
 	}
-	w.cb.RecordSuccess()
-	return nil
+
+	w.cb.RecordFailure()
+	return lastErr
 }

--- a/api-go/internal/resilience/wrapper_test.go
+++ b/api-go/internal/resilience/wrapper_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -15,9 +16,14 @@ type mockClient struct {
 	downloadErr error
 	deleteErr   error
 	delay       time.Duration
+
+	uploadCalls   atomic.Int32
+	downloadCalls atomic.Int32
+	deleteCalls   atomic.Int32
 }
 
 func (m *mockClient) Upload(ctx context.Context, name string, r io.Reader) (string, error) {
+	m.uploadCalls.Add(1)
 	if m.delay > 0 {
 		select {
 		case <-time.After(m.delay):
@@ -29,6 +35,7 @@ func (m *mockClient) Upload(ctx context.Context, name string, r io.Reader) (stri
 }
 
 func (m *mockClient) Download(ctx context.Context, name string) (io.ReadCloser, error) {
+	m.downloadCalls.Add(1)
 	if m.delay > 0 {
 		select {
 		case <-time.After(m.delay):
@@ -43,6 +50,7 @@ func (m *mockClient) Download(ctx context.Context, name string) (io.ReadCloser, 
 }
 
 func (m *mockClient) Delete(ctx context.Context, name string) error {
+	m.deleteCalls.Add(1)
 	if m.delay > 0 {
 		select {
 		case <-time.After(m.delay):
@@ -79,7 +87,12 @@ func TestWrapperPassesThrough(t *testing.T) {
 
 func TestWrapperTimeout(t *testing.T) {
 	inner := &mockClient{delay: 200 * time.Millisecond}
-	cfg := WrapperConfig{Timeout: 50 * time.Millisecond, FailureThreshold: 100, RecoveryTimeout: time.Second}
+	cfg := WrapperConfig{
+		Timeout:          50 * time.Millisecond,
+		FailureThreshold: 100,
+		RecoveryTimeout:  time.Second,
+		MaxRetries:       0, // no retries to isolate timeout behavior
+	}
 	w := Wrap(inner, cfg)
 
 	_, err := w.Upload(context.Background(), "slow.txt", strings.NewReader("data"))
@@ -93,7 +106,12 @@ func TestWrapperTimeout(t *testing.T) {
 
 func TestWrapperCircuitBreakerTrips(t *testing.T) {
 	inner := &mockClient{uploadErr: errors.New("backend down")}
-	cfg := WrapperConfig{Timeout: time.Second, FailureThreshold: 3, RecoveryTimeout: time.Second}
+	cfg := WrapperConfig{
+		Timeout:          time.Second,
+		FailureThreshold: 3,
+		RecoveryTimeout:  time.Second,
+		MaxRetries:       0, // no retries
+	}
 	w := Wrap(inner, cfg)
 
 	ctx := context.Background()
@@ -113,7 +131,12 @@ func TestWrapperCircuitBreakerTrips(t *testing.T) {
 
 func TestWrapperCircuitBreakerRecovers(t *testing.T) {
 	inner := &mockClient{uploadErr: errors.New("backend down")}
-	cfg := WrapperConfig{Timeout: time.Second, FailureThreshold: 2, RecoveryTimeout: 50 * time.Millisecond}
+	cfg := WrapperConfig{
+		Timeout:          time.Second,
+		FailureThreshold: 2,
+		RecoveryTimeout:  50 * time.Millisecond,
+		MaxRetries:       0,
+	}
 	w := Wrap(inner, cfg)
 
 	ctx := context.Background()
@@ -138,5 +161,179 @@ func TestWrapperCircuitBreakerRecovers(t *testing.T) {
 	}
 	if name != "uploaded-ok.txt" {
 		t.Fatalf("expected uploaded-ok.txt, got %s", name)
+	}
+}
+
+// --- Retry-specific tests ---
+
+// flakeyClient fails a configurable number of times then succeeds.
+type flakeyClient struct {
+	failCount   int
+	callCount   atomic.Int32
+	permanentOK bool
+}
+
+func (f *flakeyClient) Upload(ctx context.Context, name string, r io.Reader) (string, error) {
+	n := int(f.callCount.Add(1))
+	if n <= f.failCount {
+		return "", errors.New("transient failure")
+	}
+	return "uploaded-" + name, nil
+}
+
+func (f *flakeyClient) Download(ctx context.Context, name string) (io.ReadCloser, error) {
+	n := int(f.callCount.Add(1))
+	if n <= f.failCount {
+		return nil, errors.New("transient failure")
+	}
+	return io.NopCloser(strings.NewReader("data")), nil
+}
+
+func (f *flakeyClient) Delete(ctx context.Context, name string) error {
+	n := int(f.callCount.Add(1))
+	if n <= f.failCount {
+		return errors.New("transient failure")
+	}
+	return nil
+}
+
+func TestWrapperRetryUploadSucceeds(t *testing.T) {
+	inner := &flakeyClient{failCount: 2} // fails twice, then succeeds
+	cfg := WrapperConfig{
+		Timeout:          time.Second,
+		FailureThreshold: 10,
+		RecoveryTimeout:  time.Second,
+		MaxRetries:       3,
+		RetryBaseDelay:   1 * time.Millisecond,
+		RetryMaxDelay:    10 * time.Millisecond,
+	}
+	w := Wrap(inner, cfg)
+
+	name, err := w.Upload(context.Background(), "file.txt", strings.NewReader("data"))
+	if err != nil {
+		t.Fatalf("expected success after retries, got %v", err)
+	}
+	if name != "uploaded-file.txt" {
+		t.Fatalf("unexpected name: %s", name)
+	}
+	if got := int(inner.callCount.Load()); got != 3 {
+		t.Fatalf("expected 3 calls (2 failures + 1 success), got %d", got)
+	}
+}
+
+func TestWrapperRetryDownloadSucceeds(t *testing.T) {
+	inner := &flakeyClient{failCount: 1}
+	cfg := WrapperConfig{
+		Timeout:          time.Second,
+		FailureThreshold: 10,
+		RecoveryTimeout:  time.Second,
+		MaxRetries:       2,
+		RetryBaseDelay:   1 * time.Millisecond,
+		RetryMaxDelay:    10 * time.Millisecond,
+	}
+	w := Wrap(inner, cfg)
+
+	rc, err := w.Download(context.Background(), "file.txt")
+	if err != nil {
+		t.Fatalf("expected success after retry, got %v", err)
+	}
+	_ = rc.Close()
+	if got := int(inner.callCount.Load()); got != 2 {
+		t.Fatalf("expected 2 calls, got %d", got)
+	}
+}
+
+func TestWrapperRetryDeleteSucceeds(t *testing.T) {
+	inner := &flakeyClient{failCount: 1}
+	cfg := WrapperConfig{
+		Timeout:          time.Second,
+		FailureThreshold: 10,
+		RecoveryTimeout:  time.Second,
+		MaxRetries:       2,
+		RetryBaseDelay:   1 * time.Millisecond,
+		RetryMaxDelay:    10 * time.Millisecond,
+	}
+	w := Wrap(inner, cfg)
+
+	err := w.Delete(context.Background(), "file.txt")
+	if err != nil {
+		t.Fatalf("expected success after retry, got %v", err)
+	}
+	if got := int(inner.callCount.Load()); got != 2 {
+		t.Fatalf("expected 2 calls, got %d", got)
+	}
+}
+
+func TestWrapperRetryExhausted(t *testing.T) {
+	inner := &mockClient{uploadErr: errors.New("permanent failure")}
+	cfg := WrapperConfig{
+		Timeout:          time.Second,
+		FailureThreshold: 100,
+		RecoveryTimeout:  time.Second,
+		MaxRetries:       2,
+		RetryBaseDelay:   1 * time.Millisecond,
+		RetryMaxDelay:    10 * time.Millisecond,
+	}
+	w := Wrap(inner, cfg)
+
+	_, err := w.Upload(context.Background(), "fail.txt", strings.NewReader("data"))
+	if err == nil {
+		t.Fatal("expected error after retries exhausted")
+	}
+	// 1 initial + 2 retries = 3 total calls
+	if got := int(inner.uploadCalls.Load()); got != 3 {
+		t.Fatalf("expected 3 upload calls, got %d", got)
+	}
+}
+
+func TestWrapperNoRetryOnCircuitOpen(t *testing.T) {
+	inner := &mockClient{uploadErr: errors.New("backend down")}
+	cfg := WrapperConfig{
+		Timeout:          time.Second,
+		FailureThreshold: 1, // opens after 1 recorded failure
+		RecoveryTimeout:  10 * time.Second,
+		MaxRetries:       2,
+		RetryBaseDelay:   1 * time.Millisecond,
+		RetryMaxDelay:    10 * time.Millisecond,
+	}
+	w := Wrap(inner, cfg)
+
+	// First call: retries exhaust (1 initial + 2 retries = 3 backend calls),
+	// then records one failure to circuit breaker, which opens it.
+	_, err := w.Upload(context.Background(), "fail.txt", strings.NewReader("data"))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if got := int(inner.uploadCalls.Load()); got != 3 {
+		t.Fatalf("expected 3 backend calls (1 + 2 retries), got %d", got)
+	}
+
+	// Second call should get circuit open immediately with zero backend calls.
+	_, err = w.Upload(context.Background(), "fail2.txt", strings.NewReader("data"))
+	if !errors.Is(err, ErrCircuitOpen) {
+		t.Fatalf("expected ErrCircuitOpen, got %v", err)
+	}
+	// No additional backend calls.
+	if got := int(inner.uploadCalls.Load()); got != 3 {
+		t.Fatalf("expected still 3 backend calls (no new ones), got %d", got)
+	}
+}
+
+func TestWrapperRetryZeroMeansNoRetry(t *testing.T) {
+	inner := &mockClient{uploadErr: errors.New("fail")}
+	cfg := WrapperConfig{
+		Timeout:          time.Second,
+		FailureThreshold: 100,
+		RecoveryTimeout:  time.Second,
+		MaxRetries:       0,
+	}
+	w := Wrap(inner, cfg)
+
+	_, err := w.Upload(context.Background(), "file.txt", strings.NewReader("data"))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if got := int(inner.uploadCalls.Load()); got != 1 {
+		t.Fatalf("expected exactly 1 call with 0 retries, got %d", got)
 	}
 }


### PR DESCRIPTION
## Summary

- Add retry with exponential backoff for all source client operations (upload, download, delete) inside the circuit breaker wrapper — only final failures count toward the CB threshold
- Add upload failover: when upload fails on selected source after retries, automatically tries alternative sources from the bucket
- Add configurable retry settings via env vars (`SOURCE_MAX_RETRIES`, `SOURCE_RETRY_BASE_DELAY_MS`, `SOURCE_RETRY_MAX_DELAY_MS`) and YAML config
- Structured logging (`slog`) for retry attempts and failover events, OpenTelemetry trace attributes for failover counts

Closes #134

## Test plan

- [x] Retry tests: transient failure recovery (upload/download/delete), retry exhaustion, no-retry on circuit open
- [x] Failover tests: upload failover to alternate source, all-sources-fail error, single-source no-failover
- [x] Backoff calculation tests: exponential growth, max delay cap, default values
- [x] All existing resilience and manager tests pass (no regressions)
- [x] Full `go test ./...` passes
- [x] `go build ./...` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)