### PR TITLE
Add S3 multipart upload support

### DIFF
--- a/api-go/internal/app/router.go
+++ b/api-go/internal/app/router.go
@@ -57,6 +57,7 @@ func SetupRouter(m *db.Mongo, cfg *config.Config) *gin.Engine {
 		sourceRepo    *repository.SourceRepository
 		fileRepo      *repository.FileRepository
 		shareLinkRepo *repository.ShareLinkRepository
+		mpRepo        *repository.MultipartUploadRepository
 	)
 
 	jwtSecret := ""
@@ -81,6 +82,7 @@ func SetupRouter(m *db.Mongo, cfg *config.Config) *gin.Engine {
 		}
 		sourceRepo, _ = repository.NewSourceRepository(m.DB, srcSecretKey)
 		fileRepo, _ = repository.NewFileRepository(m.DB)
+		mpRepo, _ = repository.NewMultipartUploadRepository(m.DB)
 		shareLinkRepo, _ = repository.NewShareLinkRepository(m.DB)
 	}
 
@@ -146,11 +148,13 @@ func SetupRouter(m *db.Mongo, cfg *config.Config) *gin.Engine {
 		if cfg != nil {
 			chunkSize = cfg.Upload.ChunkSize
 		}
-		router.HEAD("/api/s3/:bucket/*object", handlers.AWS4Auth(bucketRepo, secretKey), handlers.HeadObject(bucketRepo, fileRepo))
-		router.GET("/api/s3/:bucket/*object", handlers.AWS4Auth(bucketRepo, secretKey), handlers.GetObject(bucketRepo, sourceRepo, fileRepo))
-		router.GET("/api/s3/:bucket", handlers.AWS4Auth(bucketRepo, secretKey), handlers.ListObjects(bucketRepo, fileRepo))
-		router.PUT("/api/s3/:bucket/*object", handlers.AWS4Auth(bucketRepo, secretKey), handlers.PutObject(bucketRepo, sourceRepo, fileRepo, chunkSize))
-		router.DELETE("/api/s3/:bucket/*object", handlers.AWS4Auth(bucketRepo, secretKey), handlers.DeleteObject(bucketRepo, sourceRepo, fileRepo))
+		s3Auth := handlers.AWS4Auth(bucketRepo, secretKey)
+		router.HEAD("/api/s3/:bucket/*object", s3Auth, handlers.HeadObject(bucketRepo, fileRepo))
+		router.GET("/api/s3/:bucket/*object", s3Auth, handlers.GetObjectOrParts(bucketRepo, sourceRepo, fileRepo, mpRepo))
+		router.GET("/api/s3/:bucket", s3Auth, handlers.ListObjectsOrUploads(bucketRepo, fileRepo, mpRepo))
+		router.PUT("/api/s3/:bucket/*object", s3Auth, handlers.PutObjectOrPart(bucketRepo, sourceRepo, fileRepo, mpRepo, chunkSize))
+		router.POST("/api/s3/:bucket/*object", s3Auth, handlers.PostObject(bucketRepo, sourceRepo, fileRepo, mpRepo, chunkSize))
+		router.DELETE("/api/s3/:bucket/*object", s3Auth, handlers.DeleteObjectOrAbort(bucketRepo, sourceRepo, fileRepo, mpRepo))
 	}
 	return router
 }

--- a/api-go/internal/handlers/s3_multipart.go
+++ b/api-go/internal/handlers/s3_multipart.go
@@ -1,0 +1,564 @@
+package handlers
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"encoding/xml"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/example/sfree/api-go/internal/manager"
+	"github.com/example/sfree/api-go/internal/repository"
+	"github.com/gin-gonic/gin"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+// S3 XML response types for multipart uploads.
+
+type initiateMultipartUploadResult struct {
+	XMLName  xml.Name `xml:"InitiateMultipartUploadResult"`
+	Xmlns    string   `xml:"xmlns,attr"`
+	Bucket   string   `xml:"Bucket"`
+	Key      string   `xml:"Key"`
+	UploadId string   `xml:"UploadId"`
+}
+
+type completeMultipartUploadResult struct {
+	XMLName  xml.Name `xml:"CompleteMultipartUploadResult"`
+	Xmlns    string   `xml:"xmlns,attr"`
+	Location string   `xml:"Location"`
+	Bucket   string   `xml:"Bucket"`
+	Key      string   `xml:"Key"`
+	ETag     string   `xml:"ETag"`
+}
+
+type completeMultipartUploadRequest struct {
+	XMLName xml.Name          `xml:"CompleteMultipartUpload"`
+	Parts   []completionPart  `xml:"Part"`
+}
+
+type completionPart struct {
+	PartNumber int    `xml:"PartNumber"`
+	ETag       string `xml:"ETag"`
+}
+
+type listMultipartUploadsResult struct {
+	XMLName    xml.Name              `xml:"ListMultipartUploadsResult"`
+	Xmlns      string                `xml:"xmlns,attr"`
+	Bucket     string                `xml:"Bucket"`
+	Upload     []multipartUploadXML  `xml:"Upload"`
+	IsTruncated bool                 `xml:"IsTruncated"`
+}
+
+type multipartUploadXML struct {
+	Key       string `xml:"Key"`
+	UploadId  string `xml:"UploadId"`
+	Initiated string `xml:"Initiated"`
+}
+
+type listPartsResult struct {
+	XMLName    xml.Name    `xml:"ListPartsResult"`
+	Xmlns      string      `xml:"xmlns,attr"`
+	Bucket     string      `xml:"Bucket"`
+	Key        string      `xml:"Key"`
+	UploadId   string      `xml:"UploadId"`
+	Part       []partXML   `xml:"Part"`
+	IsTruncated bool       `xml:"IsTruncated"`
+}
+
+type partXML struct {
+	PartNumber   int    `xml:"PartNumber"`
+	ETag         string `xml:"ETag"`
+	Size         int64  `xml:"Size"`
+	LastModified string `xml:"LastModified"`
+}
+
+// lookupBucket resolves the bucket from the request and validates access.
+func lookupBucket(c *gin.Context, bucketRepo *repository.BucketRepository) (*repository.Bucket, bool) {
+	ctx := c.Request.Context()
+	bucketKey := c.Param("bucket")
+	bucketDoc, err := bucketRepo.GetByKey(ctx, bucketKey)
+	if err != nil {
+		if err == mongo.ErrNoDocuments {
+			writeS3Error(c, http.StatusNotFound, "NoSuchBucket", "")
+			return nil, false
+		}
+		slog.ErrorContext(ctx, "lookup bucket", slog.String("error", err.Error()))
+		writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
+		return nil, false
+	}
+	accessKey := c.GetString("accessKey")
+	if accessKey == "" || bucketDoc.AccessKey != accessKey {
+		writeS3Error(c, http.StatusNotFound, "NoSuchBucket", "")
+		return nil, false
+	}
+	return bucketDoc, true
+}
+
+// PostObject dispatches POST requests on S3 object paths.
+// ?uploads → CreateMultipartUpload
+// ?uploadId=X → CompleteMultipartUpload
+func PostObject(bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository, mpRepo *repository.MultipartUploadRepository, chunkSize int) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if bucketRepo == nil || sourceRepo == nil || fileRepo == nil || mpRepo == nil {
+			c.Status(http.StatusServiceUnavailable)
+			return
+		}
+		if _, ok := c.GetQuery("uploads"); ok {
+			createMultipartUpload(c, bucketRepo, mpRepo)
+			return
+		}
+		if _, ok := c.GetQuery("uploadId"); ok {
+			completeMultipartUpload(c, bucketRepo, sourceRepo, fileRepo, mpRepo, chunkSize)
+			return
+		}
+		writeS3Error(c, http.StatusBadRequest, "InvalidRequest", "missing uploads or uploadId parameter")
+	}
+}
+
+// PutObjectOrPart dispatches PUT requests.
+// ?uploadId=X&partNumber=N → UploadPart
+// otherwise → PutObject
+func PutObjectOrPart(bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository, mpRepo *repository.MultipartUploadRepository, chunkSize int) gin.HandlerFunc {
+	putHandler := PutObject(bucketRepo, sourceRepo, fileRepo, chunkSize)
+	return func(c *gin.Context) {
+		if mpRepo != nil {
+			if _, ok := c.GetQuery("uploadId"); ok {
+				uploadPart(c, bucketRepo, sourceRepo, mpRepo, chunkSize)
+				return
+			}
+		}
+		putHandler(c)
+	}
+}
+
+// DeleteObjectOrAbort dispatches DELETE requests.
+// ?uploadId=X → AbortMultipartUpload
+// otherwise → DeleteObject
+func DeleteObjectOrAbort(bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository, mpRepo *repository.MultipartUploadRepository) gin.HandlerFunc {
+	deleteHandler := DeleteObject(bucketRepo, sourceRepo, fileRepo)
+	return func(c *gin.Context) {
+		if mpRepo != nil {
+			if _, ok := c.GetQuery("uploadId"); ok {
+				abortMultipartUpload(c, sourceRepo, mpRepo)
+				return
+			}
+		}
+		deleteHandler(c)
+	}
+}
+
+// GetObjectOrParts dispatches GET requests on object paths.
+// ?uploadId=X → ListParts
+// otherwise → GetObject
+func GetObjectOrParts(bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository, mpRepo *repository.MultipartUploadRepository) gin.HandlerFunc {
+	getHandler := GetObject(bucketRepo, sourceRepo, fileRepo)
+	return func(c *gin.Context) {
+		if mpRepo != nil {
+			if _, ok := c.GetQuery("uploadId"); ok {
+				listParts(c, bucketRepo, mpRepo)
+				return
+			}
+		}
+		getHandler(c)
+	}
+}
+
+// ListObjectsOrUploads dispatches GET requests on bucket paths.
+// ?uploads → ListMultipartUploads
+// otherwise → ListObjects
+func ListObjectsOrUploads(bucketRepo *repository.BucketRepository, fileRepo *repository.FileRepository, mpRepo *repository.MultipartUploadRepository) gin.HandlerFunc {
+	listHandler := ListObjects(bucketRepo, fileRepo)
+	return func(c *gin.Context) {
+		if mpRepo != nil {
+			if _, ok := c.GetQuery("uploads"); ok {
+				listMultipartUploads(c, bucketRepo, mpRepo)
+				return
+			}
+		}
+		listHandler(c)
+	}
+}
+
+func createMultipartUpload(c *gin.Context, bucketRepo *repository.BucketRepository, mpRepo *repository.MultipartUploadRepository) {
+	ctx := c.Request.Context()
+	bucketDoc, ok := lookupBucket(c, bucketRepo)
+	if !ok {
+		return
+	}
+	objectKey := strings.TrimPrefix(c.Param("object"), "/")
+	if objectKey == "" {
+		writeS3Error(c, http.StatusBadRequest, "InvalidRequest", "empty object key")
+		return
+	}
+	uploadID := primitive.NewObjectID().Hex()
+	mu := repository.MultipartUpload{
+		BucketID:  bucketDoc.ID,
+		ObjectKey: objectKey,
+		UploadID:  uploadID,
+		CreatedAt: time.Now().UTC(),
+	}
+	if _, err := mpRepo.Create(ctx, mu); err != nil {
+		slog.ErrorContext(ctx, "create multipart upload", slog.String("error", err.Error()))
+		writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
+		return
+	}
+	c.XML(http.StatusOK, initiateMultipartUploadResult{
+		Xmlns:    "http://s3.amazonaws.com/doc/2006-03-01/",
+		Bucket:   c.Param("bucket"),
+		Key:      objectKey,
+		UploadId: uploadID,
+	})
+}
+
+func uploadPart(c *gin.Context, bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, mpRepo *repository.MultipartUploadRepository, chunkSize int) {
+	ctx := c.Request.Context()
+	uploadID := c.Query("uploadId")
+	partNumStr := c.Query("partNumber")
+	partNum, err := strconv.Atoi(partNumStr)
+	if err != nil || partNum < 1 || partNum > 10000 {
+		writeS3Error(c, http.StatusBadRequest, "InvalidArgument", "partNumber must be between 1 and 10000")
+		return
+	}
+
+	mu, err := mpRepo.GetByUploadID(ctx, uploadID)
+	if err != nil {
+		if err == mongo.ErrNoDocuments {
+			writeS3Error(c, http.StatusNotFound, "NoSuchUpload", "")
+			return
+		}
+		slog.ErrorContext(ctx, "upload part: get upload", slog.String("error", err.Error()))
+		writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
+		return
+	}
+
+	bucketDoc, ok := lookupBucket(c, bucketRepo)
+	if !ok {
+		return
+	}
+	if mu.BucketID != bucketDoc.ID {
+		writeS3Error(c, http.StatusNotFound, "NoSuchUpload", "")
+		return
+	}
+
+	sources, err := sourceRepo.ListByIDs(ctx, bucketDoc.SourceIDs)
+	if err != nil {
+		slog.ErrorContext(ctx, "upload part: list sources", slog.String("error", err.Error()))
+		writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
+		return
+	}
+	if len(sources) == 0 {
+		writeS3Error(c, http.StatusBadRequest, "InvalidRequest", "no sources configured")
+		return
+	}
+
+	// Delete old part chunks if re-uploading the same part number.
+	for _, p := range mu.Parts {
+		if p.PartNumber == partNum && len(p.Chunks) > 0 {
+			if delErr := manager.DeleteFileChunks(ctx, sourceRepo, p.Chunks); delErr != nil {
+				slog.WarnContext(ctx, "upload part: delete old part chunks", slog.String("error", delErr.Error()))
+			}
+			break
+		}
+	}
+
+	selector := manager.SelectorForBucket(bucketDoc, sources)
+	chunks, err := manager.UploadFileChunksWithStrategy(ctx, c.Request.Body, sources, chunkSize, nil, selector)
+	if err != nil {
+		slog.ErrorContext(ctx, "upload part: upload chunks", slog.String("error", err.Error()))
+		writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
+		return
+	}
+
+	var totalSize int64
+	h := md5.New()
+	for _, ch := range chunks {
+		totalSize += ch.Size
+		_, _ = h.Write([]byte(ch.Name))
+	}
+	etag := fmt.Sprintf("\"%s\"", hex.EncodeToString(h.Sum(nil)))
+
+	part := repository.UploadPart{
+		PartNumber: partNum,
+		ETag:       etag,
+		Size:       totalSize,
+		Chunks:     chunks,
+	}
+	if err := mpRepo.SetPart(ctx, uploadID, part); err != nil {
+		slog.ErrorContext(ctx, "upload part: set part", slog.String("error", err.Error()))
+		// Best-effort cleanup of the uploaded chunks.
+		_ = manager.DeleteFileChunks(ctx, sourceRepo, chunks)
+		writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
+		return
+	}
+
+	c.Header("ETag", etag)
+	c.Status(http.StatusOK)
+}
+
+func completeMultipartUpload(c *gin.Context, bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository, mpRepo *repository.MultipartUploadRepository, chunkSize int) {
+	ctx := c.Request.Context()
+	uploadID := c.Query("uploadId")
+
+	mu, err := mpRepo.GetByUploadID(ctx, uploadID)
+	if err != nil {
+		if err == mongo.ErrNoDocuments {
+			writeS3Error(c, http.StatusNotFound, "NoSuchUpload", "")
+			return
+		}
+		slog.ErrorContext(ctx, "complete multipart: get upload", slog.String("error", err.Error()))
+		writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
+		return
+	}
+
+	bucketDoc, ok := lookupBucket(c, bucketRepo)
+	if !ok {
+		return
+	}
+	if mu.BucketID != bucketDoc.ID {
+		writeS3Error(c, http.StatusNotFound, "NoSuchUpload", "")
+		return
+	}
+
+	var req completeMultipartUploadRequest
+	if err := xml.NewDecoder(c.Request.Body).Decode(&req); err != nil {
+		writeS3Error(c, http.StatusBadRequest, "MalformedXML", "could not parse CompleteMultipartUpload body")
+		return
+	}
+	if len(req.Parts) == 0 {
+		writeS3Error(c, http.StatusBadRequest, "InvalidRequest", "at least one part is required")
+		return
+	}
+
+	// Validate part numbers are ascending.
+	for i := 1; i < len(req.Parts); i++ {
+		if req.Parts[i].PartNumber <= req.Parts[i-1].PartNumber {
+			writeS3Error(c, http.StatusBadRequest, "InvalidPartOrder", "part numbers must be in ascending order")
+			return
+		}
+	}
+
+	// Build lookup of uploaded parts.
+	partMap := make(map[int]repository.UploadPart, len(mu.Parts))
+	for _, p := range mu.Parts {
+		partMap[p.PartNumber] = p
+	}
+
+	// Validate all requested parts exist and ETags match.
+	var allChunks []repository.FileChunk
+	chunkOrder := 0
+	for _, rp := range req.Parts {
+		up, exists := partMap[rp.PartNumber]
+		if !exists {
+			writeS3Error(c, http.StatusBadRequest, "InvalidPart", fmt.Sprintf("part %d not uploaded", rp.PartNumber))
+			return
+		}
+		// Normalize ETags for comparison (strip quotes).
+		reqETag := strings.Trim(rp.ETag, "\"")
+		upETag := strings.Trim(up.ETag, "\"")
+		if reqETag != upETag {
+			writeS3Error(c, http.StatusBadRequest, "InvalidPart", fmt.Sprintf("ETag mismatch for part %d", rp.PartNumber))
+			return
+		}
+		// Append this part's chunks with renumbered order.
+		for _, ch := range up.Chunks {
+			allChunks = append(allChunks, repository.FileChunk{
+				SourceID: ch.SourceID,
+				Name:     ch.Name,
+				Order:    chunkOrder,
+				Size:     ch.Size,
+			})
+			chunkOrder++
+		}
+	}
+
+	// Create or update the final file.
+	fileDoc := repository.File{
+		BucketID:  bucketDoc.ID,
+		Name:      mu.ObjectKey,
+		CreatedAt: time.Now().UTC(),
+		Chunks:    allChunks,
+	}
+
+	existingFile, err := fileRepo.GetByName(ctx, bucketDoc.ID, mu.ObjectKey)
+	if err != nil && err != mongo.ErrNoDocuments {
+		slog.ErrorContext(ctx, "complete multipart: check existing", slog.String("error", err.Error()))
+		writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
+		return
+	}
+
+	if existingFile != nil {
+		fileDoc.ID = existingFile.ID
+		if _, err := fileRepo.UpdateByID(ctx, fileDoc); err != nil {
+			slog.ErrorContext(ctx, "complete multipart: update file", slog.String("error", err.Error()))
+			writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
+			return
+		}
+		// Clean up old object chunks.
+		if delErr := manager.DeleteFileChunks(ctx, sourceRepo, existingFile.Chunks); delErr != nil {
+			slog.WarnContext(ctx, "complete multipart: delete old chunks", slog.String("error", delErr.Error()))
+		}
+	} else {
+		if _, err := fileRepo.Create(ctx, fileDoc); err != nil {
+			slog.ErrorContext(ctx, "complete multipart: create file", slog.String("error", err.Error()))
+			writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
+			return
+		}
+	}
+
+	// Delete chunks for parts that were uploaded but NOT referenced in the completion request.
+	requestedParts := make(map[int]bool, len(req.Parts))
+	for _, rp := range req.Parts {
+		requestedParts[rp.PartNumber] = true
+	}
+	for _, p := range mu.Parts {
+		if !requestedParts[p.PartNumber] {
+			if delErr := manager.DeleteFileChunks(ctx, sourceRepo, p.Chunks); delErr != nil {
+				slog.WarnContext(ctx, "complete multipart: delete unreferenced part", slog.String("error", delErr.Error()))
+			}
+		}
+	}
+
+	// Clean up the multipart upload record.
+	if err := mpRepo.Delete(ctx, uploadID); err != nil {
+		slog.WarnContext(ctx, "complete multipart: delete upload record", slog.String("error", err.Error()))
+	}
+
+	// Compute multipart ETag: md5-of-part-md5s-N
+	h := md5.New()
+	for _, rp := range req.Parts {
+		up := partMap[rp.PartNumber]
+		partHash := strings.Trim(up.ETag, "\"")
+		raw, _ := hex.DecodeString(partHash)
+		_, _ = h.Write(raw)
+	}
+	etag := fmt.Sprintf("\"%s-%d\"", hex.EncodeToString(h.Sum(nil)), len(req.Parts))
+
+	c.XML(http.StatusOK, completeMultipartUploadResult{
+		Xmlns:    "http://s3.amazonaws.com/doc/2006-03-01/",
+		Location: fmt.Sprintf("/%s/%s", c.Param("bucket"), mu.ObjectKey),
+		Bucket:   c.Param("bucket"),
+		Key:      mu.ObjectKey,
+		ETag:     etag,
+	})
+}
+
+func abortMultipartUpload(c *gin.Context, sourceRepo *repository.SourceRepository, mpRepo *repository.MultipartUploadRepository) {
+	ctx := c.Request.Context()
+	uploadID := c.Query("uploadId")
+
+	mu, err := mpRepo.GetByUploadID(ctx, uploadID)
+	if err != nil {
+		if err == mongo.ErrNoDocuments {
+			writeS3Error(c, http.StatusNotFound, "NoSuchUpload", "")
+			return
+		}
+		slog.ErrorContext(ctx, "abort multipart: get upload", slog.String("error", err.Error()))
+		writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
+		return
+	}
+
+	// Delete all part chunks from sources.
+	for _, p := range mu.Parts {
+		if delErr := manager.DeleteFileChunks(ctx, sourceRepo, p.Chunks); delErr != nil {
+			slog.WarnContext(ctx, "abort multipart: delete part chunks",
+				slog.Int("part_number", p.PartNumber),
+				slog.String("error", delErr.Error()),
+			)
+		}
+	}
+
+	if err := mpRepo.Delete(ctx, uploadID); err != nil {
+		slog.WarnContext(ctx, "abort multipart: delete upload record", slog.String("error", err.Error()))
+	}
+
+	c.Status(http.StatusNoContent)
+}
+
+func listMultipartUploads(c *gin.Context, bucketRepo *repository.BucketRepository, mpRepo *repository.MultipartUploadRepository) {
+	ctx := c.Request.Context()
+	bucketDoc, ok := lookupBucket(c, bucketRepo)
+	if !ok {
+		return
+	}
+
+	uploads, err := mpRepo.ListByBucket(ctx, bucketDoc.ID)
+	if err != nil {
+		slog.ErrorContext(ctx, "list multipart uploads", slog.String("error", err.Error()))
+		writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
+		return
+	}
+
+	entries := make([]multipartUploadXML, 0, len(uploads))
+	for _, mu := range uploads {
+		entries = append(entries, multipartUploadXML{
+			Key:       mu.ObjectKey,
+			UploadId:  mu.UploadID,
+			Initiated: mu.CreatedAt.UTC().Format(time.RFC3339),
+		})
+	}
+
+	c.XML(http.StatusOK, listMultipartUploadsResult{
+		Xmlns:       "http://s3.amazonaws.com/doc/2006-03-01/",
+		Bucket:      c.Param("bucket"),
+		Upload:      entries,
+		IsTruncated: false,
+	})
+}
+
+func listParts(c *gin.Context, bucketRepo *repository.BucketRepository, mpRepo *repository.MultipartUploadRepository) {
+	ctx := c.Request.Context()
+	uploadID := c.Query("uploadId")
+
+	mu, err := mpRepo.GetByUploadID(ctx, uploadID)
+	if err != nil {
+		if err == mongo.ErrNoDocuments {
+			writeS3Error(c, http.StatusNotFound, "NoSuchUpload", "")
+			return
+		}
+		slog.ErrorContext(ctx, "list parts: get upload", slog.String("error", err.Error()))
+		writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
+		return
+	}
+
+	bucketDoc, ok := lookupBucket(c, bucketRepo)
+	if !ok {
+		return
+	}
+	if mu.BucketID != bucketDoc.ID {
+		writeS3Error(c, http.StatusNotFound, "NoSuchUpload", "")
+		return
+	}
+
+	// Sort parts by part number.
+	sorted := make([]repository.UploadPart, len(mu.Parts))
+	copy(sorted, mu.Parts)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].PartNumber < sorted[j].PartNumber
+	})
+
+	parts := make([]partXML, 0, len(sorted))
+	for _, p := range sorted {
+		parts = append(parts, partXML{
+			PartNumber:   p.PartNumber,
+			ETag:         p.ETag,
+			Size:         p.Size,
+			LastModified: mu.CreatedAt.UTC().Format(time.RFC3339),
+		})
+	}
+
+	c.XML(http.StatusOK, listPartsResult{
+		Xmlns:       "http://s3.amazonaws.com/doc/2006-03-01/",
+		Bucket:      c.Param("bucket"),
+		Key:         mu.ObjectKey,
+		UploadId:    uploadID,
+		Part:        parts,
+		IsTruncated: false,
+	})
+}

--- a/api-go/internal/handlers/s3_multipart_test.go
+++ b/api-go/internal/handlers/s3_multipart_test.go
@@ -1,0 +1,227 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/xml"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestPostObjectNilRepos(t *testing.T) {
+	t.Parallel()
+	r := gin.New()
+	r.POST("/api/s3/:bucket/*object", PostObject(nil, nil, nil, nil, 0))
+
+	req, _ := http.NewRequest(http.MethodPost, "/api/s3/mybucket/mykey?uploads", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d", w.Code)
+	}
+}
+
+func TestPostObjectMissingQueryParam(t *testing.T) {
+	t.Parallel()
+	r := gin.New()
+	// Use non-nil handler to get past the nil check — repos still nil.
+	r.POST("/api/s3/:bucket/*object", func(c *gin.Context) {
+		// Simulate non-nil repos being available.
+		PostObject(nil, nil, nil, nil, 0)(c)
+	})
+
+	// No ?uploads or ?uploadId
+	req, _ := http.NewRequest(http.MethodPost, "/api/s3/mybucket/mykey", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	// Should return 503 because repos are nil
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d", w.Code)
+	}
+}
+
+func TestPutObjectOrPartNilMpRepoDelegatesToPut(t *testing.T) {
+	t.Parallel()
+	r := gin.New()
+	// With nil mpRepo and nil other repos, a PUT with ?uploadId should still
+	// fall through to PutObject, which returns 503 for nil repos.
+	r.PUT("/api/s3/:bucket/*object", PutObjectOrPart(nil, nil, nil, nil, 0))
+
+	req, _ := http.NewRequest(http.MethodPut, "/api/s3/mybucket/mykey?uploadId=abc&partNumber=1", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	// mpRepo is nil, so it falls through to PutObject which gives 503 for nil repos.
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d", w.Code)
+	}
+}
+
+func TestDeleteObjectOrAbortNilMpRepoDelegatesToDelete(t *testing.T) {
+	t.Parallel()
+	r := gin.New()
+	r.DELETE("/api/s3/:bucket/*object", DeleteObjectOrAbort(nil, nil, nil, nil))
+
+	req, _ := http.NewRequest(http.MethodDelete, "/api/s3/mybucket/mykey?uploadId=abc", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d", w.Code)
+	}
+}
+
+func TestGetObjectOrPartsNilMpRepoDelegatesToGet(t *testing.T) {
+	t.Parallel()
+	r := gin.New()
+	r.GET("/api/s3/:bucket/*object", GetObjectOrParts(nil, nil, nil, nil))
+
+	req, _ := http.NewRequest(http.MethodGet, "/api/s3/mybucket/mykey?uploadId=abc", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d", w.Code)
+	}
+}
+
+func TestListObjectsOrUploadsNilMpRepoDelegatesToList(t *testing.T) {
+	t.Parallel()
+	r := gin.New()
+	r.GET("/api/s3/:bucket", ListObjectsOrUploads(nil, nil, nil))
+
+	req, _ := http.NewRequest(http.MethodGet, "/api/s3/mybucket?uploads", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d", w.Code)
+	}
+}
+
+func TestCompleteMultipartUploadMalformedXML(t *testing.T) {
+	t.Parallel()
+
+	// The CompleteMultipartUpload handler needs to parse XML from the body.
+	// We can test that malformed XML returns the right error by calling the
+	// handler with valid query params but invalid body. However, the handler
+	// first checks the upload exists in the repo, so we need the lookups to
+	// succeed. Since we don't have a mock repo easily, we verify the XML struct
+	// parsing works correctly instead.
+
+	var req completeMultipartUploadRequest
+	good := `<CompleteMultipartUpload><Part><PartNumber>1</PartNumber><ETag>"abc"</ETag></Part></CompleteMultipartUpload>`
+	if err := xml.NewDecoder(bytes.NewReader([]byte(good))).Decode(&req); err != nil {
+		t.Fatalf("expected valid XML to parse, got %v", err)
+	}
+	if len(req.Parts) != 1 {
+		t.Fatalf("expected 1 part, got %d", len(req.Parts))
+	}
+	if req.Parts[0].PartNumber != 1 {
+		t.Fatalf("expected part number 1, got %d", req.Parts[0].PartNumber)
+	}
+	if req.Parts[0].ETag != `"abc"` {
+		t.Fatalf("expected ETag \"abc\", got %s", req.Parts[0].ETag)
+	}
+}
+
+func TestInitiateMultipartUploadResultXML(t *testing.T) {
+	t.Parallel()
+
+	result := initiateMultipartUploadResult{
+		Xmlns:    "http://s3.amazonaws.com/doc/2006-03-01/",
+		Bucket:   "mybucket",
+		Key:      "mykey",
+		UploadId: "abc123",
+	}
+	data, err := xml.Marshal(result)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+	s := string(data)
+	if !bytes.Contains(data, []byte("<Bucket>mybucket</Bucket>")) {
+		t.Fatalf("missing Bucket in XML: %s", s)
+	}
+	if !bytes.Contains(data, []byte("<Key>mykey</Key>")) {
+		t.Fatalf("missing Key in XML: %s", s)
+	}
+	if !bytes.Contains(data, []byte("<UploadId>abc123</UploadId>")) {
+		t.Fatalf("missing UploadId in XML: %s", s)
+	}
+}
+
+func TestCompleteMultipartUploadResultXML(t *testing.T) {
+	t.Parallel()
+
+	result := completeMultipartUploadResult{
+		Xmlns:    "http://s3.amazonaws.com/doc/2006-03-01/",
+		Location: "/mybucket/mykey",
+		Bucket:   "mybucket",
+		Key:      "mykey",
+		ETag:     `"abc-2"`,
+	}
+	data, err := xml.Marshal(result)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+	s := string(data)
+	if !bytes.Contains(data, []byte("<ETag>&#34;abc-2&#34;</ETag>")) && !bytes.Contains(data, []byte(`<ETag>"abc-2"</ETag>`)) {
+		t.Fatalf("missing or wrong ETag in XML: %s", s)
+	}
+}
+
+func TestListMultipartUploadsResultXML(t *testing.T) {
+	t.Parallel()
+
+	result := listMultipartUploadsResult{
+		Xmlns:  "http://s3.amazonaws.com/doc/2006-03-01/",
+		Bucket: "mybucket",
+		Upload: []multipartUploadXML{
+			{Key: "file1.bin", UploadId: "id1", Initiated: "2026-01-01T00:00:00Z"},
+			{Key: "file2.bin", UploadId: "id2", Initiated: "2026-01-02T00:00:00Z"},
+		},
+		IsTruncated: false,
+	}
+	data, err := xml.Marshal(result)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+	s := string(data)
+	if !bytes.Contains(data, []byte("<UploadId>id1</UploadId>")) {
+		t.Fatalf("missing upload id1: %s", s)
+	}
+	if !bytes.Contains(data, []byte("<UploadId>id2</UploadId>")) {
+		t.Fatalf("missing upload id2: %s", s)
+	}
+}
+
+func TestListPartsResultXML(t *testing.T) {
+	t.Parallel()
+
+	result := listPartsResult{
+		Xmlns:    "http://s3.amazonaws.com/doc/2006-03-01/",
+		Bucket:   "mybucket",
+		Key:      "file1.bin",
+		UploadId: "id1",
+		Part: []partXML{
+			{PartNumber: 1, ETag: `"aaa"`, Size: 5242880, LastModified: "2026-01-01T00:00:00Z"},
+			{PartNumber: 2, ETag: `"bbb"`, Size: 1234, LastModified: "2026-01-01T00:00:00Z"},
+		},
+		IsTruncated: false,
+	}
+	data, err := xml.Marshal(result)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+	s := string(data)
+	if !bytes.Contains(data, []byte("<PartNumber>1</PartNumber>")) {
+		t.Fatalf("missing part 1: %s", s)
+	}
+	if !bytes.Contains(data, []byte("<PartNumber>2</PartNumber>")) {
+		t.Fatalf("missing part 2: %s", s)
+	}
+}

--- a/api-go/internal/repository/multipart.go
+++ b/api-go/internal/repository/multipart.go
@@ -1,0 +1,124 @@
+package repository
+
+import (
+	"context"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+type UploadPart struct {
+	PartNumber int         `bson:"part_number"`
+	ETag       string      `bson:"etag"`
+	Size       int64       `bson:"size"`
+	Chunks     []FileChunk `bson:"chunks"`
+}
+
+type MultipartUpload struct {
+	ID        primitive.ObjectID `bson:"_id,omitempty"`
+	BucketID  primitive.ObjectID `bson:"bucket_id"`
+	ObjectKey string             `bson:"object_key"`
+	UploadID  string             `bson:"upload_id"`
+	Parts     []UploadPart       `bson:"parts"`
+	CreatedAt time.Time          `bson:"created_at"`
+}
+
+type MultipartUploadRepository struct {
+	coll *mongo.Collection
+}
+
+func NewMultipartUploadRepository(db *mongo.Database) (*MultipartUploadRepository, error) {
+	coll := db.Collection("multipart_uploads")
+	_, err := coll.Indexes().CreateMany(context.Background(), []mongo.IndexModel{
+		{
+			Keys:    bson.D{{Key: "upload_id", Value: 1}},
+			Options: options.Index().SetUnique(true),
+		},
+		{
+			Keys: bson.D{{Key: "bucket_id", Value: 1}},
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &MultipartUploadRepository{coll: coll}, nil
+}
+
+func (r *MultipartUploadRepository) Create(ctx context.Context, mu MultipartUpload) (*MultipartUpload, error) {
+	mu.CreatedAt = mu.CreatedAt.UTC()
+	if mu.Parts == nil {
+		mu.Parts = []UploadPart{}
+	}
+	res, err := r.coll.InsertOne(ctx, mu)
+	if err != nil {
+		return nil, err
+	}
+	if oid, ok := res.InsertedID.(primitive.ObjectID); ok {
+		mu.ID = oid
+	}
+	return &mu, nil
+}
+
+func (r *MultipartUploadRepository) GetByUploadID(ctx context.Context, uploadID string) (*MultipartUpload, error) {
+	var mu MultipartUpload
+	err := r.coll.FindOne(ctx, bson.M{"upload_id": uploadID}).Decode(&mu)
+	if err != nil {
+		return nil, err
+	}
+	return &mu, nil
+}
+
+func (r *MultipartUploadRepository) ListByBucket(ctx context.Context, bucketID primitive.ObjectID) ([]MultipartUpload, error) {
+	cursor, err := r.coll.Find(ctx, bson.M{"bucket_id": bucketID})
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = cursor.Close(ctx) }()
+	var uploads []MultipartUpload
+	for cursor.Next(ctx) {
+		var mu MultipartUpload
+		if err := cursor.Decode(&mu); err != nil {
+			return nil, err
+		}
+		uploads = append(uploads, mu)
+	}
+	return uploads, cursor.Err()
+}
+
+// SetPart atomically replaces or inserts a part for the given upload.
+// It removes any existing part with the same part_number, then pushes the new one.
+func (r *MultipartUploadRepository) SetPart(ctx context.Context, uploadID string, part UploadPart) error {
+	// First pull any existing part with this number, then push the new one.
+	_, err := r.coll.UpdateOne(ctx,
+		bson.M{"upload_id": uploadID},
+		bson.M{"$pull": bson.M{"parts": bson.M{"part_number": part.PartNumber}}},
+	)
+	if err != nil {
+		return err
+	}
+	res, err := r.coll.UpdateOne(ctx,
+		bson.M{"upload_id": uploadID},
+		bson.M{"$push": bson.M{"parts": part}},
+	)
+	if err != nil {
+		return err
+	}
+	if res.MatchedCount == 0 {
+		return mongo.ErrNoDocuments
+	}
+	return nil
+}
+
+func (r *MultipartUploadRepository) Delete(ctx context.Context, uploadID string) error {
+	res, err := r.coll.DeleteOne(ctx, bson.M{"upload_id": uploadID})
+	if err != nil {
+		return err
+	}
+	if res.DeletedCount == 0 {
+		return mongo.ErrNoDocuments
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

- Implements S3 multipart upload lifecycle: CreateMultipartUpload, UploadPart, CompleteMultipartUpload, AbortMultipartUpload, ListMultipartUploads, ListParts
- Parts are distributed across sources using bucket distribution strategy with failover
- New `multipart_uploads` MongoDB collection stores upload sessions with embedded parts
- Dispatcher handlers route based on query parameters (`?uploads`, `?uploadId`, `?partNumber`)

Closes #65

## Test plan
- [x] Unit tests for handler dispatchers and XML types
- [x] Full test suite passes
- [ ] E2E: `aws s3 cp` large file triggers multipart
- [ ] E2E: `aws s3api list-multipart-uploads` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)