### PR TITLE
Add GitHub Releases workflow with pre-built CLI binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,31 @@ local API. Without it, the frontend defaults to a relative `/api/v1` path
 
 ### CLI
 
-Build the CLI from source:
+**Download a pre-built binary** from the
+[latest release](https://github.com/siberianbearofficial/sfree/releases/latest):
+
+| OS | Architecture | Binary |
+| --- | --- | --- |
+| Linux | x86_64 | `sfree-linux-amd64` |
+| Linux | ARM64 | `sfree-linux-arm64` |
+| macOS | Intel | `sfree-darwin-amd64` |
+| macOS | Apple Silicon | `sfree-darwin-arm64` |
+| Windows | x86_64 | `sfree-windows-amd64.exe` |
+
+```bash
+# Example: Linux x86_64
+curl -Lo sfree https://github.com/siberianbearofficial/sfree/releases/latest/download/sfree-linux-amd64
+chmod +x sfree
+sudo mv sfree /usr/local/bin/
+```
+
+**Or install with Go:**
+
+```bash
+go install github.com/example/sfree/api-go/cmd/sfree-cli@latest
+```
+
+**Or build from source:**
 
 ```bash
 cd api-go

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ sudo mv sfree /usr/local/bin/
 **Or install with Go:**
 
 ```bash
-go install github.com/example/sfree/api-go/cmd/sfree-cli@latest
+go install github.com/siberianbearofficial/sfree/api-go/cmd/sfree-cli@latest
 ```
 
 **Or build from source:**


### PR DESCRIPTION
## Summary
- Adds README install instructions for pre-built CLI binaries (download, `go install`, and build-from-source)
- Includes GitHub Actions workflow for cross-platform CLI binary releases (see note below)

## Workflow file (needs manual commit)

The PAT does not have `workflow` scope, so `.github/workflows/release.yml` could not be pushed. A repo admin needs to add the following file to this branch:

<details>
<summary><code>.github/workflows/release.yml</code> — click to expand</summary>

```yaml
name: Release

on:
  push:
    tags:
      - "v*"

permissions:
  contents: write

jobs:
  build-cli:
    runs-on: ubuntu-latest
    strategy:
      matrix:
        include:
          - goos: linux
            goarch: amd64
          - goos: linux
            goarch: arm64
          - goos: darwin
            goarch: amd64
          - goos: darwin
            goarch: arm64
          - goos: windows
            goarch: amd64
    steps:
      - uses: actions/checkout@v4

      - uses: actions/setup-go@v5
        with:
          go-version: "1.24"
          cache-dependency-path: api-go/go.sum

      - name: Build binary
        working-directory: api-go
        env:
          GOOS: ${{ matrix.goos }}
          GOARCH: ${{ matrix.goarch }}
          CGO_ENABLED: "0"
        run: |
          EXT=""
          if [ "$GOOS" = "windows" ]; then EXT=".exe"; fi
          go build -ldflags="-s -w" -o "../sfree-${GOOS}-${GOARCH}${EXT}" ./cmd/sfree-cli

      - name: Upload artifact
        uses: actions/upload-artifact@v4
        with:
          name: sfree-${{ matrix.goos }}-${{ matrix.goarch }}
          path: sfree-*

  release:
    needs: build-cli
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
        with:
          fetch-depth: 0

      - name: Download all artifacts
        uses: actions/download-artifact@v4
        with:
          path: artifacts
          merge-multiple: true

      - name: Generate checksums
        run: |
          cd artifacts
          sha256sum sfree-* > checksums-sha256.txt

      - name: Create GitHub Release
        uses: softprops/action-gh-release@v2
        with:
          generate_release_notes: true
          files: |
            artifacts/sfree-*
            artifacts/checksums-sha256.txt
```

</details>

### What this does
- Triggers on semver tag push (`v*`)
- Cross-compiles CLI for linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64
- Generates SHA-256 checksums
- Creates GitHub Release with binaries and auto-generated release notes

## Test plan
- [ ] Repo admin commits workflow file to this branch
- [ ] Merge PR
- [ ] Push a tag (`git tag v0.1.0 && git push origin v0.1.0`) and verify workflow runs
- [ ] Verify release page has binaries for all 5 platforms + checksums
- [ ] Verify download link in README works after first release

🤖 Generated with [Claude Code](https://claude.com/claude-code)