### PR TITLE
Publish Docker images to GHCR on tagged releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,11 +90,12 @@ read and write objects directly.
 ```bash
 git clone https://github.com/siberianbearofficial/sfree.git
 cd sfree
-docker compose up --build
+docker compose up
 ```
 
-This starts MongoDB, the Go API, a React frontend (with nginx), and a MinIO
-instance for local S3-compatible source testing.
+This pulls pre-built images from GHCR and starts MongoDB, the Go API, a
+React frontend (with nginx), and a MinIO instance for local S3-compatible
+source testing. To build from source instead, add `--build`.
 
 | Service  | URL                          |
 | -------- | ---------------------------- |

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ docker compose up
 This pulls pre-built images from GHCR and starts MongoDB, the Go API, a
 React frontend (with nginx), and a MinIO instance for local S3-compatible
 source testing. To build from source instead, add `--build`.
+To pin a specific release: `SFREE_VERSION=v0.2.0 docker compose up`.
 
 | Service  | URL                          |
 | -------- | ---------------------------- |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ services:
       "
 
   api:
+    image: ghcr.io/siberianbearofficial/sfree-api:latest
     build:
       context: ./api-go
       dockerfile: Dockerfile
@@ -62,6 +63,7 @@ services:
       - tracing
 
   webui:
+    image: ghcr.io/siberianbearofficial/sfree-webui:latest
     build:
       context: ./webui
       dockerfile: Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       "
 
   api:
-    image: ghcr.io/siberianbearofficial/sfree-api:latest
+    image: ghcr.io/siberianbearofficial/sfree-api:${SFREE_VERSION:-latest}
     build:
       context: ./api-go
       dockerfile: Dockerfile
@@ -63,7 +63,7 @@ services:
       - tracing
 
   webui:
-    image: ghcr.io/siberianbearofficial/sfree-webui:latest
+    image: ghcr.io/siberianbearofficial/sfree-webui:${SFREE_VERSION:-latest}
     build:
       context: ./webui
       dockerfile: Dockerfile

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -20,11 +20,19 @@ S3-compatible endpoint.
 ```bash
 git clone https://github.com/siberianbearofficial/sfree.git
 cd sfree
+docker compose up
+```
+
+Docker Compose will pull the pre-built images from GHCR. To build from
+source instead, add `--build`:
+
+```bash
 docker compose up --build
 ```
 
 Wait until you see log lines from all services (`mongo`, `minio`, `api`,
-`webui`). First build takes 2–3 minutes; subsequent starts are faster.
+`webui`). Pre-built images start in seconds; building from source takes
+2–3 minutes the first time.
 
 **Expected output (last few lines):**
 


### PR DESCRIPTION
## Summary
- Adds `image:` directives to docker-compose.yml pointing to GHCR (`ghcr.io/siberianbearofficial/sfree-api:latest` and `sfree-webui:latest`)
- Updates quickstart docs: `docker compose up` now pulls pre-built images; `--build` builds from source
- Includes GitHub Actions workflow for multi-arch Docker builds (see note below)

## Workflow file (needs manual commit)

The PAT does not have `workflow` scope, so `.github/workflows/docker.yml` could not be pushed. A repo admin needs to add the following file to this branch:

<details>
<summary><code>.github/workflows/docker.yml</code> — click to expand</summary>

```yaml
name: Docker

on:
  push:
    tags:
      - "v*"

permissions:
  contents: read
  packages: write

env:
  REGISTRY: ghcr.io

jobs:
  build-api:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4

      - uses: docker/setup-qemu-action@v3

      - uses: docker/setup-buildx-action@v3

      - uses: docker/login-action@v3
        with:
          registry: ${{ env.REGISTRY }}
          username: ${{ github.actor }}
          password: ${{ secrets.GITHUB_TOKEN }}

      - name: Extract version
        id: meta
        uses: docker/metadata-action@v5
        with:
          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/sfree-api
          tags: |
            type=semver,pattern={{version}}
            type=semver,pattern={{major}}.{{minor}}
            type=raw,value=latest

      - uses: docker/build-push-action@v6
        with:
          context: ./api-go
          platforms: linux/amd64,linux/arm64
          push: true
          tags: ${{ steps.meta.outputs.tags }}
          labels: ${{ steps.meta.outputs.labels }}
          cache-from: type=gha
          cache-to: type=gha,mode=max

  build-webui:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4

      - uses: docker/setup-qemu-action@v3

      - uses: docker/setup-buildx-action@v3

      - uses: docker/login-action@v3
        with:
          registry: ${{ env.REGISTRY }}
          username: ${{ github.actor }}
          password: ${{ secrets.GITHUB_TOKEN }}

      - name: Extract version
        id: meta
        uses: docker/metadata-action@v5
        with:
          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/sfree-webui
          tags: |
            type=semver,pattern={{version}}
            type=semver,pattern={{major}}.{{minor}}
            type=raw,value=latest

      - uses: docker/build-push-action@v6
        with:
          context: ./webui
          platforms: linux/amd64,linux/arm64
          push: true
          tags: ${{ steps.meta.outputs.tags }}
          labels: ${{ steps.meta.outputs.labels }}
          cache-from: type=gha
          cache-to: type=gha,mode=max
```

</details>

### What this does
- Triggers on semver tag push (`v*`)
- Builds `sfree-api` and `sfree-webui` images in parallel
- Multi-arch: linux/amd64 + linux/arm64 via QEMU
- Tags: `{version}`, `{major}.{minor}`, `latest`
- Uses GitHub Actions cache for faster rebuilds

## Test plan
- [ ] Repo admin commits workflow file to this branch
- [ ] Merge PR
- [ ] Push a tag and verify workflow runs
- [ ] Verify `docker pull ghcr.io/siberianbearofficial/sfree-api:latest` works
- [ ] Verify `docker pull ghcr.io/siberianbearofficial/sfree-webui:latest` works
- [ ] Verify `docker compose up` pulls pre-built images successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)