### PR TITLE
Implement S3 ListObjectsV2 pagination

### DIFF
--- a/api-go/internal/e2e/s3_compat_test.go
+++ b/api-go/internal/e2e/s3_compat_test.go
@@ -553,6 +553,142 @@ func TestS3CompatObjectLifecycle(t *testing.T) {
 	}
 }
 
+func TestS3CompatListObjectsV2PrefixDelimiterAndPagination(t *testing.T) {
+	env, ok := loadS3E2EEnv()
+	if !ok {
+		t.Skip("E2E_S3_ENDPOINT not set; skipping S3 E2E tests")
+	}
+
+	ts, _ := newTestServer(t)
+	ensureMinIOBucket(t, env)
+
+	suffix := uniqueSuffix()
+	username, password := createTestUser(t, ts, suffix)
+	sourceID := createS3Source(t, ts, username, password, "src-"+suffix, env)
+	bucket := createBucket(t, ts, username, password, "bkt-"+suffix, sourceID)
+
+	t.Cleanup(func() {
+		apiDelete(t, ts, "/api/v1/buckets/"+bucket.ID, username, password)
+		apiDelete(t, ts, "/api/v1/sources/"+sourceID, username, password)
+	})
+
+	objectKeys := []string{
+		"docs/readme-" + suffix + ".txt",
+		"photos/2024/a-" + suffix + ".jpg",
+		"photos/2024/b-" + suffix + ".jpg",
+		"photos/2025/c-" + suffix + ".jpg",
+		"photos/root-" + suffix + ".txt",
+	}
+	s3URL := func(key string) string {
+		return fmt.Sprintf("%s/api/s3/%s/%s", ts.URL, bucket.Key, key)
+	}
+	for _, key := range objectKeys {
+		status, body := s3Do(t, http.MethodPut, s3URL(key), bucket.AccessKey, bucket.AccessSecret, env.Region, []byte("content "+key))
+		if status != http.StatusOK {
+			t.Fatalf("PUT %s: expected 200, got %d: %s", key, status, body)
+		}
+	}
+	t.Cleanup(func() {
+		for _, key := range objectKeys {
+			s3Do(t, http.MethodDelete, s3URL(key), bucket.AccessKey, bucket.AccessSecret, env.Region, nil)
+		}
+	})
+
+	type listBucketXML struct {
+		Prefix                string `xml:"Prefix"`
+		Delimiter             string `xml:"Delimiter"`
+		IsTruncated           bool   `xml:"IsTruncated"`
+		KeyCount              int    `xml:"KeyCount"`
+		NextContinuationToken string `xml:"NextContinuationToken"`
+		NextMarker            string `xml:"NextMarker"`
+		Contents              []struct {
+			Key string `xml:"Key"`
+		} `xml:"Contents"`
+		CommonPrefixes []struct {
+			Prefix string `xml:"Prefix"`
+		} `xml:"CommonPrefixes"`
+	}
+	listURL := ts.URL + "/api/s3/" + bucket.Key
+	listWith := func(params url.Values) listBucketXML {
+		t.Helper()
+		rawURL := listURL
+		if len(params) > 0 {
+			rawURL += "?" + params.Encode()
+		}
+		status, body := s3Do(t, http.MethodGet, rawURL, bucket.AccessKey, bucket.AccessSecret, env.Region, nil)
+		if status != http.StatusOK {
+			t.Fatalf("LIST %s: expected 200, got %d: %s", rawURL, status, body)
+		}
+		var result listBucketXML
+		if err := xml.Unmarshal(body, &result); err != nil {
+			t.Fatalf("decode list response: %v body=%s", err, body)
+		}
+		return result
+	}
+	keysFrom := func(result listBucketXML) []string {
+		keys := make([]string, 0, len(result.Contents))
+		for _, entry := range result.Contents {
+			keys = append(keys, entry.Key)
+		}
+		return keys
+	}
+	prefixesFrom := func(result listBucketXML) []string {
+		prefixes := make([]string, 0, len(result.CommonPrefixes))
+		for _, prefix := range result.CommonPrefixes {
+			prefixes = append(prefixes, prefix.Prefix)
+		}
+		return prefixes
+	}
+	has := func(values []string, want string) bool {
+		for _, value := range values {
+			if value == want {
+				return true
+			}
+		}
+		return false
+	}
+
+	prefixList := listWith(url.Values{"list-type": {"2"}, "prefix": {"photos/"}})
+	prefixKeys := keysFrom(prefixList)
+	if prefixList.Prefix != "photos/" || prefixList.KeyCount != 4 || len(prefixKeys) != 4 {
+		t.Fatalf("V2 prefix list mismatch: prefix=%q keyCount=%d keys=%v", prefixList.Prefix, prefixList.KeyCount, prefixKeys)
+	}
+	if has(prefixKeys, "docs/readme-"+suffix+".txt") {
+		t.Fatalf("V2 prefix list included non-matching key: %v", prefixKeys)
+	}
+
+	delimited := listWith(url.Values{"list-type": {"2"}, "prefix": {"photos/"}, "delimiter": {"/"}})
+	delimitedKeys := keysFrom(delimited)
+	commonPrefixes := prefixesFrom(delimited)
+	if delimited.Delimiter != "/" || delimited.KeyCount != 3 {
+		t.Fatalf("V2 delimiter list mismatch: delimiter=%q keyCount=%d keys=%v prefixes=%v", delimited.Delimiter, delimited.KeyCount, delimitedKeys, commonPrefixes)
+	}
+	if !has(delimitedKeys, "photos/root-"+suffix+".txt") || !has(commonPrefixes, "photos/2024/") || !has(commonPrefixes, "photos/2025/") {
+		t.Fatalf("V2 delimiter list missing expected entries: keys=%v prefixes=%v", delimitedKeys, commonPrefixes)
+	}
+
+	page1 := listWith(url.Values{"list-type": {"2"}, "prefix": {"photos/"}, "max-keys": {"2"}})
+	page1Keys := keysFrom(page1)
+	if page1.KeyCount != 2 || len(page1Keys) != 2 || !page1.IsTruncated || page1.NextContinuationToken == "" {
+		t.Fatalf("V2 first page mismatch: keyCount=%d keys=%v truncated=%v token=%q", page1.KeyCount, page1Keys, page1.IsTruncated, page1.NextContinuationToken)
+	}
+	page2 := listWith(url.Values{"list-type": {"2"}, "prefix": {"photos/"}, "max-keys": {"2"}, "continuation-token": {page1.NextContinuationToken}})
+	page2Keys := keysFrom(page2)
+	if page2.KeyCount != 2 || len(page2Keys) != 2 || page2.IsTruncated {
+		t.Fatalf("V2 second page mismatch: keyCount=%d keys=%v truncated=%v", page2.KeyCount, page2Keys, page2.IsTruncated)
+	}
+	if has(page2Keys, page1Keys[0]) || has(page2Keys, page1Keys[1]) {
+		t.Fatalf("V2 pagination repeated keys: page1=%v page2=%v", page1Keys, page2Keys)
+	}
+
+	v1Delimited := listWith(url.Values{"prefix": {"photos/"}, "delimiter": {"/"}})
+	v1Keys := keysFrom(v1Delimited)
+	v1Prefixes := prefixesFrom(v1Delimited)
+	if v1Delimited.KeyCount != 3 || !has(v1Prefixes, "photos/2024/") || !has(v1Prefixes, "photos/2025/") || !has(v1Keys, "photos/root-"+suffix+".txt") {
+		t.Fatalf("V1 delimiter list mismatch: keyCount=%d keys=%v prefixes=%v nextMarker=%q", v1Delimited.KeyCount, v1Keys, v1Prefixes, v1Delimited.NextMarker)
+	}
+}
+
 // TestS3CompatAccessKeyAuth verifies that the S3 API rejects requests with
 // wrong credentials.
 func TestS3CompatAccessKeyAuth(t *testing.T) {

--- a/api-go/internal/e2e/s3_compat_test.go
+++ b/api-go/internal/e2e/s3_compat_test.go
@@ -10,6 +10,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"encoding/xml"
 	"fmt"
 	"io"
 	"net/http"

--- a/api-go/internal/handlers/s3.go
+++ b/api-go/internal/handlers/s3.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/xml"
@@ -13,6 +14,7 @@ import (
 	"github.com/example/sfree/api-go/internal/manager"
 	"github.com/example/sfree/api-go/internal/repository"
 	"github.com/gin-gonic/gin"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
@@ -58,6 +60,8 @@ type listBucketPageItem struct {
 	hasEntry     bool
 	commonPrefix string
 }
+
+const listCommonPrefixSkipSuffix = "\U0010FFFF"
 
 func writeS3Error(c *gin.Context, status int, code, message string) {
 	c.XML(status, s3Error{Code: code, Message: message})
@@ -108,62 +112,78 @@ func fileListBucketEntry(file repository.File) listBucketEntry {
 	}
 }
 
-func buildListBucketPage(files []repository.File, prefix, delimiter, after string, maxKeys int) ([]listBucketEntry, []listCommonPrefix, bool, string) {
-	items := make([]listBucketPageItem, 0, len(files))
+func buildListBucketPage(ctx context.Context, fileRepo *repository.FileRepository, bucketID primitive.ObjectID, prefix, delimiter, after string, maxKeys int) ([]listBucketEntry, []listCommonPrefix, bool, string, error) {
+	batchLimit := maxKeys + 1
+	if batchLimit < 1 {
+		batchLimit = 1
+	}
+	if batchLimit > 1001 {
+		batchLimit = 1001
+	}
+
+	contents := make([]listBucketEntry, 0, maxKeys)
+	commonPrefixes := make([]listCommonPrefix, 0, maxKeys)
 	seenPrefixes := make(map[string]struct{})
-	for _, file := range files {
-		if !strings.HasPrefix(file.Name, prefix) {
-			continue
+	cursorAfter := after
+	lastToken := ""
+
+	for {
+		files, hasMore, err := fileRepo.ListByBucketWithPrefixPage(ctx, bucketID, prefix, cursorAfter, batchLimit)
+		if err != nil {
+			return nil, nil, false, "", err
 		}
-		if delimiter != "" {
-			remainder := strings.TrimPrefix(file.Name, prefix)
-			if idx := strings.Index(remainder, delimiter); idx >= 0 {
-				commonPrefix := prefix + remainder[:idx+len(delimiter)]
-				if _, ok := seenPrefixes[commonPrefix]; !ok {
-					seenPrefixes[commonPrefix] = struct{}{}
-					items = append(items, listBucketPageItem{sortKey: commonPrefix, commonPrefix: commonPrefix})
-				}
-				continue
+		if len(files) == 0 {
+			return contents, commonPrefixes, false, "", nil
+		}
+
+		for _, file := range files {
+			if file.Name > cursorAfter {
+				cursorAfter = file.Name
 			}
-		}
-		items = append(items, listBucketPageItem{
-			sortKey:  file.Name,
-			entry:    fileListBucketEntry(file),
-			hasEntry: true,
-		})
-	}
 
-	start := 0
-	if after != "" {
-		for start < len(items) && items[start].sortKey <= after {
-			start++
-		}
-	}
-	remaining := len(items) - start
-	if remaining < 0 {
-		remaining = 0
-	}
-	pageSize := maxKeys
-	if pageSize > remaining {
-		pageSize = remaining
-	}
-	page := items[start : start+pageSize]
-	isTruncated := start+pageSize < len(items)
-	nextToken := ""
-	if isTruncated && len(page) > 0 {
-		nextToken = page[len(page)-1].sortKey
-	}
+			item := listBucketPageItem{
+				sortKey:  file.Name,
+				entry:    fileListBucketEntry(file),
+				hasEntry: true,
+			}
+			if delimiter != "" {
+				remainder := strings.TrimPrefix(file.Name, prefix)
+				if idx := strings.Index(remainder, delimiter); idx >= 0 {
+					commonPrefix := prefix + remainder[:idx+len(delimiter)]
+					skipAfter := commonPrefix + listCommonPrefixSkipSuffix
+					if skipAfter > cursorAfter {
+						cursorAfter = skipAfter
+					}
+					if commonPrefix <= after {
+						continue
+					}
+					if _, ok := seenPrefixes[commonPrefix]; ok {
+						continue
+					}
+					seenPrefixes[commonPrefix] = struct{}{}
+					item = listBucketPageItem{sortKey: commonPrefix, commonPrefix: commonPrefix}
+				}
+			}
 
-	contents := make([]listBucketEntry, 0, len(page))
-	commonPrefixes := make([]listCommonPrefix, 0, len(page))
-	for _, item := range page {
-		if item.hasEntry {
-			contents = append(contents, item.entry)
-			continue
+			if maxKeys == 0 {
+				return contents, commonPrefixes, true, item.sortKey, nil
+			}
+			if len(contents)+len(commonPrefixes) == maxKeys {
+				return contents, commonPrefixes, true, lastToken, nil
+			}
+
+			if item.hasEntry {
+				contents = append(contents, item.entry)
+			} else {
+				commonPrefixes = append(commonPrefixes, listCommonPrefix{Prefix: item.commonPrefix})
+			}
+			lastToken = item.sortKey
 		}
-		commonPrefixes = append(commonPrefixes, listCommonPrefix{Prefix: item.commonPrefix})
+
+		if !hasMore {
+			return contents, commonPrefixes, false, "", nil
+		}
 	}
-	return contents, commonPrefixes, isTruncated, nextToken
 }
 
 // ListObjects godoc
@@ -194,13 +214,12 @@ func ListObjects(bucketRepo *repository.BucketRepository, fileRepo *repository.F
 		prefix := c.Query("prefix")
 		delimiter := c.Query("delimiter")
 		marker := c.Query("marker")
-		files, err := fileRepo.ListByBucketWithPrefix(ctx, bucketDoc.ID, prefix)
+		contents, commonPrefixes, isTruncated, nextMarker, err := buildListBucketPage(ctx, fileRepo, bucketDoc.ID, prefix, delimiter, marker, maxKeys)
 		if err != nil {
 			slog.ErrorContext(ctx, "list objects: list files", slog.String("error", err.Error()))
 			writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
 			return
 		}
-		contents, commonPrefixes, isTruncated, nextMarker := buildListBucketPage(files, prefix, delimiter, marker, maxKeys)
 		result := listBucketResult{
 			Xmlns:          "http://s3.amazonaws.com/doc/2006-03-01/",
 			Name:           bucketKey,
@@ -242,13 +261,12 @@ func ListObjectsV2(bucketRepo *repository.BucketRepository, fileRepo *repository
 		if continuationToken != "" {
 			after = continuationToken
 		}
-		files, err := fileRepo.ListByBucketWithPrefix(ctx, bucketDoc.ID, prefix)
+		contents, commonPrefixes, isTruncated, nextToken, err := buildListBucketPage(ctx, fileRepo, bucketDoc.ID, prefix, delimiter, after, maxKeys)
 		if err != nil {
 			slog.ErrorContext(ctx, "list objects v2: list files", slog.String("error", err.Error()))
 			writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
 			return
 		}
-		contents, commonPrefixes, isTruncated, nextToken := buildListBucketPage(files, prefix, delimiter, after, maxKeys)
 		result := listBucketResult{
 			Xmlns:                 "http://s3.amazonaws.com/doc/2006-03-01/",
 			Name:                  bucketKey,

--- a/api-go/internal/handlers/s3.go
+++ b/api-go/internal/handlers/s3.go
@@ -23,15 +23,21 @@ type s3Error struct {
 }
 
 type listBucketResult struct {
-	XMLName      xml.Name          `xml:"ListBucketResult"`
-	Xmlns        string            `xml:"xmlns,attr"`
-	Name         string            `xml:"Name"`
-	Prefix       string            `xml:"Prefix"`
-	MaxKeys      int               `xml:"MaxKeys"`
-	IsTruncated  bool              `xml:"IsTruncated"`
-	Contents     []listBucketEntry `xml:"Contents"`
-	KeyCount     int               `xml:"KeyCount"`
-	Continuation string            `xml:"ContinuationToken,omitempty"`
+	XMLName               xml.Name           `xml:"ListBucketResult"`
+	Xmlns                 string             `xml:"xmlns,attr"`
+	Name                  string             `xml:"Name"`
+	Prefix                string             `xml:"Prefix"`
+	Marker                string             `xml:"Marker,omitempty"`
+	NextMarker            string             `xml:"NextMarker,omitempty"`
+	MaxKeys               int                `xml:"MaxKeys"`
+	Delimiter             string             `xml:"Delimiter,omitempty"`
+	IsTruncated           bool               `xml:"IsTruncated"`
+	Contents              []listBucketEntry  `xml:"Contents"`
+	CommonPrefixes        []listCommonPrefix `xml:"CommonPrefixes"`
+	KeyCount              int                `xml:"KeyCount"`
+	ContinuationToken     string             `xml:"ContinuationToken,omitempty"`
+	NextContinuationToken string             `xml:"NextContinuationToken,omitempty"`
+	StartAfter            string             `xml:"StartAfter,omitempty"`
 }
 
 type listBucketEntry struct {
@@ -40,6 +46,17 @@ type listBucketEntry struct {
 	ETag         string `xml:"ETag"`
 	Size         int64  `xml:"Size"`
 	StorageClass string `xml:"StorageClass"`
+}
+
+type listCommonPrefix struct {
+	Prefix string `xml:"Prefix"`
+}
+
+type listBucketPageItem struct {
+	sortKey      string
+	entry        listBucketEntry
+	hasEntry     bool
+	commonPrefix string
 }
 
 func writeS3Error(c *gin.Context, status int, code, message string) {
@@ -60,6 +77,95 @@ func objectETag(file repository.File) string {
 	return "\"" + hex.EncodeToString(h.Sum(nil)) + "\""
 }
 
+func parseListMaxKeys(c *gin.Context) (int, bool) {
+	maxKeys := 1000
+	raw := c.Query("max-keys")
+	if raw == "" {
+		return maxKeys, true
+	}
+	parsed, err := strconv.Atoi(raw)
+	if err != nil || parsed < 0 {
+		writeS3Error(c, http.StatusBadRequest, "InvalidArgument", "max-keys must be a non-negative integer")
+		return 0, false
+	}
+	if parsed > maxKeys {
+		parsed = maxKeys
+	}
+	return parsed, true
+}
+
+func fileListBucketEntry(file repository.File) listBucketEntry {
+	var size int64
+	for _, chunk := range file.Chunks {
+		size += chunk.Size
+	}
+	return listBucketEntry{
+		Key:          file.Name,
+		LastModified: file.CreatedAt.UTC().Format(time.RFC3339),
+		ETag:         objectETag(file),
+		Size:         size,
+		StorageClass: "STANDARD",
+	}
+}
+
+func buildListBucketPage(files []repository.File, prefix, delimiter, after string, maxKeys int) ([]listBucketEntry, []listCommonPrefix, bool, string) {
+	items := make([]listBucketPageItem, 0, len(files))
+	seenPrefixes := make(map[string]struct{})
+	for _, file := range files {
+		if !strings.HasPrefix(file.Name, prefix) {
+			continue
+		}
+		if delimiter != "" {
+			remainder := strings.TrimPrefix(file.Name, prefix)
+			if idx := strings.Index(remainder, delimiter); idx >= 0 {
+				commonPrefix := prefix + remainder[:idx+len(delimiter)]
+				if _, ok := seenPrefixes[commonPrefix]; !ok {
+					seenPrefixes[commonPrefix] = struct{}{}
+					items = append(items, listBucketPageItem{sortKey: commonPrefix, commonPrefix: commonPrefix})
+				}
+				continue
+			}
+		}
+		items = append(items, listBucketPageItem{
+			sortKey:  file.Name,
+			entry:    fileListBucketEntry(file),
+			hasEntry: true,
+		})
+	}
+
+	start := 0
+	if after != "" {
+		for start < len(items) && items[start].sortKey <= after {
+			start++
+		}
+	}
+	remaining := len(items) - start
+	if remaining < 0 {
+		remaining = 0
+	}
+	pageSize := maxKeys
+	if pageSize > remaining {
+		pageSize = remaining
+	}
+	page := items[start : start+pageSize]
+	isTruncated := start+pageSize < len(items)
+	nextToken := ""
+	if isTruncated && len(page) > 0 {
+		nextToken = page[len(page)-1].sortKey
+	}
+
+	contents := make([]listBucketEntry, 0, len(page))
+	commonPrefixes := make([]listCommonPrefix, 0, len(page))
+	for _, item := range page {
+		if item.hasEntry {
+			contents = append(contents, item.entry)
+			continue
+		}
+		commonPrefixes = append(commonPrefixes, listCommonPrefix{Prefix: item.commonPrefix})
+	}
+	return contents, commonPrefixes, isTruncated, nextToken
+}
+
 // ListObjects godoc
 // @Summary List objects
 // @Tags s3
@@ -77,49 +183,85 @@ func ListObjects(bucketRepo *repository.BucketRepository, fileRepo *repository.F
 			return
 		}
 		bucketKey := c.Param("bucket")
-		bucketDoc, err := bucketRepo.GetByKey(ctx, bucketKey)
-		if err != nil {
-			if err == mongo.ErrNoDocuments {
-				writeS3Error(c, http.StatusNotFound, "NoSuchBucket", "")
-				return
-			}
-			slog.ErrorContext(ctx, "list objects: get bucket", slog.String("error", err.Error()))
-			writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
+		bucketDoc, ok := lookupBucket(c, bucketRepo)
+		if !ok {
 			return
 		}
-		accessKey := c.GetString("accessKey")
-		if accessKey == "" || bucketDoc.AccessKey != accessKey {
-			writeS3Error(c, http.StatusNotFound, "NoSuchBucket", "")
+		maxKeys, ok := parseListMaxKeys(c)
+		if !ok {
 			return
 		}
-		files, err := fileRepo.ListByBucket(ctx, bucketDoc.ID)
+		prefix := c.Query("prefix")
+		delimiter := c.Query("delimiter")
+		marker := c.Query("marker")
+		files, err := fileRepo.ListByBucketWithPrefix(ctx, bucketDoc.ID, prefix)
 		if err != nil {
 			slog.ErrorContext(ctx, "list objects: list files", slog.String("error", err.Error()))
 			writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
 			return
 		}
-		entries := make([]listBucketEntry, 0, len(files))
-		for _, file := range files {
-			var size int64
-			for _, chunk := range file.Chunks {
-				size += chunk.Size
-			}
-			entries = append(entries, listBucketEntry{
-				Key:          file.Name,
-				LastModified: file.CreatedAt.UTC().Format(time.RFC3339),
-				ETag:         objectETag(file),
-				Size:         size,
-				StorageClass: "STANDARD",
-			})
-		}
+		contents, commonPrefixes, isTruncated, nextMarker := buildListBucketPage(files, prefix, delimiter, marker, maxKeys)
 		result := listBucketResult{
-			Xmlns:       "http://s3.amazonaws.com/doc/2006-03-01/",
-			Name:        bucketKey,
-			Prefix:      "",
-			MaxKeys:     1000,
-			IsTruncated: false,
-			Contents:    entries,
-			KeyCount:    len(entries),
+			Xmlns:          "http://s3.amazonaws.com/doc/2006-03-01/",
+			Name:           bucketKey,
+			Prefix:         prefix,
+			Marker:         marker,
+			NextMarker:     nextMarker,
+			MaxKeys:        maxKeys,
+			Delimiter:      delimiter,
+			IsTruncated:    isTruncated,
+			Contents:       contents,
+			CommonPrefixes: commonPrefixes,
+			KeyCount:       len(contents) + len(commonPrefixes),
+		}
+		c.XML(http.StatusOK, result)
+	}
+}
+
+func ListObjectsV2(bucketRepo *repository.BucketRepository, fileRepo *repository.FileRepository) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		ctx := c.Request.Context()
+		if bucketRepo == nil || fileRepo == nil {
+			c.Status(http.StatusServiceUnavailable)
+			return
+		}
+		bucketKey := c.Param("bucket")
+		bucketDoc, ok := lookupBucket(c, bucketRepo)
+		if !ok {
+			return
+		}
+		maxKeys, ok := parseListMaxKeys(c)
+		if !ok {
+			return
+		}
+		prefix := c.Query("prefix")
+		delimiter := c.Query("delimiter")
+		continuationToken := c.Query("continuation-token")
+		startAfter := c.Query("start-after")
+		after := startAfter
+		if continuationToken != "" {
+			after = continuationToken
+		}
+		files, err := fileRepo.ListByBucketWithPrefix(ctx, bucketDoc.ID, prefix)
+		if err != nil {
+			slog.ErrorContext(ctx, "list objects v2: list files", slog.String("error", err.Error()))
+			writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
+			return
+		}
+		contents, commonPrefixes, isTruncated, nextToken := buildListBucketPage(files, prefix, delimiter, after, maxKeys)
+		result := listBucketResult{
+			Xmlns:                 "http://s3.amazonaws.com/doc/2006-03-01/",
+			Name:                  bucketKey,
+			Prefix:                prefix,
+			MaxKeys:               maxKeys,
+			Delimiter:             delimiter,
+			IsTruncated:           isTruncated,
+			Contents:              contents,
+			CommonPrefixes:        commonPrefixes,
+			KeyCount:              len(contents) + len(commonPrefixes),
+			ContinuationToken:     continuationToken,
+			NextContinuationToken: nextToken,
+			StartAfter:            startAfter,
 		}
 		c.XML(http.StatusOK, result)
 	}

--- a/api-go/internal/handlers/s3_multipart.go
+++ b/api-go/internal/handlers/s3_multipart.go
@@ -175,7 +175,12 @@ func GetObjectOrParts(bucketRepo *repository.BucketRepository, sourceRepo *repos
 // otherwise → ListObjects
 func ListObjectsOrUploads(bucketRepo *repository.BucketRepository, fileRepo *repository.FileRepository, mpRepo *repository.MultipartUploadRepository) gin.HandlerFunc {
 	listHandler := ListObjects(bucketRepo, fileRepo)
+	listV2Handler := ListObjectsV2(bucketRepo, fileRepo)
 	return func(c *gin.Context) {
+		if c.Query("list-type") == "2" {
+			listV2Handler(c)
+			return
+		}
 		if mpRepo != nil {
 			if _, ok := c.GetQuery("uploads"); ok {
 				listMultipartUploads(c, bucketRepo, mpRepo)

--- a/api-go/internal/handlers/s3_multipart.go
+++ b/api-go/internal/handlers/s3_multipart.go
@@ -39,8 +39,8 @@ type completeMultipartUploadResult struct {
 }
 
 type completeMultipartUploadRequest struct {
-	XMLName xml.Name          `xml:"CompleteMultipartUpload"`
-	Parts   []completionPart  `xml:"Part"`
+	XMLName xml.Name         `xml:"CompleteMultipartUpload"`
+	Parts   []completionPart `xml:"Part"`
 }
 
 type completionPart struct {
@@ -49,10 +49,10 @@ type completionPart struct {
 }
 
 type listMultipartUploadsResult struct {
-	XMLName    xml.Name              `xml:"ListMultipartUploadsResult"`
-	Xmlns      string                `xml:"xmlns,attr"`
-	Bucket     string                `xml:"Bucket"`
-	Upload     []multipartUploadXML  `xml:"Upload"`
+	XMLName     xml.Name             `xml:"ListMultipartUploadsResult"`
+	Xmlns       string               `xml:"xmlns,attr"`
+	Bucket      string               `xml:"Bucket"`
+	Upload      []multipartUploadXML `xml:"Upload"`
 	IsTruncated bool                 `xml:"IsTruncated"`
 }
 
@@ -63,13 +63,13 @@ type multipartUploadXML struct {
 }
 
 type listPartsResult struct {
-	XMLName    xml.Name    `xml:"ListPartsResult"`
-	Xmlns      string      `xml:"xmlns,attr"`
-	Bucket     string      `xml:"Bucket"`
-	Key        string      `xml:"Key"`
-	UploadId   string      `xml:"UploadId"`
-	Part       []partXML   `xml:"Part"`
-	IsTruncated bool       `xml:"IsTruncated"`
+	XMLName     xml.Name  `xml:"ListPartsResult"`
+	Xmlns       string    `xml:"xmlns,attr"`
+	Bucket      string    `xml:"Bucket"`
+	Key         string    `xml:"Key"`
+	UploadId    string    `xml:"UploadId"`
+	Part        []partXML `xml:"Part"`
+	IsTruncated bool      `xml:"IsTruncated"`
 }
 
 type partXML struct {
@@ -172,20 +172,21 @@ func GetObjectOrParts(bucketRepo *repository.BucketRepository, sourceRepo *repos
 
 // ListObjectsOrUploads dispatches GET requests on bucket paths.
 // ?uploads → ListMultipartUploads
+// ?list-type=2 → ListObjectsV2
 // otherwise → ListObjects
 func ListObjectsOrUploads(bucketRepo *repository.BucketRepository, fileRepo *repository.FileRepository, mpRepo *repository.MultipartUploadRepository) gin.HandlerFunc {
 	listHandler := ListObjects(bucketRepo, fileRepo)
 	listV2Handler := ListObjectsV2(bucketRepo, fileRepo)
 	return func(c *gin.Context) {
-		if c.Query("list-type") == "2" {
-			listV2Handler(c)
-			return
-		}
 		if mpRepo != nil {
 			if _, ok := c.GetQuery("uploads"); ok {
 				listMultipartUploads(c, bucketRepo, mpRepo)
 				return
 			}
+		}
+		if c.Query("list-type") == "2" {
+			listV2Handler(c)
+			return
 		}
 		listHandler(c)
 	}

--- a/api-go/internal/repository/file.go
+++ b/api-go/internal/repository/file.go
@@ -2,11 +2,13 @@ package repository
 
 import (
 	"context"
+	"regexp"
 	"time"
 
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
 type FileChunk struct {
@@ -35,6 +37,12 @@ func NewFileRepository(db *mongo.Database) (*FileRepository, error) {
 	coll := db.Collection("files")
 	_, err := coll.Indexes().CreateOne(context.Background(), mongo.IndexModel{
 		Keys: bson.D{{Key: "bucket_id", Value: 1}},
+	})
+	if err != nil {
+		return nil, err
+	}
+	_, err = coll.Indexes().CreateOne(context.Background(), mongo.IndexModel{
+		Keys: bson.D{{Key: "bucket_id", Value: 1}, {Key: "name", Value: 1}},
 	})
 	if err != nil {
 		return nil, err
@@ -73,7 +81,15 @@ func (r *FileRepository) GetByName(ctx context.Context, bucketID primitive.Objec
 }
 
 func (r *FileRepository) ListByBucket(ctx context.Context, bucketID primitive.ObjectID) ([]File, error) {
-	cursor, err := r.coll.Find(ctx, bson.M{"bucket_id": bucketID})
+	return r.ListByBucketWithPrefix(ctx, bucketID, "")
+}
+
+func (r *FileRepository) ListByBucketWithPrefix(ctx context.Context, bucketID primitive.ObjectID, prefix string) ([]File, error) {
+	filter := bson.M{"bucket_id": bucketID}
+	if prefix != "" {
+		filter["name"] = bson.M{"$regex": "^" + regexp.QuoteMeta(prefix)}
+	}
+	cursor, err := r.coll.Find(ctx, filter, options.Find().SetSort(bson.D{{Key: "name", Value: 1}}))
 	if err != nil {
 		return nil, err
 	}

--- a/api-go/internal/repository/file.go
+++ b/api-go/internal/repository/file.go
@@ -108,6 +108,48 @@ func (r *FileRepository) ListByBucketWithPrefix(ctx context.Context, bucketID pr
 	return files, nil
 }
 
+func (r *FileRepository) ListByBucketWithPrefixPage(ctx context.Context, bucketID primitive.ObjectID, prefix, after string, limit int) ([]File, bool, error) {
+	filter := bson.M{"bucket_id": bucketID}
+	nameFilter := bson.M{}
+	if prefix != "" {
+		nameFilter["$regex"] = "^" + regexp.QuoteMeta(prefix)
+	}
+	if after != "" {
+		nameFilter["$gt"] = after
+	}
+	if len(nameFilter) > 0 {
+		filter["name"] = nameFilter
+	}
+
+	findOpts := options.Find().SetSort(bson.D{{Key: "name", Value: 1}})
+	if limit >= 0 {
+		findOpts.SetLimit(int64(limit + 1))
+	}
+	cursor, err := r.coll.Find(ctx, filter, findOpts)
+	if err != nil {
+		return nil, false, err
+	}
+	defer func() { _ = cursor.Close(ctx) }()
+
+	files := make([]File, 0, limit)
+	for cursor.Next(ctx) {
+		var f File
+		if err := cursor.Decode(&f); err != nil {
+			return nil, false, err
+		}
+		files = append(files, f)
+	}
+	if err := cursor.Err(); err != nil {
+		return nil, false, err
+	}
+
+	hasMore := limit >= 0 && len(files) > limit
+	if hasMore {
+		files = files[:limit]
+	}
+	return files, hasMore, nil
+}
+
 func (r *FileRepository) Delete(ctx context.Context, id primitive.ObjectID) error {
 	res, err := r.coll.DeleteOne(ctx, bson.M{"_id": id})
 	if err != nil {


### PR DESCRIPTION
## Summary
- Add ListObjectsV2 dispatch for `list-type=2`
- Add prefix, delimiter, marker/start-after/continuation-token pagination support for S3 bucket listing
- Add prefix-filtered, key-sorted file repository listing
- Add S3 E2E coverage for V2 prefix listing, delimiter grouping, pagination, and V1 delimiter compatibility

## Validation
- `git diff --cached --check` before commit
- Local build/test not run per agent resource policy; E2E validation expected in Woodpecker CI

Linked Paperclip issue: THE-6