### PR TITLE
chore: add S3 CI hardening and regression assertions

### DIFF
--- a/.woodpecker/api-go.yml
+++ b/.woodpecker/api-go.yml
@@ -13,6 +13,13 @@ when:
         - api-go/**
 
 steps:
+  - name: dependency and security audit
+    image: golang:1.24
+    commands:
+      - cd api-go
+      - go mod verify
+      - go run golang.org/x/vuln/cmd/govulncheck@latest ./...
+
   - name: unit tests
     image: golang:1.24
     commands:

--- a/.woodpecker/webui.yml
+++ b/.woodpecker/webui.yml
@@ -18,6 +18,7 @@ steps:
     commands:
       - cd webui
       - npm ci --include=dev
+      - npm audit --audit-level=high --omit=dev
       - npm run lint
       - npm run build
 

--- a/api-go/e2e/s3-api-testing-plan.md
+++ b/api-go/e2e/s3-api-testing-plan.md
@@ -1,0 +1,47 @@
+# THE-404: api-go S3/API Testing Plan
+
+**Status date:** 2026-04-21
+
+**Scope:** api-go S3-compatible endpoint behavior and REST-adjacent API side effects.
+
+## Objectives
+
+Issue status: in progress for QA coverage and regression audit.
+
+1. Reduce release risk by pinning S3 API regressions to reproducible scenarios.
+2. Increase confidence in request handling for missing resources and auth edge-cases.
+3. Keep the first pass intentionally narrow and high-signal, then expand to multipart and protocol gaps in subsequent slices.
+
+## Coverage matrix (api-go)
+
+- S3 object lifecycle (Put/Get/Head/Delete/List + auth): partially covered by existing Python and Go e2e suites.
+- Negative paths:
+  - Wrong credentials and unsigned requests.
+  - Missing/non-existent bucket and object behavior.
+  - Empty bucket/list semantics.
+- Multipart coverage: still present via route/dispatch tests and existing end-to-end scenarios.
+
+## Test execution
+
+- **Unit:** `go test ./...` (pre-existing unit/integration coverage)
+- **E2E (current):** `go test -v -tags=e2e ./internal/e2e/...` in `api-go/docker-compose.go-e2e.yml`
+- **Python E2E:** `cd api-go && make test-e2e` (source-type matrix in CI)
+
+## First coverage slice (THIS ISSUE)
+
+- Add Go e2e assertions for API behaviors that are not currently asserted:
+  - DeleteObject on missing key is idempotent (`204`) and does not fail.
+  - ListObjects on a freshly created, empty bucket returns an empty XML result (`KeyCount: 0`).
+  - Requests against non-existent bucket return `NoSuchBucket` XML error.
+  - ListObjects against non-existent bucket returns `NoSuchBucket` XML error (added in follow-up slice).
+  - Empty object path on signed PUT returns `InvalidRequest`.
+  - Object keys containing `//` work end-to-end for PUT/GET/DELETE.
+- Track follow-up slice after merge:
+  - Expand test coverage for error payload assertions (error code/shape consistency).
+
+## Evidence artifact
+
+The implementation for this issue lands in:
+
+- `api-go/internal/e2e/s3_compat_test.go`
+- `api-go/e2e/s3-api-testing-plan.md`

--- a/api-go/internal/e2e/s3_compat_test.go
+++ b/api-go/internal/e2e/s3_compat_test.go
@@ -10,6 +10,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"encoding/xml"
 	"fmt"
 	"io"
 	"net/http"
@@ -550,6 +551,215 @@ func TestS3CompatObjectLifecycle(t *testing.T) {
 	status, _ = s3Do(t, http.MethodGet, s3URL(objectKey), bucket.AccessKey, bucket.AccessSecret, env.Region, nil)
 	if status != http.StatusNotFound {
 		t.Fatalf("GET deleted object: expected 404, got %d", status)
+	}
+}
+
+// TestS3CompatDeleteMissingObjectIsIdempotent verifies repeated DELETE on missing object.
+func TestS3CompatDeleteMissingObjectIsIdempotent(t *testing.T) {
+	env, ok := loadS3E2EEnv()
+	if !ok {
+		t.Skip("E2E_S3_ENDPOINT not set; skipping S3 E2E tests")
+	}
+
+	ts, _ := newTestServer(t)
+	ensureMinIOBucket(t, env)
+
+	suffix := uniqueSuffix()
+	username, password := createTestUser(t, ts, suffix)
+	sourceID := createS3Source(t, ts, username, password, "src-"+suffix, env)
+	bucket := createBucket(t, ts, username, password, "bkt-"+suffix, sourceID)
+
+	t.Cleanup(func() {
+		apiDelete(t, ts, "/api/v1/buckets/"+bucket.ID, username, password)
+		apiDelete(t, ts, "/api/v1/sources/"+sourceID, username, password)
+	})
+
+	missingObjectURL := fmt.Sprintf("%s/api/s3/%s/missing-%s.txt", ts.URL, bucket.Key, suffix)
+
+	status, _ := s3Do(t, http.MethodDelete, missingObjectURL, bucket.AccessKey, bucket.AccessSecret, env.Region, nil)
+	if status != http.StatusNoContent {
+		t.Fatalf("first DELETE missing object: expected 204, got %d", status)
+	}
+
+	status, _ = s3Do(t, http.MethodDelete, missingObjectURL, bucket.AccessKey, bucket.AccessSecret, env.Region, nil)
+	if status != http.StatusNoContent {
+		t.Fatalf("second DELETE missing object: expected 204, got %d", status)
+	}
+}
+
+// TestS3CompatMalformedObjectPathVariants validates malformed object key path handling.
+func TestS3CompatMalformedObjectPathVariants(t *testing.T) {
+	env, ok := loadS3E2EEnv()
+	if !ok {
+		t.Skip("E2E_S3_ENDPOINT not set; skipping S3 E2E tests")
+	}
+
+	ts, _ := newTestServer(t)
+	ensureMinIOBucket(t, env)
+
+	suffix := uniqueSuffix()
+	username, password := createTestUser(t, ts, suffix)
+	sourceID := createS3Source(t, ts, username, password, "src-"+suffix, env)
+	bucket := createBucket(t, ts, username, password, "bkt-"+suffix, sourceID)
+
+	t.Cleanup(func() {
+		apiDelete(t, ts, "/api/v1/buckets/"+bucket.ID, username, password)
+		apiDelete(t, ts, "/api/v1/sources/"+sourceID, username, password)
+	})
+
+	baseURL := fmt.Sprintf("%s/api/s3/%s", ts.URL, bucket.Key)
+
+	// Empty object path should be rejected by signed PUT.
+	emptyObjectURL := baseURL + "/"
+	status, body := s3Do(t, http.MethodPut, emptyObjectURL, bucket.AccessKey, bucket.AccessSecret, env.Region, nil)
+	if status != http.StatusBadRequest {
+		t.Fatalf("empty-object PUT: expected 400, got %d: %s", status, body)
+	}
+	var emptyObjErr s3ErrorXML
+	if err := xml.Unmarshal(body, &emptyObjErr); err != nil {
+		t.Fatalf("decode empty-object PUT error: %v", err)
+	}
+	if emptyObjErr.Code != "InvalidRequest" {
+		t.Fatalf("empty-object PUT: expected InvalidRequest, got %q", emptyObjErr.Code)
+	}
+
+	// Double-slash object key should remain stable for object operations.
+	doubleSlashObject := "folder//nested//object.txt"
+	doubleSlashURL := fmt.Sprintf("%s/%s", baseURL, doubleSlashObject)
+	content := []byte("double slash object content")
+
+	status, body = s3Do(t, http.MethodPut, doubleSlashURL, bucket.AccessKey, bucket.AccessSecret, env.Region, content)
+	if status != http.StatusOK {
+		t.Fatalf("double-slash PUT: expected 200, got %d: %s", status, body)
+	}
+
+	status, body = s3Do(t, http.MethodGet, doubleSlashURL, bucket.AccessKey, bucket.AccessSecret, env.Region, nil)
+	if status != http.StatusOK {
+		t.Fatalf("double-slash GET: expected 200, got %d: %s", status, body)
+	}
+	if !bytes.Equal(body, content) {
+		t.Fatalf("double-slash GET: content mismatch; want %q got %q", content, body)
+	}
+
+	status, body = s3Do(t, http.MethodDelete, doubleSlashURL, bucket.AccessKey, bucket.AccessSecret, env.Region, nil)
+	if status != http.StatusNoContent {
+		t.Fatalf("double-slash DELETE: expected 204, got %d: %s", status, body)
+	}
+}
+
+// listBucketResultXML models the subset of list response needed for KeyCount assertions.
+type listBucketResultXML struct {
+	XMLName  xml.Name `xml:"ListBucketResult"`
+	KeyCount int      `xml:"KeyCount"`
+}
+
+// TestS3CompatListEmptyBucketReturnsZeroKeyCount verifies empty listing semantics.
+func TestS3CompatListEmptyBucketReturnsZeroKeyCount(t *testing.T) {
+	env, ok := loadS3E2EEnv()
+	if !ok {
+		t.Skip("E2E_S3_ENDPOINT not set; skipping S3 E2E tests")
+	}
+
+	ts, _ := newTestServer(t)
+	ensureMinIOBucket(t, env)
+
+	suffix := uniqueSuffix()
+	username, password := createTestUser(t, ts, suffix)
+	sourceID := createS3Source(t, ts, username, password, "src-"+suffix, env)
+	bucket := createBucket(t, ts, username, password, "bkt-"+suffix, sourceID)
+
+	t.Cleanup(func() {
+		apiDelete(t, ts, "/api/v1/buckets/"+bucket.ID, username, password)
+		apiDelete(t, ts, "/api/v1/sources/"+sourceID, username, password)
+	})
+
+	listURL := ts.URL + "/api/s3/" + bucket.Key
+	status, body := s3Do(t, http.MethodGet, listURL, bucket.AccessKey, bucket.AccessSecret, env.Region, nil)
+	if status != http.StatusOK {
+		t.Fatalf("list empty bucket: expected 200, got %d: %s", status, body)
+	}
+
+	var result listBucketResultXML
+	if err := xml.Unmarshal(body, &result); err != nil {
+		t.Fatalf("decode list response: %v", err)
+	}
+	if result.KeyCount != 0 {
+		t.Fatalf("list empty bucket: expected KeyCount 0, got %d", result.KeyCount)
+	}
+}
+
+type s3ErrorXML struct {
+	XMLName xml.Name `xml:"Error"`
+	Code    string   `xml:"Code"`
+}
+
+// TestS3CompatGetFromMissingBucketReturnsNoSuchBucket verifies missing bucket error handling.
+func TestS3CompatGetFromMissingBucketReturnsNoSuchBucket(t *testing.T) {
+	env, ok := loadS3E2EEnv()
+	if !ok {
+		t.Skip("E2E_S3_ENDPOINT not set; skipping S3 E2E tests")
+	}
+
+	ts, _ := newTestServer(t)
+	ensureMinIOBucket(t, env)
+
+	suffix := uniqueSuffix()
+	username, password := createTestUser(t, ts, suffix)
+	sourceID := createS3Source(t, ts, username, password, "src-"+suffix, env)
+	bucket := createBucket(t, ts, username, password, "bkt-"+suffix, sourceID)
+
+	t.Cleanup(func() {
+		apiDelete(t, ts, "/api/v1/buckets/"+bucket.ID, username, password)
+		apiDelete(t, ts, "/api/v1/sources/"+sourceID, username, password)
+	})
+
+	missingBucketURL := fmt.Sprintf("%s/api/s3/%s-does-not-exist/object-%s", ts.URL, bucket.Key, suffix)
+	status, body := s3Do(t, http.MethodGet, missingBucketURL, bucket.AccessKey, bucket.AccessSecret, env.Region, nil)
+	if status != http.StatusNotFound {
+		t.Fatalf("missing bucket: expected 404, got %d", status)
+	}
+
+	var errResp s3ErrorXML
+	if err := xml.Unmarshal(body, &errResp); err != nil {
+		t.Fatalf("decode missing bucket error: %v", err)
+	}
+	if errResp.Code != "NoSuchBucket" {
+		t.Fatalf("missing bucket: expected NoSuchBucket, got %q", errResp.Code)
+	}
+}
+
+// TestS3CompatListMissingBucketReturnsNoSuchBucket verifies list endpoint returns structured S3 errors.
+func TestS3CompatListMissingBucketReturnsNoSuchBucket(t *testing.T) {
+	env, ok := loadS3E2EEnv()
+	if !ok {
+		t.Skip("E2E_S3_ENDPOINT not set; skipping S3 E2E tests")
+	}
+
+	ts, _ := newTestServer(t)
+	ensureMinIOBucket(t, env)
+
+	suffix := uniqueSuffix()
+	username, password := createTestUser(t, ts, suffix)
+	sourceID := createS3Source(t, ts, username, password, "src-"+suffix, env)
+	bucket := createBucket(t, ts, username, password, "bkt-"+suffix, sourceID)
+
+	t.Cleanup(func() {
+		apiDelete(t, ts, "/api/v1/buckets/"+bucket.ID, username, password)
+		apiDelete(t, ts, "/api/v1/sources/"+sourceID, username, password)
+	})
+
+	missingBucketURL := fmt.Sprintf("%s/api/s3/%s-does-not-exist", ts.URL, bucket.Key)
+	status, body := s3Do(t, http.MethodGet, missingBucketURL, bucket.AccessKey, bucket.AccessSecret, env.Region, nil)
+	if status != http.StatusNotFound {
+		t.Fatalf("missing bucket list: expected 404, got %d", status)
+	}
+
+	var errResp s3ErrorXML
+	if err := xml.Unmarshal(body, &errResp); err != nil {
+		t.Fatalf("decode missing bucket list error: %v", err)
+	}
+	if errResp.Code != "NoSuchBucket" {
+		t.Fatalf("missing bucket list: expected NoSuchBucket, got %q", errResp.Code)
 	}
 }
 

--- a/api-go/internal/manager/file_test.go
+++ b/api-go/internal/manager/file_test.go
@@ -115,6 +115,45 @@ func TestUploadFileChunksNoSources(t *testing.T) {
 	}
 }
 
+func TestUploadFileChunksDefaultChunkSize(t *testing.T) {
+	t.Parallel()
+	payload := bytes.Repeat([]byte("x"), 5*1024*1024+123)
+	source := repository.Source{ID: primitive.NewObjectID(), Type: repository.SourceTypeTelegram}
+	for _, tc := range []struct {
+		name      string
+		chunkSize int
+	}{
+		{name: "zero", chunkSize: 0},
+		{name: "negative", chunkSize: -1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			clients := map[primitive.ObjectID]*stubSourceClient{}
+			factory := func(_ context.Context, src *repository.Source) (sourceClient, error) {
+				cli := &stubSourceClient{}
+				clients[src.ID] = cli
+				return cli, nil
+			}
+
+			chunks, err := UploadFileChunksWithStrategy(context.Background(), bytes.NewReader(payload), []repository.Source{source}, tc.chunkSize, factory, &RoundRobinSelector{})
+			if err != nil {
+				t.Fatalf("upload: %v", err)
+			}
+			if len(chunks) != 2 {
+				t.Fatalf("expected 2 chunks from default chunk size fallback, got %d", len(chunks))
+			}
+			if got := len(clients[source.ID].uploaded); got != 2 {
+				t.Fatalf("expected 2 uploads, got %d", got)
+			}
+			if chunks[0].Size != 5*1024*1024 {
+				t.Fatalf("expected first chunk size %d, got %d", 5*1024*1024, chunks[0].Size)
+			}
+			if chunks[1].Size != 123 {
+				t.Fatalf("expected second chunk size 123, got %d", chunks[1].Size)
+			}
+		})
+	}
+}
+
 func TestUploadFileChunksFactoryError(t *testing.T) {
 	t.Parallel()
 	factoryErr := errors.New("factory failed")

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -7,8 +7,8 @@ Actions workflows to this repository.
 
 | Pipeline | Paths | `pull_request` | `push` to `main` | Behavior |
 | --- | --- | --- | --- | --- |
-| `.woodpecker/api-go.yml` | `.woodpecker/api-go.yml`, `api-go/**` | Yes | Yes | Runs Go unit tests plus Python and Go E2E suites against the local S3-compatible MinIO source. Pushes to `main` also publish the backend image. |
-| `.woodpecker/webui.yml` | `.woodpecker/webui.yml`, `webui/**` | Yes | Yes | Runs `npm ci --include=dev`, `npm run lint`, and `npm run build`. Pushes to `main` also publish the frontend image. |
+| `.woodpecker/api-go.yml` | `.woodpecker/api-go.yml`, `api-go/**` | Yes | Yes | Runs dependency/security checks (`go mod verify`, `govulncheck`), unit tests, Python S3 e2e (`E2E_SOURCE_TYPE=s3`), and Go S3 e2e suites. Pushes to `main` also publish the backend image. |
+| `.woodpecker/webui.yml` | `.woodpecker/webui.yml`, `webui/**` | Yes | Yes | Runs `npm ci --include=dev`, `npm audit` (high+ findings fail), `npm run lint`, and `npm run build`. Pushes to `main` also publish the frontend image. |
 
 ## Required Secrets
 


### PR DESCRIPTION
## Summary
- Add dependency and security audit checks to `api-go` CI (`go mod verify`, `govulncheck`).
- Add `npm audit --audit-level=high` to `webui` CI.
- Add Go S3 e2e coverage for empty/error edge cases (missing objects, malformed keys, missing buckets).
- Add a focused unit test validating `UploadFileChunksWithStrategy` fallback chunk-size behavior.
- Add an internal S3 API testing plan document for follow-up coverage.
- Update `docs/ci.md` with the new pipeline behavior.

## Scope
- Files changed: `.woodpecker/api-go.yml`, `.woodpecker/webui.yml`, `api-go/internal/e2e/s3_compat_test.go`, `api-go/internal/manager/file_test.go`, `api-go/e2e/s3-api-testing-plan.md`, `docs/ci.md`.

## Validation
- No local Docker/Compose/Playwright runs were executed (resource-policy aligned).
- Changes intentionally target CI and tests; review in Woodpecker CI.

## Notes
- No endpoint changes were made in this slice, so `internal/docs/docs.go` was not regenerated.
- This branch was created to decouple repo-state sweep work from `THE-366/webui-lockfile-fix`.