### PR TITLE
THE-13: Update launch caveats and v0.1.0 docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ backend, frontend, CLI, and infrastructure into a single versioned artifact.
   distributing chunks across sources per bucket.
 - **GitHub OAuth** — authenticate via GitHub in addition to HTTP Basic Auth.
   JWT-based token login for API and CLI use.
+- **Rate limiting** — API traffic can be limited to reduce accidental or
+  abusive request volume.
 - **Error messages and UX feedback** — toast notifications, loading spinners,
   and empty states across the web UI.
 
@@ -42,5 +44,4 @@ backend, frontend, CLI, and infrastructure into a single versioned artifact.
 - No chunk redundancy or erasure coding — losing an upstream source means data
   loss for chunks stored there.
 - Auth and credential handling are functional but not production-hardened.
-- No rate limiting (planned for a future release).
 - Single-node deployment only.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,19 @@ pool free-tier and personal storage services into one namespace.
 chunks, provide erasure coding, or guarantee durability if an upstream source
 disappears. See [Launch Caveats](#launch-caveats) for the full picture.
 
+## Features
+
+- **Multi-backend buckets** backed by Google Drive, Telegram, and
+  S3-compatible storage sources.
+- **Browser UI, REST API, CLI, and S3-compatible endpoint** for managing
+  sources, buckets, objects, and generated S3 credentials.
+- **RBAC and bucket sharing** for scoped access to stored objects.
+- **Multipart upload and presigned URLs** for S3-compatible client workflows.
+- **Source failover** during object reads when a configured source is
+  temporarily unavailable.
+- **Rate limiting** on API traffic.
+- **Credential encryption** for stored upstream source secrets.
+
 ## Supported Storage Backends
 
 | Backend | API | Browser UI | Notes |
@@ -242,9 +255,8 @@ SFree is an early-stage project. These constraints are current and intentional:
 
 - **No redundancy.** Chunks are distributed, not replicated. Losing an upstream
   source can make files unrecoverable.
-- **Basic auth only.** The API uses HTTP Basic Auth. The browser UI stores
-  credentials in `localStorage`. Source API responses echo stored credential
-  payloads.
+- **Authentication is still early.** The API supports HTTP Basic Auth and OAuth,
+  but auth flows and browser token storage are not production-hardened.
 - **Uneven observability.** Google Drive sources expose the richest file and
   quota info. Telegram and S3-compatible sources return less metadata.
 


### PR DESCRIPTION
## Summary
- Replace the stale basic-auth-only launch caveat with current Basic Auth/OAuth wording.
- Add the shipped v0.1.0 README feature coverage for RBAC/bucket sharing, multipart upload, source failover, presigned URLs, rate limiting, and credential encryption.
- Move rate limiting out of changelog known limitations and into shipped features.

## Validation
- `git diff --check -- README.md CHANGELOG.md`

## Issue
- THE-13