### PR TITLE
THE-9: Add S3 GetObject range support

### DIFF
--- a/api-go/internal/e2e/s3_compat_test.go
+++ b/api-go/internal/e2e/s3_compat_test.go
@@ -17,6 +17,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -617,9 +618,15 @@ func TestS3CompatGetObjectRange(t *testing.T) {
 		t.Fatalf("GET suffix range mismatch: status=%d body=%q", status, body)
 	}
 
-	status, _, body = s3DoWithHeaders(t, http.MethodGet, s3URL, bucket.AccessKey, bucket.AccessSecret, env.Region, nil, map[string]string{"Range": "bytes=30-40"})
+	status, headers, body = s3DoWithHeaders(t, http.MethodGet, s3URL, bucket.AccessKey, bucket.AccessSecret, env.Region, nil, map[string]string{"Range": "bytes=30-40"})
 	if status != http.StatusRequestedRangeNotSatisfiable {
 		t.Fatalf("GET invalid range: expected 416, got %d: %s", status, body)
+	}
+	if got, want := headers.Get("Content-Range"), "bytes */26"; got != want {
+		t.Fatalf("GET invalid range Content-Range mismatch: got %q, want %q", got, want)
+	}
+	if got := headers.Get("Content-Length"); got == strconv.Itoa(len(objectContent)) {
+		t.Fatalf("GET invalid range must not reuse object Content-Length %q", got)
 	}
 
 	status, headers, body = s3DoWithHeaders(t, http.MethodGet, s3URL, bucket.AccessKey, bucket.AccessSecret, env.Region, nil, nil)

--- a/api-go/internal/e2e/s3_compat_test.go
+++ b/api-go/internal/e2e/s3_compat_test.go
@@ -374,6 +374,11 @@ func s3EncodePath(path string) string {
 
 // s3Do makes a signed S3 request and returns status code + body.
 func s3Do(t *testing.T, method, rawURL, accessKey, secretKey, region string, body []byte) (int, []byte) {
+	status, _, respBody := s3DoWithHeaders(t, method, rawURL, accessKey, secretKey, region, body, nil)
+	return status, respBody
+}
+
+func s3DoWithHeaders(t *testing.T, method, rawURL, accessKey, secretKey, region string, body []byte, headers map[string]string) (int, http.Header, []byte) {
 	t.Helper()
 	var reqBody io.Reader
 	if len(body) > 0 {
@@ -382,6 +387,9 @@ func s3Do(t *testing.T, method, rawURL, accessKey, secretKey, region string, bod
 	req, err := http.NewRequest(method, rawURL, reqBody)
 	if err != nil {
 		t.Fatalf("s3Do new request: %v", err)
+	}
+	for key, value := range headers {
+		req.Header.Set(key, value)
 	}
 	if err := signS3Request(req, accessKey, secretKey, region); err != nil {
 		t.Fatalf("s3Do sign request: %v", err)
@@ -392,7 +400,7 @@ func s3Do(t *testing.T, method, rawURL, accessKey, secretKey, region string, bod
 	}
 	defer resp.Body.Close()
 	respBody, _ := io.ReadAll(resp.Body)
-	return resp.StatusCode, respBody
+	return resp.StatusCode, resp.Header.Clone(), respBody
 }
 
 // uniqueSuffix returns a short timestamp-based string for naming test resources.
@@ -551,6 +559,78 @@ func TestS3CompatObjectLifecycle(t *testing.T) {
 	status, _ = s3Do(t, http.MethodGet, s3URL(objectKey), bucket.AccessKey, bucket.AccessSecret, env.Region, nil)
 	if status != http.StatusNotFound {
 		t.Fatalf("GET deleted object: expected 404, got %d", status)
+	}
+}
+
+func TestS3CompatGetObjectRange(t *testing.T) {
+	env, ok := loadS3E2EEnv()
+	if !ok {
+		t.Skip("E2E_S3_ENDPOINT not set; skipping S3 E2E tests")
+	}
+
+	ts, _ := newTestServer(t)
+	ensureMinIOBucket(t, env)
+
+	suffix := uniqueSuffix()
+	username, password := createTestUser(t, ts, suffix)
+	sourceID := createS3Source(t, ts, username, password, "src-"+suffix, env)
+	bucket := createBucket(t, ts, username, password, "bkt-"+suffix, sourceID)
+
+	t.Cleanup(func() {
+		apiDelete(t, ts, "/api/v1/buckets/"+bucket.ID, username, password)
+		apiDelete(t, ts, "/api/v1/sources/"+sourceID, username, password)
+	})
+
+	objectKey := "range-" + suffix + ".txt"
+	objectContent := []byte("abcdefghijklmnopqrstuvwxyz")
+	s3URL := fmt.Sprintf("%s/api/s3/%s/%s", ts.URL, bucket.Key, objectKey)
+
+	status, body := s3Do(t, http.MethodPut, s3URL, bucket.AccessKey, bucket.AccessSecret, env.Region, objectContent)
+	if status != http.StatusOK {
+		t.Fatalf("PUT object: expected 200, got %d: %s", status, body)
+	}
+	t.Cleanup(func() {
+		s3Do(t, http.MethodDelete, s3URL, bucket.AccessKey, bucket.AccessSecret, env.Region, nil)
+	})
+
+	status, headers, body := s3DoWithHeaders(t, http.MethodGet, s3URL, bucket.AccessKey, bucket.AccessSecret, env.Region, nil, map[string]string{"Range": "bytes=0-4"})
+	if status != http.StatusPartialContent {
+		t.Fatalf("GET range 0-4: expected 206, got %d: %s", status, body)
+	}
+	if got, want := string(body), "abcde"; got != want {
+		t.Fatalf("GET range 0-4 body mismatch: got %q, want %q", got, want)
+	}
+	if got, want := headers.Get("Content-Range"), "bytes 0-4/26"; got != want {
+		t.Fatalf("GET range 0-4 Content-Range mismatch: got %q, want %q", got, want)
+	}
+	if got := headers.Get("Accept-Ranges"); got != "bytes" {
+		t.Fatalf("GET range 0-4 Accept-Ranges mismatch: got %q", got)
+	}
+
+	status, _, body = s3DoWithHeaders(t, http.MethodGet, s3URL, bucket.AccessKey, bucket.AccessSecret, env.Region, nil, map[string]string{"Range": "bytes=20-"})
+	if status != http.StatusPartialContent || string(body) != "uvwxyz" {
+		t.Fatalf("GET open-ended range mismatch: status=%d body=%q", status, body)
+	}
+
+	status, _, body = s3DoWithHeaders(t, http.MethodGet, s3URL, bucket.AccessKey, bucket.AccessSecret, env.Region, nil, map[string]string{"Range": "bytes=-3"})
+	if status != http.StatusPartialContent || string(body) != "xyz" {
+		t.Fatalf("GET suffix range mismatch: status=%d body=%q", status, body)
+	}
+
+	status, _, body = s3DoWithHeaders(t, http.MethodGet, s3URL, bucket.AccessKey, bucket.AccessSecret, env.Region, nil, map[string]string{"Range": "bytes=30-40"})
+	if status != http.StatusRequestedRangeNotSatisfiable {
+		t.Fatalf("GET invalid range: expected 416, got %d: %s", status, body)
+	}
+
+	status, headers, body = s3DoWithHeaders(t, http.MethodGet, s3URL, bucket.AccessKey, bucket.AccessSecret, env.Region, nil, nil)
+	if status != http.StatusOK {
+		t.Fatalf("GET full object: expected 200, got %d: %s", status, body)
+	}
+	if !bytes.Equal(body, objectContent) {
+		t.Fatalf("GET full object body mismatch: got %q", body)
+	}
+	if got := headers.Get("Accept-Ranges"); got != "bytes" {
+		t.Fatalf("GET full object Accept-Ranges mismatch: got %q", got)
 	}
 }
 

--- a/api-go/internal/handlers/s3.go
+++ b/api-go/internal/handlers/s3.go
@@ -422,9 +422,9 @@ func GetObject(bucketRepo *repository.BucketRepository, sourceRepo *repository.S
 		if !ok {
 			return
 		}
-		setObjectHeaders(c, fileDoc, total)
 		rangeHeader := c.GetHeader("Range")
 		if rangeHeader == "" {
+			setObjectHeaders(c, fileDoc, total)
 			c.Status(http.StatusOK)
 			if err := manager.StreamFile(c.Request.Context(), sourceRepo, fileDoc, c.Writer); err != nil {
 				slog.ErrorContext(c.Request.Context(), "get object: stream failed", slog.String("error", err.Error()))
@@ -434,10 +434,12 @@ func GetObject(bucketRepo *repository.BucketRepository, sourceRepo *repository.S
 
 		objRange, ok := parseObjectRange(rangeHeader, total)
 		if !ok {
+			c.Header("Accept-Ranges", "bytes")
 			c.Header("Content-Range", "bytes */"+strconv.FormatInt(total, 10))
 			writeS3Error(c, http.StatusRequestedRangeNotSatisfiable, "InvalidRange", "The requested range is not satisfiable")
 			return
 		}
+		setObjectHeaders(c, fileDoc, total)
 		c.Header("Content-Length", strconv.FormatInt(objRange.end-objRange.start+1, 10))
 		c.Header("Content-Range", "bytes "+strconv.FormatInt(objRange.start, 10)+"-"+strconv.FormatInt(objRange.end, 10)+"/"+strconv.FormatInt(total, 10))
 		c.Status(http.StatusPartialContent)

--- a/api-go/internal/handlers/s3.go
+++ b/api-go/internal/handlers/s3.go
@@ -61,6 +61,11 @@ type listBucketPageItem struct {
 	commonPrefix string
 }
 
+type objectRange struct {
+	start int64
+	end   int64
+}
+
 const listCommonPrefixSkipSuffix = "\U0010FFFF"
 
 func writeS3Error(c *gin.Context, status int, code, message string) {
@@ -110,6 +115,46 @@ func fileListBucketEntry(file repository.File) listBucketEntry {
 		Size:         size,
 		StorageClass: "STANDARD",
 	}
+}
+
+func parseObjectRange(raw string, total int64) (objectRange, bool) {
+	if raw == "" {
+		return objectRange{}, false
+	}
+	if total <= 0 || !strings.HasPrefix(raw, "bytes=") || strings.Contains(raw, ",") {
+		return objectRange{}, false
+	}
+	spec := strings.TrimPrefix(raw, "bytes=")
+	parts := strings.SplitN(spec, "-", 2)
+	if len(parts) != 2 {
+		return objectRange{}, false
+	}
+	if parts[0] == "" {
+		suffixLen, err := strconv.ParseInt(parts[1], 10, 64)
+		if err != nil || suffixLen <= 0 {
+			return objectRange{}, false
+		}
+		if suffixLen >= total {
+			return objectRange{start: 0, end: total - 1}, true
+		}
+		return objectRange{start: total - suffixLen, end: total - 1}, true
+	}
+
+	start, err := strconv.ParseInt(parts[0], 10, 64)
+	if err != nil || start < 0 || start >= total {
+		return objectRange{}, false
+	}
+	end := total - 1
+	if parts[1] != "" {
+		end, err = strconv.ParseInt(parts[1], 10, 64)
+		if err != nil || end < start {
+			return objectRange{}, false
+		}
+		if end >= total {
+			end = total - 1
+		}
+	}
+	return objectRange{start: start, end: end}, true
 }
 
 func buildListBucketPage(ctx context.Context, fileRepo *repository.FileRepository, bucketID primitive.ObjectID, prefix, delimiter, after string, maxKeys int) ([]listBucketEntry, []listCommonPrefix, bool, string, error) {
@@ -326,6 +371,7 @@ func lookupObject(c *gin.Context, bucketRepo *repository.BucketRepository, fileR
 // setObjectHeaders writes standard S3 object headers (ETag, Last-Modified,
 // Content-Length, Content-Type).
 func setObjectHeaders(c *gin.Context, fileDoc *repository.File, total int64) {
+	c.Header("Accept-Ranges", "bytes")
 	c.Header("ETag", objectETag(*fileDoc))
 	c.Header("Last-Modified", fileDoc.CreatedAt.UTC().Format(http.TimeFormat))
 	c.Header("Content-Length", strconv.FormatInt(total, 10))
@@ -377,8 +423,25 @@ func GetObject(bucketRepo *repository.BucketRepository, sourceRepo *repository.S
 			return
 		}
 		setObjectHeaders(c, fileDoc, total)
-		c.Status(http.StatusOK)
-		if err := manager.StreamFile(c.Request.Context(), sourceRepo, fileDoc, c.Writer); err != nil {
+		rangeHeader := c.GetHeader("Range")
+		if rangeHeader == "" {
+			c.Status(http.StatusOK)
+			if err := manager.StreamFile(c.Request.Context(), sourceRepo, fileDoc, c.Writer); err != nil {
+				slog.ErrorContext(c.Request.Context(), "get object: stream failed", slog.String("error", err.Error()))
+			}
+			return
+		}
+
+		objRange, ok := parseObjectRange(rangeHeader, total)
+		if !ok {
+			c.Header("Content-Range", "bytes */"+strconv.FormatInt(total, 10))
+			writeS3Error(c, http.StatusRequestedRangeNotSatisfiable, "InvalidRange", "The requested range is not satisfiable")
+			return
+		}
+		c.Header("Content-Length", strconv.FormatInt(objRange.end-objRange.start+1, 10))
+		c.Header("Content-Range", "bytes "+strconv.FormatInt(objRange.start, 10)+"-"+strconv.FormatInt(objRange.end, 10)+"/"+strconv.FormatInt(total, 10))
+		c.Status(http.StatusPartialContent)
+		if err := manager.StreamFileRange(c.Request.Context(), sourceRepo, fileDoc, c.Writer, objRange.start, objRange.end); err != nil {
 			slog.ErrorContext(c.Request.Context(), "get object: stream failed", slog.String("error", err.Error()))
 		}
 	}

--- a/api-go/internal/manager/file.go
+++ b/api-go/internal/manager/file.go
@@ -155,6 +155,17 @@ func StreamFile(ctx context.Context, srcRepo *repository.SourceRepository, f *re
 	return streamFileWithFactory(ctx, f, w, factory)
 }
 
+func StreamFileRange(ctx context.Context, srcRepo *repository.SourceRepository, f *repository.File, w io.Writer, start, end int64) error {
+	factory := func(ctx context.Context, src *repository.Source) (sourceClient, error) {
+		fullSrc, err := srcRepo.GetByID(ctx, src.ID)
+		if err != nil {
+			return nil, err
+		}
+		return NewSourceClient(ctx, fullSrc)
+	}
+	return streamFileRangeWithFactory(ctx, f, w, start, end, factory)
+}
+
 // streamFileWithFactory is the testable core of StreamFile. The factory receives
 // a Source stub containing only the SourceID; it is responsible for resolving the
 // full source configuration and returning a ready client.
@@ -233,6 +244,115 @@ func streamFileWithFactory(ctx context.Context, f *repository.File, w io.Writer,
 	return nil
 }
 
+func streamFileRangeWithFactory(ctx context.Context, f *repository.File, w io.Writer, start, end int64, factory SourceClientFactory) error {
+	ctx, span := tracer.Start(ctx, "StreamFileRange",
+		trace.WithAttributes(
+			attribute.String("file.id", f.ID.Hex()),
+			attribute.Int("file.chunks", len(f.Chunks)),
+			attribute.Int64("range.start", start),
+			attribute.Int64("range.end", end),
+		),
+	)
+	defer span.End()
+
+	clients := make(map[primitive.ObjectID]sourceClient)
+	var offset int64
+	for i, ch := range f.Chunks {
+		chunkStart := offset
+		chunkEnd := offset + ch.Size - 1
+		offset += ch.Size
+		if ch.Size <= 0 || end < chunkStart {
+			break
+		}
+		if start > chunkEnd {
+			continue
+		}
+
+		localStart := maxInt64(0, start-chunkStart)
+		localEnd := minInt64(ch.Size-1, end-chunkStart)
+		if localEnd < localStart {
+			continue
+		}
+
+		cli, ok := clients[ch.SourceID]
+		if !ok {
+			var err error
+			cli, err = factory(ctx, &repository.Source{ID: ch.SourceID})
+			if err != nil {
+				span.RecordError(err)
+				span.SetStatus(codes.Error, "client creation failed")
+				return err
+			}
+			clients[ch.SourceID] = cli
+		}
+
+		_, chunkSpan := tracer.Start(ctx, "DownloadChunkRange",
+			trace.WithAttributes(
+				attribute.Int("chunk.order", i),
+				attribute.String("chunk.source_id", ch.SourceID.Hex()),
+				attribute.Int64("chunk.range_start", localStart),
+				attribute.Int64("chunk.range_end", localEnd),
+			),
+		)
+		rc, err := cli.Download(ctx, ch.Name)
+		if err != nil {
+			chunkSpan.RecordError(err)
+			chunkSpan.SetStatus(codes.Error, "download failed")
+			chunkSpan.End()
+			span.RecordError(err)
+			span.SetStatus(codes.Error, "chunk download failed")
+			return err
+		}
+
+		if ch.Checksum != "" {
+			chunkData, err := readChecksummedChunk(rc, ch, i)
+			_ = rc.Close()
+			if err != nil {
+				chunkSpan.RecordError(err)
+				chunkSpan.SetStatus(codes.Error, "read failed")
+				chunkSpan.End()
+				span.RecordError(err)
+				span.SetStatus(codes.Error, "chunk read failed")
+				return err
+			}
+			if _, err = w.Write(chunkData[localStart : localEnd+1]); err != nil {
+				chunkSpan.RecordError(err)
+				chunkSpan.SetStatus(codes.Error, "write failed")
+				chunkSpan.End()
+				span.RecordError(err)
+				span.SetStatus(codes.Error, "chunk write failed")
+				return err
+			}
+			chunkSpan.End()
+			continue
+		}
+
+		if localStart > 0 {
+			if _, err = io.CopyN(io.Discard, rc, localStart); err != nil {
+				_ = rc.Close()
+				chunkSpan.RecordError(err)
+				chunkSpan.SetStatus(codes.Error, "seek failed")
+				chunkSpan.End()
+				span.RecordError(err)
+				span.SetStatus(codes.Error, "chunk seek failed")
+				return err
+			}
+		}
+		if _, err = io.CopyN(w, rc, localEnd-localStart+1); err != nil {
+			_ = rc.Close()
+			chunkSpan.RecordError(err)
+			chunkSpan.SetStatus(codes.Error, "copy failed")
+			chunkSpan.End()
+			span.RecordError(err)
+			span.SetStatus(codes.Error, "chunk copy failed")
+			return err
+		}
+		_ = rc.Close()
+		chunkSpan.End()
+	}
+	return nil
+}
+
 func readChecksummedChunk(r io.Reader, ch repository.FileChunk, order int) ([]byte, error) {
 	if ch.Size < 0 {
 		return nil, fmt.Errorf("%w: chunk %d invalid size", ErrChecksumMismatch, order)
@@ -249,6 +369,20 @@ func readChecksummedChunk(r io.Reader, ch repository.FileChunk, order int) ([]by
 		return nil, fmt.Errorf("%w: chunk %d", ErrChecksumMismatch, order)
 	}
 	return data, nil
+}
+
+func minInt64(a, b int64) int64 {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func maxInt64(a, b int64) int64 {
+	if a > b {
+		return a
+	}
+	return b
 }
 
 func DeleteFileChunks(ctx context.Context, srcRepo *repository.SourceRepository, chunks []repository.FileChunk) error {

--- a/api-go/internal/manager/file_test.go
+++ b/api-go/internal/manager/file_test.go
@@ -555,3 +555,54 @@ func TestStreamFileNoChecksumSkipsVerification(t *testing.T) {
 		t.Fatalf("unexpected output: %q", buf.Bytes())
 	}
 }
+
+func TestStreamFileRangeAcrossChunks(t *testing.T) {
+	t.Parallel()
+	srcID := primitive.NewObjectID()
+	chunks := []repository.FileChunk{
+		{SourceID: srcID, Name: "chunk0", Order: 0, Size: 5},
+		{SourceID: srcID, Name: "chunk1", Order: 1, Size: 5},
+		{SourceID: srcID, Name: "chunk2", Order: 2, Size: 5},
+	}
+	f := &repository.File{Chunks: chunks}
+
+	var buf bytes.Buffer
+	err := streamFileRangeWithFactory(context.Background(), f, &buf, 3, 11, func(_ context.Context, _ *repository.Source) (sourceClient, error) {
+		return &fixedDownloadClient{data: map[string][]byte{
+			"chunk0": []byte("abcde"),
+			"chunk1": []byte("fghij"),
+			"chunk2": []byte("klmno"),
+		}}, nil
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if got, want := buf.String(), "defghijkl"; got != want {
+		t.Fatalf("range output mismatch: got %q, want %q", got, want)
+	}
+}
+
+func TestStreamFileRangeVerifiesChecksummedChunk(t *testing.T) {
+	t.Parallel()
+	payload := []byte("abcdefghij")
+	sum := sha256.Sum256(payload)
+	chunk := repository.FileChunk{
+		SourceID: primitive.NewObjectID(),
+		Name:     "chunk0",
+		Order:    0,
+		Size:     int64(len(payload)),
+		Checksum: hex.EncodeToString(sum[:]),
+	}
+	f := &repository.File{Chunks: []repository.FileChunk{chunk}}
+
+	var buf bytes.Buffer
+	err := streamFileRangeWithFactory(context.Background(), f, &buf, 2, 6, func(_ context.Context, _ *repository.Source) (sourceClient, error) {
+		return &fixedDownloadClient{data: map[string][]byte{"chunk0": payload}}, nil
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if got, want := buf.String(), "cdefg"; got != want {
+		t.Fatalf("range output mismatch: got %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

Adds single-range HTTP `Range` support for S3 `GetObject`, including partial content headers and chunk-aware range streaming.

## Linked Issue

THE-9

## What Changed

- Parse and validate `Range: bytes=...` in the S3 `GetObject` handler.
- Return `206 Partial Content` with `Content-Range` and partial `Content-Length` for valid single ranges.
- Return `416 InvalidRange` for malformed or unsatisfiable ranges.
- Add `Accept-Ranges: bytes` to S3 GET and HEAD object responses.
- Add manager range streaming across chunk boundaries while preserving checksum validation for checksummed chunks.
- Add focused manager coverage and S3 compat E2E coverage for fixed, open-ended, suffix, invalid, and full-object GET cases.

## Validation

- tests run: not run locally per SFree resource policy; Go/unit/e2e validation should run in Woodpecker.
- manual checks: branch based on latest `origin/main`; touched files limited to `api-go/internal/handlers/s3.go`, `api-go/internal/manager/file.go`, `api-go/internal/manager/file_test.go`, and `api-go/internal/e2e/s3_compat_test.go`; `gofmt` applied to touched Go files.

## Docs Impact

- [x] no docs change needed
- [ ] docs updated in this PR
- [ ] follow-up docs issue needed