### PR TITLE
test: add S3 multipart E2E coverage

### DIFF
--- a/api-go/internal/e2e/s3_compat_test.go
+++ b/api-go/internal/e2e/s3_compat_test.go
@@ -101,6 +101,44 @@ func ensureMinIOBucket(t *testing.T, env s3E2EEnv) {
 	}
 }
 
+func listS3SourceObjectKeys(t *testing.T, env s3E2EEnv) map[string]struct{} {
+	t.Helper()
+
+	ctx := context.Background()
+	awsCfg, err := awsconfig.LoadDefaultConfig(ctx,
+		awsconfig.WithRegion(env.Region),
+		awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(env.AccessKeyID, env.SecretKey, "")),
+	)
+	if err != nil {
+		t.Fatalf("list source objects: load aws config: %v", err)
+	}
+	client := awss3.NewFromConfig(awsCfg, func(opts *awss3.Options) {
+		opts.BaseEndpoint = aws.String(env.Endpoint)
+		opts.UsePathStyle = env.PathStyle
+	})
+
+	keys := map[string]struct{}{}
+	var continuation *string
+	for {
+		out, err := client.ListObjectsV2(ctx, &awss3.ListObjectsV2Input{
+			Bucket:            aws.String(env.Bucket),
+			ContinuationToken: continuation,
+		})
+		if err != nil {
+			t.Fatalf("list source objects: %v", err)
+		}
+		for _, object := range out.Contents {
+			if object.Key != nil {
+				keys[*object.Key] = struct{}{}
+			}
+		}
+		if out.NextContinuationToken == nil {
+			return keys
+		}
+		continuation = out.NextContinuationToken
+	}
+}
+
 // newTestServer connects to MongoDB (with retry) and starts an httptest server.
 func newTestServer(t *testing.T) (*httptest.Server, *appconfig.Config) {
 	t.Helper()
@@ -409,6 +447,38 @@ func uniqueSuffix() string {
 	return fmt.Sprintf("%d", time.Now().UnixNano())
 }
 
+func setupS3CompatTest(t *testing.T, env s3E2EEnv, suffix string) (*httptest.Server, createBucketResult) {
+	t.Helper()
+
+	ts, _ := newTestServer(t)
+	ensureMinIOBucket(t, env)
+
+	username, password := createTestUser(t, ts, suffix)
+	sourceID := createS3Source(t, ts, username, password, "src-"+suffix, env)
+	bucket := createBucket(t, ts, username, password, "bkt-"+suffix, sourceID)
+
+	t.Cleanup(func() {
+		apiDelete(t, ts, "/api/v1/buckets/"+bucket.ID, username, password)
+		apiDelete(t, ts, "/api/v1/sources/"+sourceID, username, password)
+	})
+
+	return ts, bucket
+}
+
+func assertS3Error(t *testing.T, body []byte, wantCode string) {
+	t.Helper()
+
+	var result struct {
+		Code string `xml:"Code"`
+	}
+	if err := xml.Unmarshal(body, &result); err != nil {
+		t.Fatalf("decode S3 error: %v body=%s", err, body)
+	}
+	if result.Code != wantCode {
+		t.Fatalf("S3 error code mismatch: got %q, want %q body=%s", result.Code, wantCode, body)
+	}
+}
+
 // TestS3CompatSourceAndBucketCreation tests source/bucket CRUD plus the
 // deletion-blocked-by-bucket constraint.
 func TestS3CompatSourceAndBucketCreation(t *testing.T) {
@@ -639,6 +709,189 @@ func TestS3CompatGetObjectRange(t *testing.T) {
 	if got := headers.Get("Accept-Ranges"); got != "bytes" {
 		t.Fatalf("GET full object Accept-Ranges mismatch: got %q", got)
 	}
+}
+
+func TestS3CompatMultipartUploadLifecycle(t *testing.T) {
+	env, ok := loadS3E2EEnv()
+	if !ok {
+		t.Skip("E2E_S3_ENDPOINT not set; skipping S3 E2E tests")
+	}
+
+	suffix := uniqueSuffix()
+	ts, bucket := setupS3CompatTest(t, env, suffix)
+	s3URL := func(key string, params url.Values) string {
+		rawURL := fmt.Sprintf("%s/api/s3/%s/%s", ts.URL, bucket.Key, key)
+		if len(params) > 0 {
+			rawURL += "?" + params.Encode()
+		}
+		return rawURL
+	}
+
+	objectKey := "multipart-" + suffix + ".txt"
+	createURL := s3URL(objectKey, url.Values{"uploads": {""}})
+	status, body := s3Do(t, http.MethodPost, createURL, bucket.AccessKey, bucket.AccessSecret, env.Region, nil)
+	if status != http.StatusOK {
+		t.Fatalf("CreateMultipartUpload: expected 200, got %d: %s", status, body)
+	}
+	var createResult struct {
+		UploadID string `xml:"UploadId"`
+	}
+	if err := xml.Unmarshal(body, &createResult); err != nil || createResult.UploadID == "" {
+		t.Fatalf("CreateMultipartUpload decode: uploadId=%q err=%v body=%s", createResult.UploadID, err, body)
+	}
+
+	partURL := func(uploadID string, partNumber int) string {
+		return s3URL(objectKey, url.Values{
+			"partNumber": {strconv.Itoa(partNumber)},
+			"uploadId":   {uploadID},
+		})
+	}
+	part1Original := []byte("part-one-original")
+	status, headers, body := s3DoWithHeaders(t, http.MethodPut, partURL(createResult.UploadID, 1), bucket.AccessKey, bucket.AccessSecret, env.Region, part1Original, nil)
+	if status != http.StatusOK {
+		t.Fatalf("UploadPart original part 1: expected 200, got %d: %s", status, body)
+	}
+	part1OriginalETag := headers.Get("ETag")
+	if part1OriginalETag == "" {
+		t.Fatal("UploadPart original part 1: missing ETag")
+	}
+
+	part1Replacement := []byte("part-one-replacement")
+	status, headers, body = s3DoWithHeaders(t, http.MethodPut, partURL(createResult.UploadID, 1), bucket.AccessKey, bucket.AccessSecret, env.Region, part1Replacement, nil)
+	if status != http.StatusOK {
+		t.Fatalf("UploadPart replacement part 1: expected 200, got %d: %s", status, body)
+	}
+	part1ETag := headers.Get("ETag")
+	if part1ETag == "" {
+		t.Fatal("UploadPart replacement part 1: missing ETag")
+	}
+	if part1ETag == part1OriginalETag {
+		t.Fatalf("UploadPart replacement part 1: ETag did not change after re-upload: %s", part1ETag)
+	}
+
+	part2 := []byte("part-two")
+	status, headers, body = s3DoWithHeaders(t, http.MethodPut, partURL(createResult.UploadID, 2), bucket.AccessKey, bucket.AccessSecret, env.Region, part2, nil)
+	if status != http.StatusOK {
+		t.Fatalf("UploadPart part 2: expected 200, got %d: %s", status, body)
+	}
+	part2ETag := headers.Get("ETag")
+	if part2ETag == "" {
+		t.Fatal("UploadPart part 2: missing ETag")
+	}
+
+	listPartsURL := s3URL(objectKey, url.Values{"uploadId": {createResult.UploadID}})
+	status, body = s3Do(t, http.MethodGet, listPartsURL, bucket.AccessKey, bucket.AccessSecret, env.Region, nil)
+	if status != http.StatusOK {
+		t.Fatalf("ListParts: expected 200, got %d: %s", status, body)
+	}
+	var partsResult struct {
+		Parts []struct {
+			PartNumber int    `xml:"PartNumber"`
+			ETag       string `xml:"ETag"`
+			Size       int64  `xml:"Size"`
+		} `xml:"Part"`
+	}
+	if err := xml.Unmarshal(body, &partsResult); err != nil {
+		t.Fatalf("ListParts decode: %v body=%s", err, body)
+	}
+	if len(partsResult.Parts) != 2 {
+		t.Fatalf("ListParts: expected 2 parts, got %d: %+v", len(partsResult.Parts), partsResult.Parts)
+	}
+	expectedParts := []struct {
+		number int
+		size   int64
+		etag   string
+	}{
+		{number: 1, size: int64(len(part1Replacement)), etag: part1ETag},
+		{number: 2, size: int64(len(part2)), etag: part2ETag},
+	}
+	for i, want := range expectedParts {
+		got := partsResult.Parts[i]
+		if got.PartNumber != want.number || got.Size != want.size || got.ETag != want.etag {
+			t.Fatalf("ListParts part %d mismatch: got number=%d size=%d etag=%q, want number=%d size=%d etag=%q",
+				i, got.PartNumber, got.Size, got.ETag, want.number, want.size, want.etag)
+		}
+	}
+
+	completeBody := []byte(fmt.Sprintf(
+		`<CompleteMultipartUpload><Part><PartNumber>1</PartNumber><ETag>%s</ETag></Part><Part><PartNumber>2</PartNumber><ETag>%s</ETag></Part></CompleteMultipartUpload>`,
+		part1ETag, part2ETag,
+	))
+	completeURL := s3URL(objectKey, url.Values{"uploadId": {createResult.UploadID}})
+	status, body = s3Do(t, http.MethodPost, completeURL, bucket.AccessKey, bucket.AccessSecret, env.Region, completeBody)
+	if status != http.StatusOK {
+		t.Fatalf("CompleteMultipartUpload: expected 200, got %d: %s", status, body)
+	}
+
+	status, body = s3Do(t, http.MethodGet, s3URL(objectKey, nil), bucket.AccessKey, bucket.AccessSecret, env.Region, nil)
+	if status != http.StatusOK {
+		t.Fatalf("GET completed multipart object: expected 200, got %d: %s", status, body)
+	}
+	if want := append(append([]byte{}, part1Replacement...), part2...); !bytes.Equal(body, want) {
+		t.Fatalf("GET completed multipart object: got %q, want %q", body, want)
+	}
+
+	status, body = s3Do(t, http.MethodGet, listPartsURL, bucket.AccessKey, bucket.AccessSecret, env.Region, nil)
+	if status < 400 {
+		t.Fatalf("ListParts completed upload: expected non-2xx, got %d: %s", status, body)
+	}
+	assertS3Error(t, body, "NoSuchUpload")
+
+	abortKey := "multipart-abort-" + suffix + ".txt"
+	beforeAbortKeys := listS3SourceObjectKeys(t, env)
+	status, body = s3Do(t, http.MethodPost, s3URL(abortKey, url.Values{"uploads": {""}}), bucket.AccessKey, bucket.AccessSecret, env.Region, nil)
+	if status != http.StatusOK {
+		t.Fatalf("CreateMultipartUpload for abort: expected 200, got %d: %s", status, body)
+	}
+	var abortCreateResult struct {
+		UploadID string `xml:"UploadId"`
+	}
+	if err := xml.Unmarshal(body, &abortCreateResult); err != nil || abortCreateResult.UploadID == "" {
+		t.Fatalf("CreateMultipartUpload for abort decode: uploadId=%q err=%v body=%s", abortCreateResult.UploadID, err, body)
+	}
+	abortPartURL := s3URL(abortKey, url.Values{"partNumber": {"1"}, "uploadId": {abortCreateResult.UploadID}})
+	status, body = s3Do(t, http.MethodPut, abortPartURL, bucket.AccessKey, bucket.AccessSecret, env.Region, []byte("abort-me"))
+	if status != http.StatusOK {
+		t.Fatalf("UploadPart for abort: expected 200, got %d: %s", status, body)
+	}
+	afterAbortPartKeys := listS3SourceObjectKeys(t, env)
+	if len(afterAbortPartKeys) <= len(beforeAbortKeys) {
+		t.Fatalf("UploadPart for abort: expected source chunk object to be created; before=%d after=%d", len(beforeAbortKeys), len(afterAbortPartKeys))
+	}
+	abortURL := s3URL(abortKey, url.Values{"uploadId": {abortCreateResult.UploadID}})
+	status, body = s3Do(t, http.MethodDelete, abortURL, bucket.AccessKey, bucket.AccessSecret, env.Region, nil)
+	if status != http.StatusNoContent {
+		t.Fatalf("AbortMultipartUpload: expected 204, got %d: %s", status, body)
+	}
+	afterAbortKeys := listS3SourceObjectKeys(t, env)
+	if len(afterAbortKeys) != len(beforeAbortKeys) {
+		t.Fatalf("AbortMultipartUpload: source chunks were not cleaned up; before=%d after=%d", len(beforeAbortKeys), len(afterAbortKeys))
+	}
+	for key := range beforeAbortKeys {
+		if _, ok := afterAbortKeys[key]; !ok {
+			t.Fatalf("AbortMultipartUpload: source key %q disappeared unexpectedly", key)
+		}
+	}
+	status, body = s3Do(t, http.MethodGet, abortURL, bucket.AccessKey, bucket.AccessSecret, env.Region, nil)
+	if status < 400 {
+		t.Fatalf("ListParts aborted upload: expected non-2xx, got %d: %s", status, body)
+	}
+	assertS3Error(t, body, "NoSuchUpload")
+	status, body = s3Do(t, http.MethodGet, s3URL(abortKey, nil), bucket.AccessKey, bucket.AccessSecret, env.Region, nil)
+	if status != http.StatusNotFound {
+		t.Fatalf("GET aborted multipart object: expected 404, got %d: %s", status, body)
+	}
+
+	status, body = s3Do(t, http.MethodPut, s3URL("missing-upload-"+suffix+".txt", url.Values{"partNumber": {"1"}, "uploadId": {"missing-upload-id"}}), bucket.AccessKey, bucket.AccessSecret, env.Region, []byte("missing"))
+	if status < 400 {
+		t.Fatalf("UploadPart missing upload: expected non-2xx, got %d: %s", status, body)
+	}
+	assertS3Error(t, body, "NoSuchUpload")
+	status, body = s3Do(t, http.MethodDelete, s3URL("empty-upload-"+suffix+".txt", url.Values{"uploadId": {""}}), bucket.AccessKey, bucket.AccessSecret, env.Region, nil)
+	if status < 400 {
+		t.Fatalf("AbortMultipartUpload empty uploadId: expected non-2xx, got %d: %s", status, body)
+	}
+	assertS3Error(t, body, "NoSuchUpload")
 }
 
 func TestS3CompatListObjectsV2PrefixDelimiterAndPagination(t *testing.T) {

--- a/docs/qa-coverage-audit-2026-04-21.md
+++ b/docs/qa-coverage-audit-2026-04-21.md
@@ -2,7 +2,7 @@
 
 Date: 2026-04-21
 
-Scope: `api-go` automated tests, Woodpecker backend validation, and recent `origin/main` changes.
+Scope: `api-go` automated tests, Woodpecker backend validation, recent `origin/main` changes, and the checked-out multipart E2E coverage branch.
 
 ## Coverage Map
 
@@ -10,36 +10,35 @@ Scope: `api-go` automated tests, Woodpecker backend validation, and recent `orig
 | --- | --- | --- |
 | Object write/read roundtrip | Python E2E and Go S3 E2E cover PUT, LIST, GET, overwrite, DELETE with an S3 source. | Covered for simple objects. |
 | Chunking correctness | `internal/manager/file_test.go` covers round-robin chunking, weighted placement, checksum storage, and failover. | Covered at unit level. |
-| Metadata integrity | File chunk size/checksum metadata is unit-tested. S3 ETag and basic object headers are checked in E2E. | Weak for user metadata and content type because those are not implemented. |
+| Metadata integrity | File chunk size/checksum metadata is unit-tested. S3 ETag, range headers, and basic object headers are checked in E2E. | Weak for user metadata and content type because those are not implemented. |
 | Placement logic | Round-robin, weighted selection, and upload failover have unit coverage. | Covered for manager logic. |
-| Reconstruction/retrieval | Manager tests cover checksum-verified streaming, legacy chunks, oversized chunks, truncated chunks, and corruption. S3 E2E covers full-object download. | Covered for manager logic; weak for HTTP error behavior on backend corruption. |
+| Reconstruction/retrieval | Manager tests cover checksum-verified streaming, range streaming across chunks, legacy chunks, oversized chunks, truncated chunks, and corruption. S3 E2E covers full-object and ranged download. | Covered for manager logic; weak for HTTP error behavior on backend corruption. |
 | Corruption detection | SHA-256 mismatch paths are unit-tested, including short and oversized chunk reads. | Covered at unit level. |
 | Source/backend failure cases | Manager failover and resilience wrappers have tests. | Covered for upload/retry logic; weak for GET failure surfaced through S3 HTTP. |
-| Critical S3-compatible API behavior | Go E2E covers source/bucket creation, object lifecycle, auth failure, presigned GET/PUT, HEAD, and expired presign. | Covered for simple operations; weak for multipart and listing semantics. |
-| Recent bug regressions | Recent checksum work has unit tests. Web UI lockfile fix belongs to web UI CI. | Partially covered. |
+| Critical S3-compatible API behavior | Go E2E covers source/bucket creation, object lifecycle, auth failure, presigned GET/PUT, HEAD, expired presign, range GET, ListObjectsV2 prefix/delimiter/pagination, and multipart lifecycle on the checked-out branch. | Covered for currently implemented core operations; weak for unimplemented S3 operations and backend-failure HTTP semantics. |
+| Recent bug regressions | Recent checksum, ListObjectsV2, range GET, and multipart work have focused tests. Web UI lockfile fix belongs to web UI CI. | Covered for the latest backend regressions. |
 | Recently changed code paths | Backend CI runs Go unit tests plus Python and Go E2E through Woodpecker for `api-go/**`. | Covered by CI routing. |
 
 ## Prioritized Missing Tests
 
-1. Add live S3 multipart E2E coverage in `api-go/internal/e2e/s3_compat_test.go`.
-   Acceptance: create multipart upload, upload two parts, list parts, complete upload, GET combined object, re-upload a part, abort an upload, and assert missing/invalid upload IDs return S3 errors.
+1. Define and fix S3 GET backend corruption/failure behavior, then add regression coverage.
+   Acceptance: a corrupted or unavailable chunk must not look like a successful full-object download to an S3 client. Current handler code writes `200 OK` or `206 Partial Content` before `manager.StreamFile` / `manager.StreamFileRange` returns, so product-code behavior needs Software Engineer Head ownership before QA can add a stable expected-behavior test.
 
-2. Add S3 GET backend corruption/failure regression coverage.
-   Acceptance: a corrupted or unavailable chunk must not look like a successful full-object download to an S3 client. Current handler code writes `200 OK` before `manager.StreamFile` returns, so this likely needs Software Engineer Head review before QA can write a stable expected-behavior test.
+2. Add S3 object metadata/header behavior coverage when metadata support is implemented.
+   Acceptance: PUT with `Content-Type` and `x-amz-meta-*` either preserves those values through HEAD/GET or returns an intentional S3-compatible unsupported-feature response.
 
-3. Add ListObjectsV2 and prefix/delimiter/pagination E2E once that implementation lands.
-   Acceptance: SDK-style `list-type=2` requests respect `prefix`, `delimiter`, `max-keys`, and continuation tokens, and V1 behavior is not regressed.
-
-4. Add Range GET/HEAD E2E when range support lands.
-   Acceptance: valid byte ranges return `206`, `Content-Range`, and partial content; invalid ranges return the expected S3 error; HEAD advertises range support without a body.
-
-5. Add DeleteObjects and CopyObject E2E after those code paths are implemented.
+3. Add DeleteObjects and CopyObject E2E after those code paths are implemented.
    Acceptance: batch delete is idempotent and reports per-key errors; copy preserves content and expected metadata/ETag behavior.
+
+4. Add S3 lifecycle/error-shape coverage for malformed and unsupported requests.
+   Acceptance: unsupported operations and malformed query combinations return XML S3 errors with stable status codes instead of generic JSON or empty responses.
 
 ## Work Completed In This Audit
 
-- Added `TestStreamFileChecksumRejectsTruncatedChunk` to cover short chunk reads under checksum verification.
-- Reviewed `.woodpecker/api-go.yml`; backend PRs and pushes to main already run Go unit tests plus S3-backed Python and Go E2E suites in Woodpecker.
+- Confirmed `TestS3CompatGetObjectRange` covers valid bounded, open-ended, suffix, invalid, and full-object GET range behavior.
+- Confirmed `TestS3CompatListObjectsV2PrefixDelimiterAndPagination` covers V2 prefix filtering, delimiter common prefixes, continuation-token pagination, and V1 delimiter regression behavior.
+- Confirmed the checked-out branch adds `TestS3CompatMultipartUploadLifecycle` for create, upload, re-upload part, list parts, complete, GET completed object, abort cleanup, and missing upload IDs.
+- Reviewed `.woodpecker/api-go.yml`; backend PRs and pushes to main run Go unit tests plus S3-backed Python and Go E2E suites in Woodpecker.
 
 ## Verification
 


### PR DESCRIPTION
## Summary

- Adds live Go E2E coverage for S3 multipart create, upload part, list parts, complete, and GET verification.
- Covers re-uploading the same part number before completion.
- Covers abort cleanup by checking the backing S3 source object set returns to its pre-abort state.
- Covers missing/empty upload IDs returning structured `NoSuchUpload` S3 errors.

## Verification

- Ran `gofmt` and `git diff --check`.
- Did not run local Docker, Playwright, or Go E2E tests per QA role/task instruction; Woodpecker should run the `api-go` pipeline for this `api-go/**` change.