### PR TITLE
THE-8: Add S3 DeleteObjects support

### DIFF
--- a/.woodpecker/api-go.yml
+++ b/.woodpecker/api-go.yml
@@ -72,6 +72,3 @@ services:
     privileged: true
     environment:
       DOCKER_TLS_CERTDIR: ""
-    command:
-      - --host=tcp://0.0.0.0:2375
-      - --tls=false

--- a/.woodpecker/api-go.yml
+++ b/.woodpecker/api-go.yml
@@ -32,8 +32,9 @@ steps:
       - echo "Waiting for Docker daemon..."
       - for i in $(seq 1 60); do docker info >/dev/null 2>&1 && break; echo "still waiting ($i)"; sleep 1; done
       - docker info
+      - for image in "$GO_IMAGE" "$PYTHON_IMAGE" "$MONGO_IMAGE" "$MINIO_IMAGE"; do for i in $(seq 1 4); do docker pull "$image" && break; if [ "$i" = 4 ]; then exit 1; fi; sleep $((i * 10)); done; done
       - cd api-go
-      - E2E_SOURCE_TYPE=s3 docker compose -f docker-compose.e2e.yml up --build --abort-on-container-exit --exit-code-from e2e-tests
+      - E2E_SOURCE_TYPE=s3 docker compose -f docker-compose.e2e.yml up --pull never --build --abort-on-container-exit --exit-code-from e2e-tests
       - docker compose -f docker-compose.e2e.yml down -v
 
   - name: go e2e tests (s3)
@@ -47,8 +48,9 @@ steps:
     commands:
       - echo "Waiting for Docker daemon..."
       - for i in $(seq 1 60); do docker info >/dev/null 2>&1 && break; echo "still waiting ($i)"; sleep 1; done
+      - for image in "$GO_IMAGE" "$MONGO_IMAGE" "$MINIO_IMAGE"; do for i in $(seq 1 4); do docker pull "$image" && break; if [ "$i" = 4 ]; then exit 1; fi; sleep $((i * 10)); done; done
       - cd api-go
-      - docker compose -f docker-compose.go-e2e.yml up --build --abort-on-container-exit --exit-code-from go-e2e-tests
+      - docker compose -f docker-compose.go-e2e.yml up --pull never --build --abort-on-container-exit --exit-code-from go-e2e-tests
       - docker compose -f docker-compose.go-e2e.yml down -v
 
   - name: build and push

--- a/api-go/internal/app/router.go
+++ b/api-go/internal/app/router.go
@@ -164,6 +164,7 @@ func SetupRouter(m *db.Mongo, cfg *config.Config) *gin.Engine {
 		router.GET("/api/s3/:bucket/*object", s3Auth, handlers.GetObjectOrParts(bucketRepo, sourceRepo, fileRepo, mpRepo))
 		router.GET("/api/s3/:bucket", s3Auth, handlers.ListObjectsOrUploads(bucketRepo, fileRepo, mpRepo))
 		router.PUT("/api/s3/:bucket/*object", s3Auth, handlers.PutObjectOrPart(bucketRepo, sourceRepo, fileRepo, mpRepo, chunkSize))
+		router.POST("/api/s3/:bucket", s3Auth, handlers.PostBucket(bucketRepo, sourceRepo, fileRepo))
 		router.POST("/api/s3/:bucket/*object", s3Auth, handlers.PostObject(bucketRepo, sourceRepo, fileRepo, mpRepo, chunkSize))
 		router.DELETE("/api/s3/:bucket/*object", s3Auth, handlers.DeleteObjectOrAbort(bucketRepo, sourceRepo, fileRepo, mpRepo))
 	}

--- a/api-go/internal/e2e/s3_compat_test.go
+++ b/api-go/internal/e2e/s3_compat_test.go
@@ -641,6 +641,112 @@ func TestS3CompatGetObjectRange(t *testing.T) {
 	}
 }
 
+func TestS3CompatDeleteObjects(t *testing.T) {
+	env, ok := loadS3E2EEnv()
+	if !ok {
+		t.Skip("E2E_S3_ENDPOINT not set; skipping S3 E2E tests")
+	}
+
+	ts, _ := newTestServer(t)
+	ensureMinIOBucket(t, env)
+
+	suffix := uniqueSuffix()
+	username, password := createTestUser(t, ts, suffix)
+	sourceID := createS3Source(t, ts, username, password, "src-"+suffix, env)
+	bucket := createBucket(t, ts, username, password, "bkt-"+suffix, sourceID)
+
+	t.Cleanup(func() {
+		apiDelete(t, ts, "/api/v1/buckets/"+bucket.ID, username, password)
+		apiDelete(t, ts, "/api/v1/sources/"+sourceID, username, password)
+	})
+
+	objectKeys := []string{
+		"multi-delete/a-" + suffix + ".txt",
+		"multi-delete/b-" + suffix + ".txt",
+		"multi-delete/c-" + suffix + ".txt",
+	}
+	s3URL := func(key string) string {
+		return fmt.Sprintf("%s/api/s3/%s/%s", ts.URL, bucket.Key, key)
+	}
+	for _, key := range objectKeys {
+		status, body := s3Do(t, http.MethodPut, s3URL(key), bucket.AccessKey, bucket.AccessSecret, env.Region, []byte("content "+key))
+		if status != http.StatusOK {
+			t.Fatalf("PUT %s: expected 200, got %d: %s", key, status, body)
+		}
+	}
+	t.Cleanup(func() {
+		for _, key := range objectKeys {
+			s3Do(t, http.MethodDelete, s3URL(key), bucket.AccessKey, bucket.AccessSecret, env.Region, nil)
+		}
+	})
+
+	type deleteResultXML struct {
+		Deleted []struct {
+			Key string `xml:"Key"`
+		} `xml:"Deleted"`
+		Errors []struct {
+			Key  string `xml:"Key"`
+			Code string `xml:"Code"`
+		} `xml:"Error"`
+	}
+	deleteURL := ts.URL + "/api/s3/" + bucket.Key + "?delete"
+	deleteBody := []byte(fmt.Sprintf(`<Delete>
+		<Object><Key>%s</Key></Object>
+		<Object><Key>%s</Key></Object>
+		<Object><Key>%s</Key></Object>
+	</Delete>`, objectKeys[0], objectKeys[1], "multi-delete/missing-"+suffix+".txt"))
+	status, body := s3Do(t, http.MethodPost, deleteURL, bucket.AccessKey, bucket.AccessSecret, env.Region, deleteBody)
+	if status != http.StatusOK {
+		t.Fatalf("DeleteObjects: expected 200, got %d: %s", status, body)
+	}
+	var result deleteResultXML
+	if err := xml.Unmarshal(body, &result); err != nil {
+		t.Fatalf("decode DeleteObjects response: %v body=%s", err, body)
+	}
+	if len(result.Errors) != 0 {
+		t.Fatalf("DeleteObjects expected no errors, got %+v", result.Errors)
+	}
+	if len(result.Deleted) != 3 {
+		t.Fatalf("DeleteObjects expected 3 Deleted entries including missing key, got %+v", result.Deleted)
+	}
+
+	listURL := ts.URL + "/api/s3/" + bucket.Key + "?list-type=2&prefix=multi-delete/"
+	status, body = s3Do(t, http.MethodGet, listURL, bucket.AccessKey, bucket.AccessSecret, env.Region, nil)
+	if status != http.StatusOK {
+		t.Fatalf("LIST after DeleteObjects: expected 200, got %d: %s", status, body)
+	}
+	if strings.Contains(string(body), objectKeys[0]) || strings.Contains(string(body), objectKeys[1]) {
+		t.Fatalf("LIST after DeleteObjects included deleted keys: %s", body)
+	}
+	if !strings.Contains(string(body), objectKeys[2]) {
+		t.Fatalf("LIST after DeleteObjects missing survivor key %q: %s", objectKeys[2], body)
+	}
+
+	quietBody := []byte(fmt.Sprintf(`<Delete><Quiet>true</Quiet><Object><Key>%s</Key></Object></Delete>`, objectKeys[2]))
+	status, body = s3Do(t, http.MethodPost, deleteURL, bucket.AccessKey, bucket.AccessSecret, env.Region, quietBody)
+	if status != http.StatusOK {
+		t.Fatalf("DeleteObjects quiet: expected 200, got %d: %s", status, body)
+	}
+	result = deleteResultXML{}
+	if err := xml.Unmarshal(body, &result); err != nil {
+		t.Fatalf("decode quiet DeleteObjects response: %v body=%s", err, body)
+	}
+	if len(result.Deleted) != 0 || len(result.Errors) != 0 {
+		t.Fatalf("quiet DeleteObjects expected no Deleted or Error entries, got %+v", result)
+	}
+
+	var tooMany strings.Builder
+	tooMany.WriteString("<Delete>")
+	for i := 0; i < 1001; i++ {
+		fmt.Fprintf(&tooMany, "<Object><Key>too-many-%d</Key></Object>", i)
+	}
+	tooMany.WriteString("</Delete>")
+	status, body = s3Do(t, http.MethodPost, deleteURL, bucket.AccessKey, bucket.AccessSecret, env.Region, []byte(tooMany.String()))
+	if status != http.StatusBadRequest {
+		t.Fatalf("DeleteObjects too many keys: expected 400, got %d: %s", status, body)
+	}
+}
+
 func TestS3CompatListObjectsV2PrefixDelimiterAndPagination(t *testing.T) {
 	env, ok := loadS3E2EEnv()
 	if !ok {

--- a/api-go/internal/e2e/s3_compat_test.go
+++ b/api-go/internal/e2e/s3_compat_test.go
@@ -17,6 +17,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 	"testing"
@@ -365,7 +366,7 @@ func signS3Request(req *http.Request, accessKey, secretKey, region string) error
 	canonReq := strings.Join([]string{
 		req.Method,
 		canonURI,
-		req.URL.RawQuery,
+		s3CanonicalQuery(req.URL),
 		canonHeaders,
 		signedHeaders,
 		payloadHash,
@@ -387,6 +388,57 @@ func signS3Request(req *http.Request, accessKey, secretKey, region string) error
 		accessKey, scope, signedHeaders, hex.EncodeToString(sig),
 	))
 	return nil
+}
+
+func s3CanonicalQuery(u *url.URL) string {
+	if u == nil {
+		return ""
+	}
+	values, _ := url.ParseQuery(u.RawQuery)
+	type kv struct {
+		k string
+		v string
+	}
+	items := make([]kv, 0)
+	for k, vs := range values {
+		if len(vs) == 0 {
+			items = append(items, kv{k: k})
+			continue
+		}
+		for _, v := range vs {
+			items = append(items, kv{k: k, v: v})
+		}
+	}
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].k == items[j].k {
+			return items[i].v < items[j].v
+		}
+		return items[i].k < items[j].k
+	})
+	var b strings.Builder
+	for i, item := range items {
+		if i > 0 {
+			b.WriteByte('&')
+		}
+		b.WriteString(s3EncodeQuery(item.k))
+		b.WriteByte('=')
+		b.WriteString(s3EncodeQuery(item.v))
+	}
+	return b.String()
+}
+
+func s3EncodeQuery(s string) string {
+	var b strings.Builder
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') ||
+			c == '-' || c == '_' || c == '.' || c == '~' {
+			b.WriteByte(c)
+		} else {
+			fmt.Fprintf(&b, "%%%02X", c)
+		}
+	}
+	return b.String()
 }
 
 func s3HmacSHA256(key, data []byte) []byte {

--- a/api-go/internal/handlers/s3.go
+++ b/api-go/internal/handlers/s3.go
@@ -5,6 +5,8 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/xml"
+	"errors"
+	"io"
 	"log/slog"
 	"net/http"
 	"strconv"
@@ -16,6 +18,16 @@ import (
 	"github.com/gin-gonic/gin"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
+)
+
+const (
+	maxDeleteObjects                = 1000
+	maxDeleteObjectsRequestBodySize = 8 * 1024 * 1024
+)
+
+var (
+	errDeleteObjectsMalformedXML = errors.New("malformed delete objects XML")
+	errDeleteObjectsTooMany      = errors.New("too many delete objects")
 )
 
 type s3Error struct {
@@ -50,6 +62,103 @@ type deleteObjectError struct {
 	Key     string `xml:"Key"`
 	Code    string `xml:"Code"`
 	Message string `xml:"Message"`
+}
+
+func decodeDeleteObjectsRequest(r io.Reader) (deleteObjectsRequest, error) {
+	decoder := xml.NewDecoder(r)
+	var req deleteObjectsRequest
+	for {
+		token, err := decoder.Token()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return req, errDeleteObjectsMalformedXML
+			}
+			return req, err
+		}
+		start, ok := token.(xml.StartElement)
+		if !ok {
+			continue
+		}
+		if start.Name.Local != "Delete" {
+			return req, errDeleteObjectsMalformedXML
+		}
+		if err := decodeDeleteObjectsElement(decoder, &req); err != nil {
+			return req, err
+		}
+		return req, nil
+	}
+}
+
+func decodeDeleteObjectsElement(decoder *xml.Decoder, req *deleteObjectsRequest) error {
+	for {
+		token, err := decoder.Token()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return errDeleteObjectsMalformedXML
+			}
+			return err
+		}
+		switch tok := token.(type) {
+		case xml.StartElement:
+			switch tok.Name.Local {
+			case "Quiet":
+				if err := decoder.DecodeElement(&req.Quiet, &tok); err != nil {
+					return err
+				}
+			case "Object":
+				if len(req.Objects) >= maxDeleteObjects {
+					return errDeleteObjectsTooMany
+				}
+				obj, err := decodeDeleteObjectElement(decoder)
+				if err != nil {
+					return err
+				}
+				req.Objects = append(req.Objects, obj)
+			default:
+				if err := decoder.Skip(); err != nil {
+					return err
+				}
+			}
+		case xml.EndElement:
+			if tok.Name.Local == "Delete" {
+				return nil
+			}
+		}
+	}
+}
+
+func decodeDeleteObjectElement(decoder *xml.Decoder) (deleteObjectRequest, error) {
+	var obj deleteObjectRequest
+	for {
+		token, err := decoder.Token()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return obj, errDeleteObjectsMalformedXML
+			}
+			return obj, err
+		}
+		switch tok := token.(type) {
+		case xml.StartElement:
+			switch tok.Name.Local {
+			case "Key":
+				if err := decoder.DecodeElement(&obj.Key, &tok); err != nil {
+					return obj, err
+				}
+			case "VersionId":
+				if err := decoder.DecodeElement(&obj.VersionID, &tok); err != nil {
+					return obj, err
+				}
+			default:
+				if err := decoder.Skip(); err != nil {
+					return obj, err
+				}
+			}
+		case xml.EndElement:
+			if tok.Name.Local == "Object" {
+				return obj, nil
+			}
+		}
+	}
 }
 
 type listBucketResult struct {
@@ -648,14 +757,18 @@ func DeleteObjects(bucketRepo *repository.BucketRepository, sourceRepo *reposito
 			return
 		}
 
-		var req deleteObjectsRequest
-		decoder := xml.NewDecoder(c.Request.Body)
-		if err := decoder.Decode(&req); err != nil {
+		req, err := decodeDeleteObjectsRequest(http.MaxBytesReader(c.Writer, c.Request.Body, maxDeleteObjectsRequestBodySize))
+		if err != nil {
+			if errors.Is(err, errDeleteObjectsTooMany) {
+				writeS3Error(c, http.StatusBadRequest, "InvalidRequest", "DeleteObjects supports at most 1000 objects per request")
+				return
+			}
+			var maxBytesErr *http.MaxBytesError
+			if errors.As(err, &maxBytesErr) {
+				writeS3Error(c, http.StatusBadRequest, "InvalidRequest", "DeleteObjects request body is too large")
+				return
+			}
 			writeS3Error(c, http.StatusBadRequest, "MalformedXML", "The XML you provided was not well-formed or did not validate against our published schema")
-			return
-		}
-		if len(req.Objects) > 1000 {
-			writeS3Error(c, http.StatusBadRequest, "InvalidRequest", "DeleteObjects supports at most 1000 objects per request")
 			return
 		}
 

--- a/api-go/internal/handlers/s3.go
+++ b/api-go/internal/handlers/s3.go
@@ -24,6 +24,34 @@ type s3Error struct {
 	Message string   `xml:"Message"`
 }
 
+type deleteObjectsRequest struct {
+	XMLName xml.Name              `xml:"Delete"`
+	Quiet   bool                  `xml:"Quiet"`
+	Objects []deleteObjectRequest `xml:"Object"`
+}
+
+type deleteObjectRequest struct {
+	Key       string `xml:"Key"`
+	VersionID string `xml:"VersionId,omitempty"`
+}
+
+type deleteObjectsResult struct {
+	XMLName xml.Name              `xml:"DeleteResult"`
+	Xmlns   string                `xml:"xmlns,attr"`
+	Deleted []deletedObjectResult `xml:"Deleted,omitempty"`
+	Errors  []deleteObjectError   `xml:"Error,omitempty"`
+}
+
+type deletedObjectResult struct {
+	Key string `xml:"Key"`
+}
+
+type deleteObjectError struct {
+	Key     string `xml:"Key"`
+	Code    string `xml:"Code"`
+	Message string `xml:"Message"`
+}
+
 type listBucketResult struct {
 	XMLName               xml.Name           `xml:"ListBucketResult"`
 	Xmlns                 string             `xml:"xmlns,attr"`
@@ -70,6 +98,26 @@ const listCommonPrefixSkipSuffix = "\U0010FFFF"
 
 func writeS3Error(c *gin.Context, status int, code, message string) {
 	c.XML(status, s3Error{Code: code, Message: message})
+}
+
+func deleteObjectByName(ctx context.Context, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository, bucketID primitive.ObjectID, name string) (bool, error) {
+	fileDoc, err := fileRepo.GetByName(ctx, bucketID, name)
+	if err != nil {
+		if err == mongo.ErrNoDocuments {
+			return false, nil
+		}
+		return false, err
+	}
+	if err := fileRepo.Delete(ctx, fileDoc.ID); err != nil {
+		if err == mongo.ErrNoDocuments {
+			return false, nil
+		}
+		return false, err
+	}
+	if err := manager.DeleteFileChunks(ctx, sourceRepo, fileDoc.Chunks); err != nil {
+		slog.WarnContext(ctx, "delete object: delete chunks", slog.String("error", err.Error()))
+	}
+	return true, nil
 }
 
 func objectETag(file repository.File) string {
@@ -579,28 +627,66 @@ func DeleteObject(bucketRepo *repository.BucketRepository, sourceRepo *repositor
 			c.Status(http.StatusNoContent)
 			return
 		}
-		fileDoc, err := fileRepo.GetByName(ctx, bucketDoc.ID, name)
-		if err != nil {
-			if err == mongo.ErrNoDocuments {
-				c.Status(http.StatusNoContent)
-				return
-			}
-			slog.ErrorContext(ctx, "delete object: get file", slog.String("error", err.Error()))
-			writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
-			return
-		}
-		if err := fileRepo.Delete(ctx, fileDoc.ID); err != nil {
-			if err == mongo.ErrNoDocuments {
-				c.Status(http.StatusNoContent)
-				return
-			}
+		if _, err := deleteObjectByName(ctx, sourceRepo, fileRepo, bucketDoc.ID, name); err != nil {
 			slog.ErrorContext(ctx, "delete object: delete file", slog.String("error", err.Error()))
 			writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
 			return
 		}
-		if err := manager.DeleteFileChunks(ctx, sourceRepo, fileDoc.Chunks); err != nil {
-			slog.WarnContext(ctx, "delete object: delete chunks", slog.String("error", err.Error()))
-		}
 		c.Status(http.StatusNoContent)
+	}
+}
+
+func DeleteObjects(bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		ctx := c.Request.Context()
+		if bucketRepo == nil || sourceRepo == nil || fileRepo == nil {
+			c.Status(http.StatusServiceUnavailable)
+			return
+		}
+		bucketDoc, ok := lookupBucket(c, bucketRepo)
+		if !ok {
+			return
+		}
+
+		var req deleteObjectsRequest
+		decoder := xml.NewDecoder(c.Request.Body)
+		if err := decoder.Decode(&req); err != nil {
+			writeS3Error(c, http.StatusBadRequest, "MalformedXML", "The XML you provided was not well-formed or did not validate against our published schema")
+			return
+		}
+		if len(req.Objects) > 1000 {
+			writeS3Error(c, http.StatusBadRequest, "InvalidRequest", "DeleteObjects supports at most 1000 objects per request")
+			return
+		}
+
+		result := deleteObjectsResult{
+			Xmlns:   "http://s3.amazonaws.com/doc/2006-03-01/",
+			Deleted: make([]deletedObjectResult, 0, len(req.Objects)),
+			Errors:  make([]deleteObjectError, 0),
+		}
+		for _, obj := range req.Objects {
+			key := obj.Key
+			if key == "" {
+				result.Errors = append(result.Errors, deleteObjectError{
+					Key:     key,
+					Code:    "InvalidArgument",
+					Message: "Object key must not be empty",
+				})
+				continue
+			}
+			if _, err := deleteObjectByName(ctx, sourceRepo, fileRepo, bucketDoc.ID, key); err != nil {
+				slog.ErrorContext(ctx, "delete objects: delete file", slog.String("key", key), slog.String("error", err.Error()))
+				result.Errors = append(result.Errors, deleteObjectError{
+					Key:     key,
+					Code:    "InternalError",
+					Message: "Internal error deleting object",
+				})
+				continue
+			}
+			if !req.Quiet {
+				result.Deleted = append(result.Deleted, deletedObjectResult{Key: key})
+			}
+		}
+		c.XML(http.StatusOK, result)
 	}
 }

--- a/api-go/internal/handlers/s3_multipart.go
+++ b/api-go/internal/handlers/s3_multipart.go
@@ -122,6 +122,19 @@ func PostObject(bucketRepo *repository.BucketRepository, sourceRepo *repository.
 	}
 }
 
+// PostBucket dispatches POST requests on S3 bucket paths.
+// ?delete -> DeleteObjects
+func PostBucket(bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository) gin.HandlerFunc {
+	deleteObjectsHandler := DeleteObjects(bucketRepo, sourceRepo, fileRepo)
+	return func(c *gin.Context) {
+		if _, ok := c.GetQuery("delete"); ok {
+			deleteObjectsHandler(c)
+			return
+		}
+		writeS3Error(c, http.StatusBadRequest, "InvalidRequest", "missing delete parameter")
+	}
+}
+
 // PutObjectOrPart dispatches PUT requests.
 // ?uploadId=X&partNumber=N → UploadPart
 // otherwise → PutObject

--- a/api-go/internal/handlers/s3_test.go
+++ b/api-go/internal/handlers/s3_test.go
@@ -1,0 +1,55 @@
+package handlers
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestDecodeDeleteObjectsRequestParsesQuietAndObjects(t *testing.T) {
+	t.Parallel()
+
+	body := `<Delete xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Quiet>true</Quiet><Object><Key>a.txt</Key><VersionId>v1</VersionId></Object><Ignored><Nested>value</Nested></Ignored></Delete>`
+	req, err := decodeDeleteObjectsRequest(strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("decode DeleteObjects request: %v", err)
+	}
+	if !req.Quiet {
+		t.Fatal("expected quiet mode")
+	}
+	if len(req.Objects) != 1 {
+		t.Fatalf("expected 1 object, got %d", len(req.Objects))
+	}
+	if req.Objects[0].Key != "a.txt" || req.Objects[0].VersionID != "v1" {
+		t.Fatalf("unexpected object: %+v", req.Objects[0])
+	}
+}
+
+func TestDecodeDeleteObjectsRequestRejectsTooManyObjectsDuringParse(t *testing.T) {
+	t.Parallel()
+
+	var body strings.Builder
+	body.WriteString("<Delete>")
+	for i := 0; i < maxDeleteObjects+1; i++ {
+		fmt.Fprintf(&body, "<Object><Key>too-many-%d</Key></Object>", i)
+	}
+	body.WriteString("</Delete>")
+
+	req, err := decodeDeleteObjectsRequest(strings.NewReader(body.String()))
+	if !errors.Is(err, errDeleteObjectsTooMany) {
+		t.Fatalf("expected too many objects error, got %v", err)
+	}
+	if len(req.Objects) != maxDeleteObjects {
+		t.Fatalf("expected parser to retain only %d objects, got %d", maxDeleteObjects, len(req.Objects))
+	}
+}
+
+func TestDecodeDeleteObjectsRequestRejectsMalformedRoot(t *testing.T) {
+	t.Parallel()
+
+	_, err := decodeDeleteObjectsRequest(strings.NewReader("<NotDelete></NotDelete>"))
+	if !errors.Is(err, errDeleteObjectsMalformedXML) {
+		t.Fatalf("expected malformed XML error, got %v", err)
+	}
+}

--- a/scripts/woodpecker-smoke.sh
+++ b/scripts/woodpecker-smoke.sh
@@ -55,7 +55,18 @@ step "Build CLI"
 pass "sfree CLI builds"
 
 step "Start Compose stack"
-compose up -d --build
+for image in "$GO_IMAGE" "$NODE_IMAGE" "$NGINX_IMAGE" "$MONGO_IMAGE" "$MINIO_IMAGE" "$MINIO_MC_IMAGE"; do
+	for i in $(seq 1 4); do
+		if docker pull "$image"; then
+			break
+		fi
+		if [ "$i" -eq 4 ]; then
+			fail "Unable to pull $image"
+		fi
+		sleep $((i * 10))
+	done
+done
+compose up -d --pull never --build
 pass "Woodpecker starts the root Compose stack"
 
 step "Wait for API readiness"


### PR DESCRIPTION
## Summary

Adds S3 `DeleteObjects` multi-delete support for bucket-level `POST ?delete` requests.

## Linked Issue

THE-8

## What Changed

- Add bucket-level S3 POST dispatch for `?delete`.
- Parse DeleteObjects XML requests with `Object` entries and optional `Quiet`.
- Reuse object deletion semantics so missing keys are reported as deleted.
- Return `DeleteResult` XML with `Deleted` and `Error` entries.
- Enforce the S3 1000-object request limit during streaming XML parsing instead of after full decode.
- Cap DeleteObjects request bodies with `http.MaxBytesReader`.
- Add S3 compat E2E coverage for deleting two objects, treating a missing key as deleted, quiet mode, max-object rejection, and list verification.
- Add focused parser unit coverage for valid namespaced DeleteObjects XML, malformed roots, and over-limit object counting.
- Merge current `origin/main`, including the S3 GET failure-semantics fix from #178 and Woodpecker image-pull stabilization from #177.
- Fix the `api-go` Woodpecker service schema so the refreshed PR pipeline can start.
- Fix the S3 e2e SigV4 helper to canonicalize query strings for subresource requests such as `?delete`.
- Pre-pull Woodpecker compose images sequentially with retries before `compose up --pull never` to reduce registry throttling in nested Docker validation.

## Validation

- tests run locally: not run per SFree resource policy; Go/unit/e2e validation runs in Woodpecker.
- manual checks: `gofmt` applied to touched Go files; `git diff --check` passed after the latest CI helper fixes.
- CI status: Woodpecker pipeline 279 passed for commit `45de7c1`.

## Docs Impact

- [x] no docs change needed
- [ ] docs updated in this PR
- [ ] follow-up docs issue needed