### PR TITLE
Stabilize Woodpecker image pulls

### DIFF
--- a/.woodpecker/api-go.yml
+++ b/.woodpecker/api-go.yml
@@ -14,16 +14,20 @@ when:
 
 steps:
   - name: unit tests
-    image: golang:1.24
+    image: public.ecr.aws/docker/library/golang:1.24
     commands:
       - cd api-go
       - go test ./...
 
   - name: e2e tests
-    image: docker:27-cli
+    image: public.ecr.aws/docker/library/docker:27-cli
     environment:
       DOCKER_HOST: tcp://docker:2375
       DOCKER_TLS_CERTDIR: ""
+      GO_IMAGE: public.ecr.aws/docker/library/golang:1.24
+      PYTHON_IMAGE: public.ecr.aws/docker/library/python:3.12-slim
+      MONGO_IMAGE: public.ecr.aws/docker/library/mongo:7.0.32-rc2-jammy
+      MINIO_IMAGE: quay.io/minio/minio:RELEASE.2025-01-20T14-49-07Z
     commands:
       - echo "Waiting for Docker daemon..."
       - for i in $(seq 1 60); do docker info >/dev/null 2>&1 && break; echo "still waiting ($i)"; sleep 1; done
@@ -33,10 +37,13 @@ steps:
       - docker compose -f docker-compose.e2e.yml down -v
 
   - name: go e2e tests (s3)
-    image: docker:27-cli
+    image: public.ecr.aws/docker/library/docker:27-cli
     environment:
       DOCKER_HOST: tcp://docker:2375
       DOCKER_TLS_CERTDIR: ""
+      GO_IMAGE: public.ecr.aws/docker/library/golang:1.24
+      MONGO_IMAGE: public.ecr.aws/docker/library/mongo:7
+      MINIO_IMAGE: quay.io/minio/minio:RELEASE.2025-01-20T14-49-07Z
     commands:
       - echo "Waiting for Docker daemon..."
       - for i in $(seq 1 60); do docker info >/dev/null 2>&1 && break; echo "still waiting ($i)"; sleep 1; done
@@ -61,7 +68,7 @@ steps:
 
 services:
   - name: docker
-    image: docker:27-dind
+    image: public.ecr.aws/docker/library/docker:27-dind
     privileged: true
     environment:
       DOCKER_TLS_CERTDIR: ""

--- a/.woodpecker/smoke.yml
+++ b/.woodpecker/smoke.yml
@@ -20,10 +20,16 @@ when:
 
 steps:
   - name: stack smoke
-    image: golang:1.24-alpine
+    image: public.ecr.aws/docker/library/golang:1.24-alpine
     environment:
       DOCKER_HOST: tcp://docker:2375
       DOCKER_TLS_CERTDIR: ""
+      GO_IMAGE: public.ecr.aws/docker/library/golang:1.24
+      NODE_IMAGE: public.ecr.aws/docker/library/node:20-alpine
+      NGINX_IMAGE: public.ecr.aws/docker/library/nginx:alpine
+      MONGO_IMAGE: public.ecr.aws/docker/library/mongo:7.0.32-rc2-jammy
+      MINIO_IMAGE: quay.io/minio/minio:RELEASE.2025-01-20T14-49-07Z
+      MINIO_MC_IMAGE: quay.io/minio/mc:latest
     commands:
       - apk add --no-cache aws-cli curl docker-cli docker-cli-compose jq
       - chmod +x scripts/woodpecker-smoke.sh
@@ -31,7 +37,7 @@ steps:
 
 services:
   - name: docker
-    image: docker:27-dind
+    image: public.ecr.aws/docker/library/docker:27-dind
     privileged: true
     environment:
       DOCKER_TLS_CERTDIR: ""

--- a/api-go/Dockerfile
+++ b/api-go/Dockerfile
@@ -1,5 +1,6 @@
 # syntax=docker/dockerfile:1
-FROM golang:1.24 AS builder
+ARG GO_IMAGE=golang:1.24
+FROM ${GO_IMAGE} AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/api-go/Dockerfile.go-e2e
+++ b/api-go/Dockerfile.go-e2e
@@ -1,4 +1,5 @@
-FROM golang:1.24
+ARG GO_IMAGE=golang:1.24
+FROM ${GO_IMAGE}
 
 WORKDIR /app
 

--- a/api-go/docker-compose.ci.yml
+++ b/api-go/docker-compose.ci.yml
@@ -1,6 +1,9 @@
 services:
   api-go:
-    build: .
+    build:
+      context: .
+      args:
+        GO_IMAGE: ${GO_IMAGE:-golang:1.24}
     environment:
       - GIN_MODE=release
       - ENV=test
@@ -8,7 +11,7 @@ services:
     depends_on:
       - mongo
   mongo:
-    image: mongo:7.0.32-rc2-jammy
+    image: ${MONGO_IMAGE:-mongo:7.0.32-rc2-jammy}
     environment:
       - MONGO_INITDB_ROOT_USERNAME=root
       - MONGO_INITDB_ROOT_PASSWORD=example

--- a/api-go/docker-compose.e2e.yml
+++ b/api-go/docker-compose.e2e.yml
@@ -1,12 +1,12 @@
 services:
   mongo:
-    image: mongo:7.0.32-rc2-jammy
+    image: ${MONGO_IMAGE:-mongo:7.0.32-rc2-jammy}
     environment:
       - MONGO_INITDB_ROOT_USERNAME=root
       - MONGO_INITDB_ROOT_PASSWORD=example
 
   minio:
-    image: minio/minio:RELEASE.2025-01-20T14-49-07Z
+    image: ${MINIO_IMAGE:-minio/minio:RELEASE.2025-01-20T14-49-07Z}
     environment:
       - MINIO_ROOT_USER=minioadmin
       - MINIO_ROOT_PASSWORD=minioadmin
@@ -15,6 +15,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      args:
+        GO_IMAGE: ${GO_IMAGE:-golang:1.24}
     environment:
       - ENV=test
       - GIN_MODE=release
@@ -27,6 +29,8 @@ services:
     build:
       context: .
       dockerfile: e2e/Dockerfile
+      args:
+        PYTHON_IMAGE: ${PYTHON_IMAGE:-python:3.12-slim}
     environment:
       - E2E_BASE_API_URL=http://api-go:8080
       - E2E_SOURCE_TYPE=${E2E_SOURCE_TYPE}

--- a/api-go/docker-compose.go-e2e.yml
+++ b/api-go/docker-compose.go-e2e.yml
@@ -1,6 +1,6 @@
 services:
   mongo:
-    image: mongo:7
+    image: ${MONGO_IMAGE:-mongo:7}
     environment:
       - MONGO_INITDB_ROOT_USERNAME=root
       - MONGO_INITDB_ROOT_PASSWORD=example
@@ -11,7 +11,7 @@ services:
       retries: 12
 
   minio:
-    image: minio/minio:RELEASE.2025-01-20T14-49-07Z
+    image: ${MINIO_IMAGE:-minio/minio:RELEASE.2025-01-20T14-49-07Z}
     environment:
       - MINIO_ROOT_USER=minioadmin
       - MINIO_ROOT_PASSWORD=minioadmin
@@ -26,6 +26,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.go-e2e
+      args:
+        GO_IMAGE: ${GO_IMAGE:-golang:1.24}
     environment:
       - ENV=test
       - E2E_S3_ENDPOINT=${E2E_S3_ENDPOINT:-http://minio:9000}

--- a/api-go/docker-compose.yml
+++ b/api-go/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   mongo:
-    image: mongo:7.0.32-rc2-jammy
+    image: ${MONGO_IMAGE:-mongo:7.0.32-rc2-jammy}
     environment:
       - MONGO_INITDB_ROOT_USERNAME=root
       - MONGO_INITDB_ROOT_PASSWORD=example

--- a/api-go/e2e/Dockerfile
+++ b/api-go/e2e/Dockerfile
@@ -1,4 +1,5 @@
-FROM python:3.12-slim
+ARG PYTHON_IMAGE=python:3.12-slim
+FROM ${PYTHON_IMAGE}
 
 WORKDIR /work
 COPY e2e/requirements.txt /tmp/requirements.txt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   mongo:
-    image: mongo:7.0.32-rc2-jammy
+    image: ${MONGO_IMAGE:-mongo:7.0.32-rc2-jammy}
     environment:
       MONGO_INITDB_ROOT_USERNAME: root
       MONGO_INITDB_ROOT_PASSWORD: example
@@ -8,7 +8,7 @@ services:
       - mongo-data:/data/db
 
   minio:
-    image: minio/minio:RELEASE.2025-01-20T14-49-07Z
+    image: ${MINIO_IMAGE:-minio/minio:RELEASE.2025-01-20T14-49-07Z}
     environment:
       MINIO_ROOT_USER: minioadmin
       MINIO_ROOT_PASSWORD: minioadmin
@@ -19,7 +19,7 @@ services:
       - minio-data:/data
 
   minio-init:
-    image: minio/mc
+    image: ${MINIO_MC_IMAGE:-minio/mc}
     depends_on:
       - minio
     entrypoint: >
@@ -33,6 +33,8 @@ services:
     build:
       context: ./api-go
       dockerfile: Dockerfile
+      args:
+        GO_IMAGE: ${GO_IMAGE:-golang:1.24}
     environment:
       ENV: local
       DB_HOST: mongo
@@ -65,6 +67,9 @@ services:
     build:
       context: ./webui
       dockerfile: Dockerfile
+      args:
+        NODE_IMAGE: ${NODE_IMAGE:-node:20-alpine}
+        NGINX_IMAGE: ${NGINX_IMAGE:-nginx:alpine}
     environment:
       API_HOST: api
       API_PORT: "8080"

--- a/webui/Dockerfile
+++ b/webui/Dockerfile
@@ -1,5 +1,7 @@
 # Build stage
-FROM node:20-alpine AS build
+ARG NODE_IMAGE=node:20-alpine
+ARG NGINX_IMAGE=nginx:alpine
+FROM ${NODE_IMAGE} AS build
 WORKDIR /app
 COPY package*.json ./
 RUN npm ci --include=dev
@@ -7,7 +9,7 @@ COPY . .
 RUN npm run build
 
 # Production stage
-FROM nginx:alpine
+FROM ${NGINX_IMAGE}
 COPY --from=build /app/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/templates/default.conf.template
 ENV API_HOST=api


### PR DESCRIPTION
## Summary
- route affected Woodpecker job and service images through ECR Public/Quay mirrors
- make compose service images overridable while preserving local Docker Hub defaults
- make Dockerfile base images overridable so compose builds do not hit Docker Hub in CI

## Validation
- git diff --check
- verified mirror manifests with registry HEAD requests for Mongo, MinIO, Docker, Go, Python, Node, and Nginx tags
- did not run local Docker/Compose/builds per THE-418 constraints

Relates to THE-418. Blocks THE-8 until Woodpecker confirms.