### PR TITLE
Fix S3 GET failure semantics for corrupt chunks

### DIFF
--- a/api-go/internal/handlers/s3.go
+++ b/api-go/internal/handlers/s3.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
-	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -68,7 +67,10 @@ type objectRange struct {
 	end   int64
 }
 
-const listCommonPrefixSkipSuffix = "\U0010FFFF"
+const (
+	listCommonPrefixSkipSuffix = "\U0010FFFF"
+	s3GetPreflightBytes        = int64(1)
+)
 
 var (
 	streamS3Object      = manager.StreamFile
@@ -389,33 +391,19 @@ func setObjectHeaders(c *gin.Context, fileDoc *repository.File, total int64) {
 	c.Header("Content-Type", "application/octet-stream")
 }
 
-func stageObjectBody(stream func(io.Writer) error) (*os.File, error) {
-	tmp, err := os.CreateTemp("", "sfree-s3-get-*")
-	if err != nil {
-		return nil, err
+// preflightObjectRange checks the first response byte before success headers are
+// committed. Later source failures are logged and surface to clients as an
+// incomplete body under the declared Content-Length, which preserves large
+// object streaming without staging the full response in memory or on disk.
+func preflightObjectRange(ctx context.Context, sourceRepo *repository.SourceRepository, fileDoc *repository.File, start, end int64) error {
+	if end < start {
+		return nil
 	}
-	keep := false
-	defer func() {
-		if !keep {
-			name := tmp.Name()
-			_ = tmp.Close()
-			_ = os.Remove(name)
-		}
-	}()
-	if err := stream(tmp); err != nil {
-		return nil, err
+	preflightEnd := start + s3GetPreflightBytes - 1
+	if preflightEnd > end {
+		preflightEnd = end
 	}
-	if _, err := tmp.Seek(0, io.SeekStart); err != nil {
-		return nil, err
-	}
-	keep = true
-	return tmp, nil
-}
-
-func closeAndRemove(file *os.File) {
-	name := file.Name()
-	_ = file.Close()
-	_ = os.Remove(name)
+	return streamS3ObjectRange(ctx, sourceRepo, fileDoc, io.Discard, start, preflightEnd)
 }
 
 // HeadObject godoc
@@ -473,19 +461,15 @@ func getObject(bucketRepo objectBucketReader, sourceRepo *repository.SourceRepos
 		}
 		rangeHeader := c.GetHeader("Range")
 		if rangeHeader == "" {
-			body, err := stageObjectBody(func(w io.Writer) error {
-				return streamS3Object(c.Request.Context(), sourceRepo, fileDoc, w)
-			})
-			if err != nil {
+			if err := preflightObjectRange(c.Request.Context(), sourceRepo, fileDoc, 0, total-1); err != nil {
 				slog.ErrorContext(c.Request.Context(), "get object: stream failed", slog.String("error", err.Error()))
 				writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
 				return
 			}
-			defer closeAndRemove(body)
 			setObjectHeaders(c, fileDoc, total)
 			c.Status(http.StatusOK)
-			if _, err := io.Copy(c.Writer, body); err != nil {
-				slog.ErrorContext(c.Request.Context(), "get object: write failed", slog.String("error", err.Error()))
+			if err := streamS3Object(c.Request.Context(), sourceRepo, fileDoc, c.Writer); err != nil {
+				slog.ErrorContext(c.Request.Context(), "get object: stream failed after response commit", slog.String("error", err.Error()))
 			}
 			return
 		}
@@ -497,21 +481,17 @@ func getObject(bucketRepo objectBucketReader, sourceRepo *repository.SourceRepos
 			writeS3Error(c, http.StatusRequestedRangeNotSatisfiable, "InvalidRange", "The requested range is not satisfiable")
 			return
 		}
-		body, err := stageObjectBody(func(w io.Writer) error {
-			return streamS3ObjectRange(c.Request.Context(), sourceRepo, fileDoc, w, objRange.start, objRange.end)
-		})
-		if err != nil {
+		if err := preflightObjectRange(c.Request.Context(), sourceRepo, fileDoc, objRange.start, objRange.end); err != nil {
 			slog.ErrorContext(c.Request.Context(), "get object: stream failed", slog.String("error", err.Error()))
 			writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
 			return
 		}
-		defer closeAndRemove(body)
 		setObjectHeaders(c, fileDoc, total)
 		c.Header("Content-Length", strconv.FormatInt(objRange.end-objRange.start+1, 10))
 		c.Header("Content-Range", "bytes "+strconv.FormatInt(objRange.start, 10)+"-"+strconv.FormatInt(objRange.end, 10)+"/"+strconv.FormatInt(total, 10))
 		c.Status(http.StatusPartialContent)
-		if _, err := io.Copy(c.Writer, body); err != nil {
-			slog.ErrorContext(c.Request.Context(), "get object: write failed", slog.String("error", err.Error()))
+		if err := streamS3ObjectRange(c.Request.Context(), sourceRepo, fileDoc, c.Writer, objRange.start, objRange.end); err != nil {
+			slog.ErrorContext(c.Request.Context(), "get object: stream failed after response commit", slog.String("error", err.Error()))
 		}
 	}
 }

--- a/api-go/internal/handlers/s3.go
+++ b/api-go/internal/handlers/s3.go
@@ -5,8 +5,10 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/xml"
+	"io"
 	"log/slog"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -67,6 +69,19 @@ type objectRange struct {
 }
 
 const listCommonPrefixSkipSuffix = "\U0010FFFF"
+
+var (
+	streamS3Object      = manager.StreamFile
+	streamS3ObjectRange = manager.StreamFileRange
+)
+
+type objectBucketReader interface {
+	GetByKey(ctx context.Context, key string) (*repository.Bucket, error)
+}
+
+type objectFileReader interface {
+	GetByName(ctx context.Context, bucketID primitive.ObjectID, name string) (*repository.File, error)
+}
 
 func writeS3Error(c *gin.Context, status int, code, message string) {
 	c.XML(status, s3Error{Code: code, Message: message})
@@ -330,9 +345,7 @@ func ListObjectsV2(bucketRepo *repository.BucketRepository, fileRepo *repository
 	}
 }
 
-// lookupObject resolves the bucket and file from the request context.
-// Returns the file document and total size, or writes an S3 error and returns false.
-func lookupObject(c *gin.Context, bucketRepo *repository.BucketRepository, fileRepo *repository.FileRepository) (*repository.File, int64, bool) {
+func lookupObject(c *gin.Context, bucketRepo objectBucketReader, fileRepo objectFileReader) (*repository.File, int64, bool) {
 	ctx := c.Request.Context()
 	bucketKey := c.Param("bucket")
 	name := strings.TrimPrefix(c.Param("object"), "/")
@@ -368,14 +381,41 @@ func lookupObject(c *gin.Context, bucketRepo *repository.BucketRepository, fileR
 	return fileDoc, total, true
 }
 
-// setObjectHeaders writes standard S3 object headers (ETag, Last-Modified,
-// Content-Length, Content-Type).
 func setObjectHeaders(c *gin.Context, fileDoc *repository.File, total int64) {
 	c.Header("Accept-Ranges", "bytes")
 	c.Header("ETag", objectETag(*fileDoc))
 	c.Header("Last-Modified", fileDoc.CreatedAt.UTC().Format(http.TimeFormat))
 	c.Header("Content-Length", strconv.FormatInt(total, 10))
 	c.Header("Content-Type", "application/octet-stream")
+}
+
+func stageObjectBody(stream func(io.Writer) error) (*os.File, error) {
+	tmp, err := os.CreateTemp("", "sfree-s3-get-*")
+	if err != nil {
+		return nil, err
+	}
+	keep := false
+	defer func() {
+		if !keep {
+			name := tmp.Name()
+			_ = tmp.Close()
+			_ = os.Remove(name)
+		}
+	}()
+	if err := stream(tmp); err != nil {
+		return nil, err
+	}
+	if _, err := tmp.Seek(0, io.SeekStart); err != nil {
+		return nil, err
+	}
+	keep = true
+	return tmp, nil
+}
+
+func closeAndRemove(file *os.File) {
+	name := file.Name()
+	_ = file.Close()
+	_ = os.Remove(name)
 }
 
 // HeadObject godoc
@@ -413,6 +453,15 @@ func HeadObject(bucketRepo *repository.BucketRepository, fileRepo *repository.Fi
 // @Failure 500 {string} string ""
 // @Router /api/s3/{bucket}/{object} [get]
 func GetObject(bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository) gin.HandlerFunc {
+	if bucketRepo == nil || sourceRepo == nil || fileRepo == nil {
+		return func(c *gin.Context) {
+			c.Status(http.StatusServiceUnavailable)
+		}
+	}
+	return getObject(bucketRepo, sourceRepo, fileRepo)
+}
+
+func getObject(bucketRepo objectBucketReader, sourceRepo *repository.SourceRepository, fileRepo objectFileReader) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		if bucketRepo == nil || sourceRepo == nil || fileRepo == nil {
 			c.Status(http.StatusServiceUnavailable)
@@ -424,10 +473,19 @@ func GetObject(bucketRepo *repository.BucketRepository, sourceRepo *repository.S
 		}
 		rangeHeader := c.GetHeader("Range")
 		if rangeHeader == "" {
+			body, err := stageObjectBody(func(w io.Writer) error {
+				return streamS3Object(c.Request.Context(), sourceRepo, fileDoc, w)
+			})
+			if err != nil {
+				slog.ErrorContext(c.Request.Context(), "get object: stream failed", slog.String("error", err.Error()))
+				writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
+				return
+			}
+			defer closeAndRemove(body)
 			setObjectHeaders(c, fileDoc, total)
 			c.Status(http.StatusOK)
-			if err := manager.StreamFile(c.Request.Context(), sourceRepo, fileDoc, c.Writer); err != nil {
-				slog.ErrorContext(c.Request.Context(), "get object: stream failed", slog.String("error", err.Error()))
+			if _, err := io.Copy(c.Writer, body); err != nil {
+				slog.ErrorContext(c.Request.Context(), "get object: write failed", slog.String("error", err.Error()))
 			}
 			return
 		}
@@ -439,12 +497,21 @@ func GetObject(bucketRepo *repository.BucketRepository, sourceRepo *repository.S
 			writeS3Error(c, http.StatusRequestedRangeNotSatisfiable, "InvalidRange", "The requested range is not satisfiable")
 			return
 		}
+		body, err := stageObjectBody(func(w io.Writer) error {
+			return streamS3ObjectRange(c.Request.Context(), sourceRepo, fileDoc, w, objRange.start, objRange.end)
+		})
+		if err != nil {
+			slog.ErrorContext(c.Request.Context(), "get object: stream failed", slog.String("error", err.Error()))
+			writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
+			return
+		}
+		defer closeAndRemove(body)
 		setObjectHeaders(c, fileDoc, total)
 		c.Header("Content-Length", strconv.FormatInt(objRange.end-objRange.start+1, 10))
 		c.Header("Content-Range", "bytes "+strconv.FormatInt(objRange.start, 10)+"-"+strconv.FormatInt(objRange.end, 10)+"/"+strconv.FormatInt(total, 10))
 		c.Status(http.StatusPartialContent)
-		if err := manager.StreamFileRange(c.Request.Context(), sourceRepo, fileDoc, c.Writer, objRange.start, objRange.end); err != nil {
-			slog.ErrorContext(c.Request.Context(), "get object: stream failed", slog.String("error", err.Error()))
+		if _, err := io.Copy(c.Writer, body); err != nil {
+			slog.ErrorContext(c.Request.Context(), "get object: write failed", slog.String("error", err.Error()))
 		}
 	}
 }

--- a/api-go/internal/handlers/s3_get_test.go
+++ b/api-go/internal/handlers/s3_get_test.go
@@ -62,9 +62,11 @@ func getObjectFailureTestHandler(t *testing.T) gin.HandlerFunc {
 }
 
 func TestGetObjectStreamFailureReturnsS3ErrorBeforeSuccess(t *testing.T) {
-	origStream := streamS3Object
-	t.Cleanup(func() { streamS3Object = origStream })
-	streamS3Object = func(_ context.Context, _ *repository.SourceRepository, _ *repository.File, w io.Writer) error {
+	origStreamRange := streamS3ObjectRange
+	t.Cleanup(func() { streamS3ObjectRange = origStreamRange })
+	var gotStart, gotEnd int64
+	streamS3ObjectRange = func(_ context.Context, _ *repository.SourceRepository, _ *repository.File, w io.Writer, start, end int64) error {
+		gotStart, gotEnd = start, end
 		_, _ = io.WriteString(w, "partial")
 		return manager.ErrChecksumMismatch
 	}
@@ -82,6 +84,9 @@ func TestGetObjectStreamFailureReturnsS3ErrorBeforeSuccess(t *testing.T) {
 
 	if w.Code != http.StatusInternalServerError {
 		t.Fatalf("expected 500, got %d", w.Code)
+	}
+	if gotStart != 0 || gotEnd != 0 {
+		t.Fatalf("expected bounded preflight range 0-0, got %d-%d", gotStart, gotEnd)
 	}
 	if body := w.Body.String(); !strings.Contains(body, "<Code>InternalError</Code>") || strings.Contains(body, "partial") {
 		t.Fatalf("unexpected body: %s", body)
@@ -119,8 +124,8 @@ func TestGetObjectRangeStreamFailureReturnsS3ErrorBeforePartialContent(t *testin
 	if w.Code != http.StatusInternalServerError {
 		t.Fatalf("expected 500, got %d", w.Code)
 	}
-	if gotStart != 2 || gotEnd != 4 {
-		t.Fatalf("expected requested range 2-4, got %d-%d", gotStart, gotEnd)
+	if gotStart != 2 || gotEnd != 2 {
+		t.Fatalf("expected bounded preflight range 2-2, got %d-%d", gotStart, gotEnd)
 	}
 	if body := w.Body.String(); !strings.Contains(body, "<Code>InternalError</Code>") || strings.Contains(body, "par") {
 		t.Fatalf("unexpected body: %s", body)
@@ -130,5 +135,44 @@ func TestGetObjectRangeStreamFailureReturnsS3ErrorBeforePartialContent(t *testin
 	}
 	if got := w.Header().Get("ETag"); got != "" {
 		t.Fatalf("expected no success ETag header, got %q", got)
+	}
+}
+
+func TestGetObjectStreamsBodyAfterBoundedPreflight(t *testing.T) {
+	origStream := streamS3Object
+	origStreamRange := streamS3ObjectRange
+	t.Cleanup(func() {
+		streamS3Object = origStream
+		streamS3ObjectRange = origStreamRange
+	})
+	var gotStart, gotEnd int64
+	streamS3ObjectRange = func(_ context.Context, _ *repository.SourceRepository, _ *repository.File, _ io.Writer, start, end int64) error {
+		gotStart, gotEnd = start, end
+		return nil
+	}
+	streamS3Object = func(_ context.Context, _ *repository.SourceRepository, _ *repository.File, w io.Writer) error {
+		_, err := io.WriteString(w, "complete")
+		return err
+	}
+
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("accessKey", "access-key")
+		c.Next()
+	})
+	r.GET("/api/s3/:bucket/*object", getObjectFailureTestHandler(t))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/s3/bucket/object.txt", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if gotStart != 0 || gotEnd != 0 {
+		t.Fatalf("expected bounded preflight range 0-0, got %d-%d", gotStart, gotEnd)
+	}
+	if body := w.Body.String(); body != "complete" {
+		t.Fatalf("unexpected body: %s", body)
 	}
 }

--- a/api-go/internal/handlers/s3_get_test.go
+++ b/api-go/internal/handlers/s3_get_test.go
@@ -1,0 +1,134 @@
+package handlers
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/example/sfree/api-go/internal/manager"
+	"github.com/example/sfree/api-go/internal/repository"
+	"github.com/gin-gonic/gin"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+type fakeObjectBucketReader struct {
+	bucket *repository.Bucket
+	err    error
+}
+
+func (r fakeObjectBucketReader) GetByKey(_ context.Context, _ string) (*repository.Bucket, error) {
+	return r.bucket, r.err
+}
+
+type fakeObjectFileReader struct {
+	file *repository.File
+	err  error
+}
+
+func (r fakeObjectFileReader) GetByName(_ context.Context, _ primitive.ObjectID, _ string) (*repository.File, error) {
+	return r.file, r.err
+}
+
+func getObjectFailureTestHandler(t *testing.T) gin.HandlerFunc {
+	t.Helper()
+
+	bucketID := primitive.NewObjectID()
+	sourceID := primitive.NewObjectID()
+	bucketRepo := fakeObjectBucketReader{
+		bucket: &repository.Bucket{
+			ID:        bucketID,
+			Key:       "bucket",
+			AccessKey: "access-key",
+		},
+	}
+	fileRepo := fakeObjectFileReader{
+		file: &repository.File{
+			ID:        primitive.NewObjectID(),
+			BucketID:  bucketID,
+			Name:      "object.txt",
+			CreatedAt: time.Unix(1700000000, 0).UTC(),
+			Chunks: []repository.FileChunk{
+				{SourceID: sourceID, Name: "chunk-1", Order: 0, Size: 7, Checksum: "bad"},
+			},
+		},
+	}
+	sourceRepo := &repository.SourceRepository{}
+
+	return getObject(bucketRepo, sourceRepo, fileRepo)
+}
+
+func TestGetObjectStreamFailureReturnsS3ErrorBeforeSuccess(t *testing.T) {
+	origStream := streamS3Object
+	t.Cleanup(func() { streamS3Object = origStream })
+	streamS3Object = func(_ context.Context, _ *repository.SourceRepository, _ *repository.File, w io.Writer) error {
+		_, _ = io.WriteString(w, "partial")
+		return manager.ErrChecksumMismatch
+	}
+
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("accessKey", "access-key")
+		c.Next()
+	})
+	r.GET("/api/s3/:bucket/*object", getObjectFailureTestHandler(t))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/s3/bucket/object.txt", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", w.Code)
+	}
+	if body := w.Body.String(); !strings.Contains(body, "<Code>InternalError</Code>") || strings.Contains(body, "partial") {
+		t.Fatalf("unexpected body: %s", body)
+	}
+	if got := w.Header().Get("ETag"); got != "" {
+		t.Fatalf("expected no success ETag header, got %q", got)
+	}
+	if got := w.Header().Get("Accept-Ranges"); got != "" {
+		t.Fatalf("expected no success Accept-Ranges header, got %q", got)
+	}
+}
+
+func TestGetObjectRangeStreamFailureReturnsS3ErrorBeforePartialContent(t *testing.T) {
+	origStreamRange := streamS3ObjectRange
+	t.Cleanup(func() { streamS3ObjectRange = origStreamRange })
+	var gotStart, gotEnd int64
+	streamS3ObjectRange = func(_ context.Context, _ *repository.SourceRepository, _ *repository.File, w io.Writer, start, end int64) error {
+		gotStart, gotEnd = start, end
+		_, _ = io.WriteString(w, "par")
+		return manager.ErrChecksumMismatch
+	}
+
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("accessKey", "access-key")
+		c.Next()
+	})
+	r.GET("/api/s3/:bucket/*object", getObjectFailureTestHandler(t))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/s3/bucket/object.txt", nil)
+	req.Header.Set("Range", "bytes=2-4")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", w.Code)
+	}
+	if gotStart != 2 || gotEnd != 4 {
+		t.Fatalf("expected requested range 2-4, got %d-%d", gotStart, gotEnd)
+	}
+	if body := w.Body.String(); !strings.Contains(body, "<Code>InternalError</Code>") || strings.Contains(body, "par") {
+		t.Fatalf("unexpected body: %s", body)
+	}
+	if got := w.Header().Get("Content-Range"); got != "" {
+		t.Fatalf("expected no success Content-Range header, got %q", got)
+	}
+	if got := w.Header().Get("ETag"); got != "" {
+		t.Fatalf("expected no success ETag header, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

- Add bounded S3 GET/ranged-GET preflight before committing success headers so immediate reconstruction failures return a stable S3 `InternalError` XML response.
- Preserve large-object streaming by removing full temp-file response staging; successful GETs stream directly from sources to the client.
- Document the post-commit behavior in code: later source failures are logged and surface as incomplete bodies under the declared `Content-Length`.
- Add focused handler regressions for full GET and ranged GET preflight failures plus successful streaming after preflight.

## Validation

- `gofmt` on touched Go files
- Not run locally: `go test ./...` / `golangci-lint run` per heartbeat instruction to keep CPU-bound validation in CI/Woodpecker.