### PR TITLE
THE-7: Add S3 CopyObject support

### DIFF
--- a/api-go/internal/e2e/s3_compat_test.go
+++ b/api-go/internal/e2e/s3_compat_test.go
@@ -760,6 +760,19 @@ func TestS3CompatCopyObject(t *testing.T) {
 	if status != http.StatusNotImplemented {
 		t.Fatalf("CopyObject REPLACE: expected 501, got %d: %s", status, body)
 	}
+
+	status, body = s3Do(t, http.MethodDelete, s3URL(sourceBucket, sourceKey), sourceBucket.AccessKey, sourceBucket.AccessSecret, env.Region, nil)
+	if status != http.StatusNoContent {
+		t.Fatalf("DELETE source after copy: expected 204, got %d: %s", status, body)
+	}
+	status, body = s3Do(t, http.MethodGet, s3URL(sourceBucket, sameBucketKey), sourceBucket.AccessKey, sourceBucket.AccessSecret, env.Region, nil)
+	if status != http.StatusOK || !bytes.Equal(body, objectContent) {
+		t.Fatalf("GET same-bucket copy after source delete mismatch: status=%d body=%q", status, body)
+	}
+	status, body = s3Do(t, http.MethodGet, s3URL(destBucket, crossBucketKey), destBucket.AccessKey, destBucket.AccessSecret, env.Region, nil)
+	if status != http.StatusOK || !bytes.Equal(body, objectContent) {
+		t.Fatalf("GET cross-bucket copy after source delete mismatch: status=%d body=%q", status, body)
+	}
 }
 
 func TestS3CompatGetObjectRange(t *testing.T) {

--- a/api-go/internal/e2e/s3_compat_test.go
+++ b/api-go/internal/e2e/s3_compat_test.go
@@ -685,6 +685,83 @@ func TestS3CompatObjectLifecycle(t *testing.T) {
 	}
 }
 
+func TestS3CompatCopyObject(t *testing.T) {
+	env, ok := loadS3E2EEnv()
+	if !ok {
+		t.Skip("E2E_S3_ENDPOINT not set; skipping S3 E2E tests")
+	}
+
+	ts, _ := newTestServer(t)
+	ensureMinIOBucket(t, env)
+
+	suffix := uniqueSuffix()
+	username, password := createTestUser(t, ts, suffix)
+	sourceID := createS3Source(t, ts, username, password, "src-"+suffix, env)
+	sourceBucket := createBucket(t, ts, username, password, "src-bkt-"+suffix, sourceID)
+	destBucket := createBucket(t, ts, username, password, "dst-bkt-"+suffix, sourceID)
+
+	t.Cleanup(func() {
+		apiDelete(t, ts, "/api/v1/buckets/"+destBucket.ID, username, password)
+		apiDelete(t, ts, "/api/v1/buckets/"+sourceBucket.ID, username, password)
+		apiDelete(t, ts, "/api/v1/sources/"+sourceID, username, password)
+	})
+
+	sourceKey := "copy-source-" + suffix + ".txt"
+	sameBucketKey := "copy-same-" + suffix + ".txt"
+	crossBucketKey := "copy-cross-" + suffix + ".txt"
+	objectContent := []byte("copy me without duplicating chunks")
+	s3URL := func(bucket createBucketResult, key string) string {
+		return fmt.Sprintf("%s/api/s3/%s/%s", ts.URL, bucket.Key, key)
+	}
+
+	status, body := s3Do(t, http.MethodPut, s3URL(sourceBucket, sourceKey), sourceBucket.AccessKey, sourceBucket.AccessSecret, env.Region, objectContent)
+	if status != http.StatusOK {
+		t.Fatalf("PUT source object: expected 200, got %d: %s", status, body)
+	}
+
+	copyHeaders := map[string]string{"x-amz-copy-source": "/" + sourceBucket.Key + "/" + sourceKey}
+	status, _, body = s3DoWithHeaders(t, http.MethodPut, s3URL(sourceBucket, sameBucketKey), sourceBucket.AccessKey, sourceBucket.AccessSecret, env.Region, nil, copyHeaders)
+	if status != http.StatusOK {
+		t.Fatalf("CopyObject same bucket: expected 200, got %d: %s", status, body)
+	}
+	var result struct {
+		ETag         string `xml:"ETag"`
+		LastModified string `xml:"LastModified"`
+	}
+	if err := xml.Unmarshal(body, &result); err != nil {
+		t.Fatalf("decode CopyObject result: %v body=%s", err, body)
+	}
+	if result.ETag == "" || result.LastModified == "" {
+		t.Fatalf("CopyObject result missing ETag or LastModified: %+v body=%s", result, body)
+	}
+	status, body = s3Do(t, http.MethodGet, s3URL(sourceBucket, sameBucketKey), sourceBucket.AccessKey, sourceBucket.AccessSecret, env.Region, nil)
+	if status != http.StatusOK || !bytes.Equal(body, objectContent) {
+		t.Fatalf("GET same-bucket copy mismatch: status=%d body=%q", status, body)
+	}
+
+	status, _, body = s3DoWithHeaders(t, http.MethodPut, s3URL(destBucket, crossBucketKey), destBucket.AccessKey, destBucket.AccessSecret, env.Region, nil, copyHeaders)
+	if status != http.StatusOK {
+		t.Fatalf("CopyObject cross bucket: expected 200, got %d: %s", status, body)
+	}
+	status, body = s3Do(t, http.MethodGet, s3URL(destBucket, crossBucketKey), destBucket.AccessKey, destBucket.AccessSecret, env.Region, nil)
+	if status != http.StatusOK || !bytes.Equal(body, objectContent) {
+		t.Fatalf("GET cross-bucket copy mismatch: status=%d body=%q", status, body)
+	}
+
+	replaceHeaders := map[string]string{
+		"x-amz-copy-source":        "/" + sourceBucket.Key + "/" + sourceKey,
+		"x-amz-metadata-directive": "REPLACE",
+	}
+	status, body = s3Do(t, http.MethodPut, s3URL(sourceBucket, "copy-replace-"+suffix+".txt"), sourceBucket.AccessKey, sourceBucket.AccessSecret, env.Region, nil)
+	if status != http.StatusOK {
+		t.Fatalf("PUT replace-control object: expected 200, got %d: %s", status, body)
+	}
+	status, _, body = s3DoWithHeaders(t, http.MethodPut, s3URL(sourceBucket, "copy-replace-"+suffix+".txt"), sourceBucket.AccessKey, sourceBucket.AccessSecret, env.Region, nil, replaceHeaders)
+	if status != http.StatusNotImplemented {
+		t.Fatalf("CopyObject REPLACE: expected 501, got %d: %s", status, body)
+	}
+}
+
 func TestS3CompatGetObjectRange(t *testing.T) {
 	env, ok := loadS3E2EEnv()
 	if !ok {

--- a/api-go/internal/handlers/bucket.go
+++ b/api-go/internal/handlers/bucket.go
@@ -586,13 +586,13 @@ func DeleteFile(bucketRepo *repository.BucketRepository, sourceRepo *repository.
 			c.Status(http.StatusNotFound)
 			return
 		}
-		if err := manager.DeleteFileChunks(ctx, sourceRepo, fileDoc.Chunks); err != nil {
-			slog.ErrorContext(ctx, "delete file: delete chunk", slog.String("error", err.Error()))
+		if err := fileRepo.Delete(ctx, fileID); err != nil {
+			slog.ErrorContext(ctx, "delete file: delete metadata", slog.String("error", err.Error()))
 			c.Status(http.StatusInternalServerError)
 			return
 		}
-		if err := fileRepo.Delete(ctx, fileID); err != nil {
-			slog.ErrorContext(ctx, "delete file: delete metadata", slog.String("error", err.Error()))
+		if err := deleteFileChunksIfUnreferenced(ctx, sourceRepo, fileRepo, fileDoc.Chunks); err != nil {
+			slog.ErrorContext(ctx, "delete file: delete chunk", slog.String("error", err.Error()))
 			c.Status(http.StatusInternalServerError)
 			return
 		}

--- a/api-go/internal/handlers/s3.go
+++ b/api-go/internal/handlers/s3.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -52,6 +53,12 @@ type deleteObjectsResult struct {
 	Xmlns   string                `xml:"xmlns,attr"`
 	Deleted []deletedObjectResult `xml:"Deleted,omitempty"`
 	Errors  []deleteObjectError   `xml:"Error,omitempty"`
+}
+
+type copyObjectResult struct {
+	XMLName      xml.Name `xml:"CopyObjectResult"`
+	ETag         string   `xml:"ETag"`
+	LastModified string   `xml:"LastModified"`
 }
 
 type deletedObjectResult struct {
@@ -223,6 +230,25 @@ type objectFileReader interface {
 
 func writeS3Error(c *gin.Context, status int, code, message string) {
 	c.XML(status, s3Error{Code: code, Message: message})
+}
+
+func parseCopySource(raw string) (string, string, bool) {
+	raw = strings.TrimSpace(raw)
+	raw = strings.TrimPrefix(raw, "/")
+	raw, _, _ = strings.Cut(raw, "?")
+	parts := strings.SplitN(raw, "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", false
+	}
+	bucket, err := url.PathUnescape(parts[0])
+	if err != nil || bucket == "" {
+		return "", "", false
+	}
+	key, err := url.PathUnescape(parts[1])
+	if err != nil || key == "" {
+		return "", "", false
+	}
+	return bucket, key, true
 }
 
 func deleteObjectByName(ctx context.Context, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository, bucketID primitive.ObjectID, name string) (bool, error) {
@@ -742,6 +768,107 @@ func PutObject(bucketRepo *repository.BucketRepository, sourceRepo *repository.S
 			slog.WarnContext(ctx, "put object: delete old chunks", slog.String("error", err.Error()))
 		}
 		c.Status(http.StatusOK)
+	}
+}
+
+// CopyObject godoc
+// @Summary Copy object
+// @Tags s3
+// @Param bucket path string true "Destination bucket key"
+// @Param object path string true "Destination object key"
+// @Success 200 {string} string ""
+// @Failure 400 {string} string ""
+// @Failure 404 {string} string ""
+// @Failure 500 {string} string ""
+// @Router /api/s3/{bucket}/{object} [put]
+func CopyObject(bucketRepo *repository.BucketRepository, fileRepo *repository.FileRepository) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		ctx := c.Request.Context()
+		if bucketRepo == nil || fileRepo == nil {
+			c.Status(http.StatusServiceUnavailable)
+			return
+		}
+		destBucket, ok := lookupBucket(c, bucketRepo)
+		if !ok {
+			return
+		}
+		destKey := strings.TrimPrefix(c.Param("object"), "/")
+		if destKey == "" {
+			writeS3Error(c, http.StatusBadRequest, "InvalidRequest", "empty destination object key")
+			return
+		}
+		directive := strings.ToUpper(strings.TrimSpace(c.GetHeader("x-amz-metadata-directive")))
+		if directive == "" {
+			directive = "COPY"
+		}
+		if directive != "COPY" {
+			writeS3Error(c, http.StatusNotImplemented, "NotImplemented", "x-amz-metadata-directive REPLACE is not supported")
+			return
+		}
+		sourceBucketKey, sourceKey, ok := parseCopySource(c.GetHeader("x-amz-copy-source"))
+		if !ok {
+			writeS3Error(c, http.StatusBadRequest, "InvalidArgument", "x-amz-copy-source must be /bucket/key")
+			return
+		}
+		sourceBucket, err := bucketRepo.GetByKey(ctx, sourceBucketKey)
+		if err != nil {
+			if err == mongo.ErrNoDocuments {
+				writeS3Error(c, http.StatusNotFound, "NoSuchBucket", "")
+				return
+			}
+			slog.ErrorContext(ctx, "copy object: get source bucket", slog.String("error", err.Error()))
+			writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
+			return
+		}
+		if sourceBucket.ID != destBucket.ID && sourceBucket.UserID != destBucket.UserID {
+			writeS3Error(c, http.StatusForbidden, "AccessDenied", "")
+			return
+		}
+		sourceFile, err := fileRepo.GetByName(ctx, sourceBucket.ID, sourceKey)
+		if err != nil {
+			if err == mongo.ErrNoDocuments {
+				writeS3Error(c, http.StatusNotFound, "NoSuchKey", "")
+				return
+			}
+			slog.ErrorContext(ctx, "copy object: get source file", slog.String("error", err.Error()))
+			writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
+			return
+		}
+
+		now := time.Now().UTC()
+		chunks := append([]repository.FileChunk(nil), sourceFile.Chunks...)
+		copyFile := repository.File{BucketID: destBucket.ID, Name: destKey, CreatedAt: now, Chunks: chunks}
+		existingFile, err := fileRepo.GetByName(ctx, destBucket.ID, destKey)
+		if err != nil && err != mongo.ErrNoDocuments {
+			slog.ErrorContext(ctx, "copy object: get existing file", slog.String("error", err.Error()))
+			writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
+			return
+		}
+		if err == mongo.ErrNoDocuments {
+			existingFile = nil
+		}
+		if existingFile == nil {
+			created, err := fileRepo.Create(ctx, copyFile)
+			if err != nil {
+				slog.ErrorContext(ctx, "copy object: create file", slog.String("error", err.Error()))
+				writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
+				return
+			}
+			copyFile = *created
+		} else {
+			copyFile.ID = existingFile.ID
+			updated, err := fileRepo.UpdateByID(ctx, copyFile)
+			if err != nil {
+				slog.ErrorContext(ctx, "copy object: update file", slog.String("error", err.Error()))
+				writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
+				return
+			}
+			copyFile = *updated
+		}
+		c.XML(http.StatusOK, copyObjectResult{
+			ETag:         objectETag(copyFile),
+			LastModified: now.Format(time.RFC3339),
+		})
 	}
 }
 

--- a/api-go/internal/handlers/s3.go
+++ b/api-go/internal/handlers/s3.go
@@ -57,6 +57,7 @@ type deleteObjectsResult struct {
 
 type copyObjectResult struct {
 	XMLName      xml.Name `xml:"CopyObjectResult"`
+	Xmlns        string   `xml:"xmlns,attr"`
 	ETag         string   `xml:"ETag"`
 	LastModified string   `xml:"LastModified"`
 }
@@ -232,6 +233,28 @@ func writeS3Error(c *gin.Context, status int, code, message string) {
 	c.XML(status, s3Error{Code: code, Message: message})
 }
 
+func deleteFileChunksIfUnreferenced(ctx context.Context, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository, chunks []repository.FileChunk) error {
+	seen := make(map[string]struct{}, len(chunks))
+	for _, chunk := range chunks {
+		ref := chunk.SourceID.Hex() + "/" + chunk.Name
+		if _, ok := seen[ref]; ok {
+			continue
+		}
+		seen[ref] = struct{}{}
+		count, err := fileRepo.CountByChunk(ctx, chunk.SourceID, chunk.Name)
+		if err != nil {
+			return err
+		}
+		if count > 0 {
+			continue
+		}
+		if err := manager.DeleteFileChunks(ctx, sourceRepo, []repository.FileChunk{chunk}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func parseCopySource(raw string) (string, string, bool) {
 	raw = strings.TrimSpace(raw)
 	raw = strings.TrimPrefix(raw, "/")
@@ -265,7 +288,7 @@ func deleteObjectByName(ctx context.Context, sourceRepo *repository.SourceReposi
 		}
 		return false, err
 	}
-	if err := manager.DeleteFileChunks(ctx, sourceRepo, fileDoc.Chunks); err != nil {
+	if err := deleteFileChunksIfUnreferenced(ctx, sourceRepo, fileRepo, fileDoc.Chunks); err != nil {
 		slog.WarnContext(ctx, "delete object: delete chunks", slog.String("error", err.Error()))
 	}
 	return true, nil
@@ -764,7 +787,7 @@ func PutObject(bucketRepo *repository.BucketRepository, sourceRepo *repository.S
 			writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
 			return
 		}
-		if err := manager.DeleteFileChunks(ctx, sourceRepo, existingFile.Chunks); err != nil {
+		if err := deleteFileChunksIfUnreferenced(ctx, sourceRepo, fileRepo, existingFile.Chunks); err != nil {
 			slog.WarnContext(ctx, "put object: delete old chunks", slog.String("error", err.Error()))
 		}
 		c.Status(http.StatusOK)
@@ -781,10 +804,10 @@ func PutObject(bucketRepo *repository.BucketRepository, sourceRepo *repository.S
 // @Failure 404 {string} string ""
 // @Failure 500 {string} string ""
 // @Router /api/s3/{bucket}/{object} [put]
-func CopyObject(bucketRepo *repository.BucketRepository, fileRepo *repository.FileRepository) gin.HandlerFunc {
+func CopyObject(bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		ctx := c.Request.Context()
-		if bucketRepo == nil || fileRepo == nil {
+		if bucketRepo == nil || sourceRepo == nil || fileRepo == nil {
 			c.Status(http.StatusServiceUnavailable)
 			return
 		}
@@ -864,8 +887,12 @@ func CopyObject(bucketRepo *repository.BucketRepository, fileRepo *repository.Fi
 				return
 			}
 			copyFile = *updated
+			if err := deleteFileChunksIfUnreferenced(ctx, sourceRepo, fileRepo, existingFile.Chunks); err != nil {
+				slog.WarnContext(ctx, "copy object: delete old chunks", slog.String("error", err.Error()))
+			}
 		}
 		c.XML(http.StatusOK, copyObjectResult{
+			Xmlns:        "http://s3.amazonaws.com/doc/2006-03-01/",
 			ETag:         objectETag(copyFile),
 			LastModified: now.Format(time.RFC3339),
 		})

--- a/api-go/internal/handlers/s3_multipart.go
+++ b/api-go/internal/handlers/s3_multipart.go
@@ -141,7 +141,7 @@ func PostBucket(bucketRepo *repository.BucketRepository, sourceRepo *repository.
 // otherwise → PutObject
 func PutObjectOrPart(bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository, mpRepo *repository.MultipartUploadRepository, chunkSize int) gin.HandlerFunc {
 	putHandler := PutObject(bucketRepo, sourceRepo, fileRepo, chunkSize)
-	copyHandler := CopyObject(bucketRepo, fileRepo)
+	copyHandler := CopyObject(bucketRepo, sourceRepo, fileRepo)
 	return func(c *gin.Context) {
 		if c.GetHeader("x-amz-copy-source") != "" {
 			if _, ok := c.GetQuery("uploadId"); ok {
@@ -429,8 +429,7 @@ func completeMultipartUpload(c *gin.Context, bucketRepo *repository.BucketReposi
 			writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
 			return
 		}
-		// Clean up old object chunks.
-		if delErr := manager.DeleteFileChunks(ctx, sourceRepo, existingFile.Chunks); delErr != nil {
+		if delErr := deleteFileChunksIfUnreferenced(ctx, sourceRepo, fileRepo, existingFile.Chunks); delErr != nil {
 			slog.WarnContext(ctx, "complete multipart: delete old chunks", slog.String("error", delErr.Error()))
 		}
 	} else {

--- a/api-go/internal/handlers/s3_multipart.go
+++ b/api-go/internal/handlers/s3_multipart.go
@@ -136,11 +136,21 @@ func PostBucket(bucketRepo *repository.BucketRepository, sourceRepo *repository.
 }
 
 // PutObjectOrPart dispatches PUT requests.
+// x-amz-copy-source → CopyObject
 // ?uploadId=X&partNumber=N → UploadPart
 // otherwise → PutObject
 func PutObjectOrPart(bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository, mpRepo *repository.MultipartUploadRepository, chunkSize int) gin.HandlerFunc {
 	putHandler := PutObject(bucketRepo, sourceRepo, fileRepo, chunkSize)
+	copyHandler := CopyObject(bucketRepo, fileRepo)
 	return func(c *gin.Context) {
+		if c.GetHeader("x-amz-copy-source") != "" {
+			if _, ok := c.GetQuery("uploadId"); ok {
+				writeS3Error(c, http.StatusNotImplemented, "NotImplemented", "UploadPartCopy is not supported")
+				return
+			}
+			copyHandler(c)
+			return
+		}
 		if mpRepo != nil {
 			if _, ok := c.GetQuery("uploadId"); ok {
 				uploadPart(c, bucketRepo, sourceRepo, mpRepo, chunkSize)

--- a/api-go/internal/handlers/s3_test.go
+++ b/api-go/internal/handlers/s3_test.go
@@ -53,3 +53,19 @@ func TestDecodeDeleteObjectsRequestRejectsMalformedRoot(t *testing.T) {
 		t.Fatalf("expected malformed XML error, got %v", err)
 	}
 }
+
+func TestParseCopySource(t *testing.T) {
+	t.Parallel()
+
+	bucket, key, ok := parseCopySource("/bucket/a%20b/c.txt")
+	if !ok {
+		t.Fatal("expected copy source to parse")
+	}
+	if bucket != "bucket" || key != "a b/c.txt" {
+		t.Fatalf("unexpected copy source: bucket=%q key=%q", bucket, key)
+	}
+
+	if _, _, ok := parseCopySource("/bucket"); ok {
+		t.Fatal("expected missing key to fail")
+	}
+}

--- a/api-go/internal/repository/file.go
+++ b/api-go/internal/repository/file.go
@@ -80,6 +80,15 @@ func (r *FileRepository) GetByName(ctx context.Context, bucketID primitive.Objec
 	return &f, nil
 }
 
+func (r *FileRepository) CountByChunk(ctx context.Context, sourceID primitive.ObjectID, name string) (int64, error) {
+	return r.coll.CountDocuments(ctx, bson.M{
+		"chunks": bson.M{"$elemMatch": bson.M{
+			"source_id": sourceID,
+			"name":      name,
+		}},
+	})
+}
+
 func (r *FileRepository) ListByBucket(ctx context.Context, bucketID primitive.ObjectID) ([]File, error) {
 	return r.ListByBucketWithPrefix(ctx, bucketID, "")
 }


### PR DESCRIPTION
## Summary

Adds S3 `CopyObject` support for object-level `PUT` requests with `x-amz-copy-source`.

## Linked Issue

THE-7

## What Changed

- Dispatch `x-amz-copy-source` requests from `PutObjectOrPart` to a new `CopyObject` handler.
- Parse `/bucket/key` and `bucket/key` copy-source headers, including percent-encoded paths.
- Validate destination bucket access through existing SigV4 bucket auth.
- Allow same-bucket copies and cross-bucket copies when both buckets belong to the same SFree user.
- Create or overwrite destination `File` metadata pointing at the source chunks, avoiding data duplication.
- Preserve shared chunks on delete/overwrite paths so copied objects remain readable after source deletion.
- Return `CopyObjectResult` XML with `ETag` and `LastModified`.
- Support default/`COPY` metadata directive and return `NotImplemented` for `REPLACE`.
- Return `NotImplemented` for `UploadPartCopy` requests instead of misrouting them.
- Add unit coverage for copy-source parsing.
- Add S3 compat E2E coverage for same-bucket copy, same-user cross-bucket copy, `REPLACE` rejection, and copy survival after source deletion.

## Validation

- Local tests were not run per SFree CPU-bound-task policy.
- Local `gofmt` was not run for the follow-up commit under the same policy; formatting was reviewed in diff.
- Woodpecker should run Go/unit/e2e and smoke validation on this PR.

## Docs Impact

- [x] no docs change needed
- [ ] docs updated in this PR
- [ ] follow-up docs issue needed