### PR TITLE
Extract REST handler identity and ObjectID helpers

### DIFF
--- a/api-go/internal/handlers/bucket.go
+++ b/api-go/internal/handlers/bucket.go
@@ -71,14 +71,8 @@ func CreateBucket(repo *repository.BucketRepository, sourceRepo *repository.Sour
 			c.Status(http.StatusServiceUnavailable)
 			return
 		}
-		userIDHex := c.GetString("userID")
-		if userIDHex == "" {
-			c.Status(http.StatusUnauthorized)
-			return
-		}
-		userID, err := primitive.ObjectIDFromHex(userIDHex)
-		if err != nil {
-			c.Status(http.StatusUnauthorized)
+		userID, ok := authenticatedUserID(c)
+		if !ok {
 			return
 		}
 		if secretKey == "" {
@@ -177,14 +171,8 @@ func ListBuckets(repo *repository.BucketRepository, grantRepo *repository.Bucket
 			c.Status(http.StatusServiceUnavailable)
 			return
 		}
-		userIDHex := c.GetString("userID")
-		if userIDHex == "" {
-			c.Status(http.StatusUnauthorized)
-			return
-		}
-		userID, err := primitive.ObjectIDFromHex(userIDHex)
-		if err != nil {
-			c.Status(http.StatusUnauthorized)
+		userID, ok := authenticatedUserID(c)
+		if !ok {
 			return
 		}
 
@@ -505,10 +493,8 @@ func DownloadFile(bucketRepo *repository.BucketRepository, sourceRepo *repositor
 		}
 		bucketID := acc.Bucket.ID
 
-		fileHex := c.Param("file_id")
-		fileID, err := primitive.ObjectIDFromHex(fileHex)
-		if err != nil {
-			c.Status(http.StatusBadRequest)
+		fileID, ok := routeObjectID(c, "file_id")
+		if !ok {
 			return
 		}
 		fileDoc, err := fileRepo.GetByID(c.Request.Context(), fileID)
@@ -566,10 +552,8 @@ func DeleteFile(bucketRepo *repository.BucketRepository, sourceRepo *repository.
 		}
 		bucketID := acc.Bucket.ID
 
-		fileHex := c.Param("file_id")
-		fileID, err := primitive.ObjectIDFromHex(fileHex)
-		if err != nil {
-			c.Status(http.StatusBadRequest)
+		fileID, ok := routeObjectID(c, "file_id")
+		if !ok {
 			return
 		}
 		fileDoc, err := fileRepo.GetByID(c.Request.Context(), fileID)

--- a/api-go/internal/handlers/bucket_grant.go
+++ b/api-go/internal/handlers/bucket_grant.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/example/sfree/api-go/internal/repository"
 	"github.com/gin-gonic/gin"
-	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
@@ -84,8 +83,10 @@ func CreateGrant(bucketRepo *repository.BucketRepository, grantRepo *repository.
 			return
 		}
 
-		userIDHex := c.GetString("userID")
-		granterID, _ := primitive.ObjectIDFromHex(userIDHex)
+		granterID, ok := authenticatedUserID(c)
+		if !ok {
+			return
+		}
 
 		grant := repository.BucketGrant{
 			BucketID:  acc.Bucket.ID,
@@ -191,9 +192,8 @@ func UpdateGrant(bucketRepo *repository.BucketRepository, grantRepo *repository.
 			return
 		}
 
-		grantID, err := primitive.ObjectIDFromHex(c.Param("grant_id"))
-		if err != nil {
-			c.Status(http.StatusBadRequest)
+		grantID, ok := routeObjectID(c, "grant_id")
+		if !ok {
 			return
 		}
 
@@ -243,9 +243,8 @@ func DeleteGrant(bucketRepo *repository.BucketRepository, grantRepo *repository.
 			return
 		}
 
-		grantID, err := primitive.ObjectIDFromHex(c.Param("grant_id"))
-		if err != nil {
-			c.Status(http.StatusBadRequest)
+		grantID, ok := routeObjectID(c, "grant_id")
+		if !ok {
 			return
 		}
 

--- a/api-go/internal/handlers/permission.go
+++ b/api-go/internal/handlers/permission.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/example/sfree/api-go/internal/repository"
 	"github.com/gin-gonic/gin"
-	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
@@ -25,20 +24,12 @@ func requireBucketAccess(
 	grantRepo *repository.BucketGrantRepository,
 	requiredRole repository.BucketRole,
 ) *bucketAccess {
-	idHex := c.Param("id")
-	bucketID, err := primitive.ObjectIDFromHex(idHex)
-	if err != nil {
-		c.Status(http.StatusBadRequest)
+	bucketID, ok := routeObjectID(c, "id")
+	if !ok {
 		return nil
 	}
-	userIDHex := c.GetString("userID")
-	if userIDHex == "" {
-		c.Status(http.StatusUnauthorized)
-		return nil
-	}
-	userID, err := primitive.ObjectIDFromHex(userIDHex)
-	if err != nil {
-		c.Status(http.StatusUnauthorized)
+	userID, ok := authenticatedUserID(c)
+	if !ok {
 		return nil
 	}
 

--- a/api-go/internal/handlers/request_helpers.go
+++ b/api-go/internal/handlers/request_helpers.go
@@ -1,0 +1,31 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+func authenticatedUserID(c *gin.Context) (primitive.ObjectID, bool) {
+	userIDHex := c.GetString("userID")
+	if userIDHex == "" {
+		c.Status(http.StatusUnauthorized)
+		return primitive.NilObjectID, false
+	}
+	userID, err := primitive.ObjectIDFromHex(userIDHex)
+	if err != nil {
+		c.Status(http.StatusUnauthorized)
+		return primitive.NilObjectID, false
+	}
+	return userID, true
+}
+
+func routeObjectID(c *gin.Context, param string) (primitive.ObjectID, bool) {
+	id, err := primitive.ObjectIDFromHex(c.Param(param))
+	if err != nil {
+		c.Status(http.StatusBadRequest)
+		return primitive.NilObjectID, false
+	}
+	return id, true
+}

--- a/api-go/internal/handlers/request_helpers_test.go
+++ b/api-go/internal/handlers/request_helpers_test.go
@@ -1,0 +1,88 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/example/sfree/api-go/internal/repository"
+	"github.com/gin-gonic/gin"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+func TestAuthenticatedUserIDRejectsMissingAndInvalidUserID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		userID string
+	}{
+		{name: "missing"},
+		{name: "invalid", userID: "not-a-valid-oid"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			r := gin.New()
+			handlers := []gin.HandlerFunc{}
+			if tt.userID != "" {
+				handlers = append(handlers, setUserID(tt.userID))
+			}
+			handlers = append(handlers, func(c *gin.Context) {
+				if _, ok := authenticatedUserID(c); ok {
+					t.Fatal("expected user id parse to fail")
+				}
+			})
+			r.GET("/me", handlers...)
+
+			req, _ := http.NewRequest(http.MethodGet, "/me", nil)
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+
+			if w.Code != http.StatusUnauthorized {
+				t.Fatalf("expected 401, got %d", w.Code)
+			}
+		})
+	}
+}
+
+func TestRouteObjectIDRejectsShareLinkFileID(t *testing.T) {
+	t.Parallel()
+	r := gin.New()
+	r.POST("/buckets/:id/files/:file_id/share", func(c *gin.Context) {
+		if _, ok := routeObjectID(c, "file_id"); ok {
+			t.Fatal("expected file id parse to fail")
+		}
+	})
+
+	req, _ := http.NewRequest(http.MethodPost, "/buckets/"+primitive.NewObjectID().Hex()+"/files/not-a-valid-oid/share", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestCreateShareLinkRejectsInvalidAuthenticatedUserID(t *testing.T) {
+	t.Parallel()
+	r := gin.New()
+	r.POST(
+		"/buckets/:id/files/:file_id/share",
+		setUserID("not-a-valid-oid"),
+		CreateShareLink(&repository.BucketRepository{}, &repository.FileRepository{}, &repository.ShareLinkRepository{}, nil),
+	)
+
+	req, _ := http.NewRequest(
+		http.MethodPost,
+		"/buckets/"+primitive.NewObjectID().Hex()+"/files/"+primitive.NewObjectID().Hex()+"/share",
+		nil,
+	)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}

--- a/api-go/internal/handlers/sharelink.go
+++ b/api-go/internal/handlers/sharelink.go
@@ -11,7 +11,6 @@ import (
 	"github.com/example/sfree/api-go/internal/manager"
 	"github.com/example/sfree/api-go/internal/repository"
 	"github.com/gin-gonic/gin"
-	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
@@ -60,13 +59,14 @@ func CreateShareLink(bucketRepo *repository.BucketRepository, fileRepo *reposito
 		}
 		bucketID := acc.Bucket.ID
 
-		fileID, err := primitive.ObjectIDFromHex(c.Param("file_id"))
-		if err != nil {
-			c.Status(http.StatusBadRequest)
+		fileID, ok := routeObjectID(c, "file_id")
+		if !ok {
 			return
 		}
-		userIDHex := c.GetString("userID")
-		userID, _ := primitive.ObjectIDFromHex(userIDHex)
+		userID, ok := authenticatedUserID(c)
+		if !ok {
+			return
+		}
 
 		// Verify file exists in bucket.
 		fileDoc, err := fileRepo.GetByID(c.Request.Context(), fileID)
@@ -219,9 +219,8 @@ func ListShareLinks(bucketRepo *repository.BucketRepository, fileRepo *repositor
 		}
 		bucketID := acc.Bucket.ID
 
-		fileID, err := primitive.ObjectIDFromHex(c.Param("file_id"))
-		if err != nil {
-			c.Status(http.StatusBadRequest)
+		fileID, ok := routeObjectID(c, "file_id")
+		if !ok {
 			return
 		}
 
@@ -281,19 +280,12 @@ func DeleteShareLink(shareLinkRepo *repository.ShareLinkRepository) gin.HandlerF
 			c.Status(http.StatusServiceUnavailable)
 			return
 		}
-		id, err := primitive.ObjectIDFromHex(c.Param("id"))
-		if err != nil {
-			c.Status(http.StatusBadRequest)
+		id, ok := routeObjectID(c, "id")
+		if !ok {
 			return
 		}
-		userIDHex := c.GetString("userID")
-		if userIDHex == "" {
-			c.Status(http.StatusUnauthorized)
-			return
-		}
-		userID, err := primitive.ObjectIDFromHex(userIDHex)
-		if err != nil {
-			c.Status(http.StatusUnauthorized)
+		userID, ok := authenticatedUserID(c)
+		if !ok {
 			return
 		}
 

--- a/api-go/internal/handlers/source.go
+++ b/api-go/internal/handlers/source.go
@@ -12,7 +12,6 @@ import (
 	"github.com/example/sfree/api-go/internal/s3compat"
 	"github.com/example/sfree/api-go/internal/telegram"
 	"github.com/gin-gonic/gin"
-	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
@@ -157,14 +156,8 @@ func saveSource(c *gin.Context, repo *repository.SourceRepository, sourceType re
 		c.Status(http.StatusServiceUnavailable)
 		return
 	}
-	userIDHex := c.GetString("userID")
-	if userIDHex == "" {
-		c.Status(http.StatusUnauthorized)
-		return
-	}
-	userID, err := primitive.ObjectIDFromHex(userIDHex)
-	if err != nil {
-		c.Status(http.StatusUnauthorized)
+	userID, ok := authenticatedUserID(c)
+	if !ok {
 		return
 	}
 	source := repository.Source{
@@ -205,14 +198,8 @@ func ListSources(repo *repository.SourceRepository) gin.HandlerFunc {
 			c.Status(http.StatusServiceUnavailable)
 			return
 		}
-		userIDHex := c.GetString("userID")
-		if userIDHex == "" {
-			c.Status(http.StatusUnauthorized)
-			return
-		}
-		userID, err := primitive.ObjectIDFromHex(userIDHex)
-		if err != nil {
-			c.Status(http.StatusUnauthorized)
+		userID, ok := authenticatedUserID(c)
+		if !ok {
 			return
 		}
 		sources, err := repo.ListByUser(c.Request.Context(), userID)
@@ -254,20 +241,12 @@ func DeleteSource(repo *repository.SourceRepository, bucketRepo *repository.Buck
 			c.Status(http.StatusServiceUnavailable)
 			return
 		}
-		userIDHex := c.GetString("userID")
-		if userIDHex == "" {
-			c.Status(http.StatusUnauthorized)
+		userID, ok := authenticatedUserID(c)
+		if !ok {
 			return
 		}
-		userID, err := primitive.ObjectIDFromHex(userIDHex)
-		if err != nil {
-			c.Status(http.StatusUnauthorized)
-			return
-		}
-		idHex := c.Param("id")
-		id, err := primitive.ObjectIDFromHex(idHex)
-		if err != nil {
-			c.Status(http.StatusBadRequest)
+		id, ok := routeObjectID(c, "id")
+		if !ok {
 			return
 		}
 		inUse, err := bucketRepo.HasSourceReference(c.Request.Context(), userID, id)
@@ -312,20 +291,12 @@ func GetSourceInfo(repo *repository.SourceRepository) gin.HandlerFunc {
 			c.Status(http.StatusServiceUnavailable)
 			return
 		}
-		userIDHex := c.GetString("userID")
-		if userIDHex == "" {
-			c.Status(http.StatusUnauthorized)
+		userID, ok := authenticatedUserID(c)
+		if !ok {
 			return
 		}
-		userID, err := primitive.ObjectIDFromHex(userIDHex)
-		if err != nil {
-			c.Status(http.StatusUnauthorized)
-			return
-		}
-		idHex := c.Param("id")
-		id, err := primitive.ObjectIDFromHex(idHex)
-		if err != nil {
-			c.Status(http.StatusBadRequest)
+		id, ok := routeObjectID(c, "id")
+		if !ok {
 			return
 		}
 		src, err := repo.GetByID(c.Request.Context(), id)
@@ -443,20 +414,12 @@ func DownloadSourceFile(sourceRepo *repository.SourceRepository) gin.HandlerFunc
 			c.Status(http.StatusServiceUnavailable)
 			return
 		}
-		userIDHex := c.GetString("userID")
-		if userIDHex == "" {
-			c.Status(http.StatusUnauthorized)
+		userID, ok := authenticatedUserID(c)
+		if !ok {
 			return
 		}
-		userID, err := primitive.ObjectIDFromHex(userIDHex)
-		if err != nil {
-			c.Status(http.StatusUnauthorized)
-			return
-		}
-		idHex := c.Param("id")
-		id, err := primitive.ObjectIDFromHex(idHex)
-		if err != nil {
-			c.Status(http.StatusBadRequest)
+		id, ok := routeObjectID(c, "id")
+		if !ok {
 			return
 		}
 		fileID := c.Param("file_id")

--- a/api-go/internal/handlers/user.go
+++ b/api-go/internal/handlers/user.go
@@ -8,7 +8,6 @@ import (
 	"github.com/example/sfree/api-go/internal/cryptoutil"
 	"github.com/example/sfree/api-go/internal/repository"
 	"github.com/gin-gonic/gin"
-	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 	"golang.org/x/crypto/bcrypt"
 )
@@ -25,14 +24,8 @@ type currentUserResponse struct {
 // GetCurrentUser returns the profile of the authenticated user.
 func GetCurrentUser(repo *repository.UserRepository) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		userIDHex := c.GetString("userID")
-		if userIDHex == "" {
-			c.Status(http.StatusUnauthorized)
-			return
-		}
-		oid, err := primitive.ObjectIDFromHex(userIDHex)
-		if err != nil {
-			c.Status(http.StatusUnauthorized)
+		oid, ok := authenticatedUserID(c)
+		if !ok {
 			return
 		}
 		user, err := repo.GetByID(c.Request.Context(), oid)


### PR DESCRIPTION
## Summary
- Add shared REST handler helpers for authenticated user ObjectID and route ObjectID parsing.
- Replace duplicated parsing in bucket, source, bucket grant, share link, user, and permission handlers.
- Tighten `CreateShareLink` and grant creation to stop ignoring authenticated user ID parse results.
- Add focused unit coverage for missing/invalid user IDs and share-link file ID parsing.

## Validation
- `gofmt`
- `git diff --check`

Full test validation is left to Woodpecker per task instructions.