### PR TITLE
THE-434 Split api-go router wiring from route registration

### DIFF
--- a/api-go/internal/app/router.go
+++ b/api-go/internal/app/router.go
@@ -3,21 +3,29 @@ package app
 import (
 	"github.com/example/sfree/api-go/internal/config"
 	"github.com/example/sfree/api-go/internal/db"
-	"github.com/example/sfree/api-go/internal/handlers"
 	"github.com/example/sfree/api-go/internal/observability"
 	"github.com/example/sfree/api-go/internal/ratelimit"
-	"github.com/example/sfree/api-go/internal/repository"
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
-	swaggerFiles "github.com/swaggo/files"
-	ginSwagger "github.com/swaggo/gin-swagger"
 	"go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin"
 )
 
 func SetupRouter(m *db.Mongo, cfg *config.Config) *gin.Engine {
 	router := gin.New()
 
+	registerMiddleware(router, cfg)
+	registerProbeRoutes(router, m)
+
+	deps := newRouterDependencies(m, cfg)
+	registerRESTRoutes(router, cfg, deps)
+	registerPublicShareRoutes(router, deps)
+	registerDocsMetricsRoutes(router)
+	registerS3Routes(router, cfg, deps)
+
+	return router
+}
+
+func registerMiddleware(router *gin.Engine, cfg *config.Config) {
 	corsConfig := cors.Config{
 		AllowMethods:     []string{"GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"},
 		AllowHeaders:     []string{"Origin", "Content-Length", "Content-Type", "Authorization"},
@@ -44,129 +52,4 @@ func SetupRouter(m *db.Mongo, cfg *config.Config) *gin.Engine {
 		}
 	}
 	router.Use(ratelimit.Middleware(rlCfg))
-
-	router.GET("/readyz", handlers.Readyz)
-	router.GET("/healthz", handlers.Healthz)
-	router.GET("/publication/ready", handlers.PublicationReady)
-	router.GET("/dbz", handlers.DBProbe(m))
-
-	var (
-		auth          gin.HandlerFunc
-		userRepo      *repository.UserRepository
-		bucketRepo    *repository.BucketRepository
-		sourceRepo    *repository.SourceRepository
-		fileRepo      *repository.FileRepository
-		shareLinkRepo *repository.ShareLinkRepository
-		mpRepo        *repository.MultipartUploadRepository
-		grantRepo     *repository.BucketGrantRepository
-	)
-
-	jwtSecret := ""
-	if cfg != nil {
-		jwtSecret = cfg.JWTSecret
-		if jwtSecret == "" {
-			jwtSecret = cfg.AccessSecretKey
-		}
-	}
-
-	if m != nil {
-		var err error
-		userRepo, err = repository.NewUserRepository(m.DB)
-		if err == nil {
-			auth = handlers.Auth(userRepo, jwtSecret)
-			router.POST("/api/v1/users", handlers.CreateUser(userRepo))
-		}
-		bucketRepo, _ = repository.NewBucketRepository(m.DB)
-		srcSecretKey := ""
-		if cfg != nil {
-			srcSecretKey = cfg.AccessSecretKey
-		}
-		sourceRepo, _ = repository.NewSourceRepository(m.DB, srcSecretKey)
-		fileRepo, _ = repository.NewFileRepository(m.DB)
-		mpRepo, _ = repository.NewMultipartUploadRepository(m.DB)
-		shareLinkRepo, _ = repository.NewShareLinkRepository(m.DB)
-		grantRepo, _ = repository.NewBucketGrantRepository(m.DB)
-	}
-
-	// OAuth and auth utility routes.
-	if cfg != nil && userRepo != nil {
-		router.GET("/api/v1/auth/github", handlers.GitHubLogin(cfg))
-		router.GET("/api/v1/auth/github/callback", handlers.GitHubCallback(cfg, userRepo))
-		if auth != nil {
-			router.GET("/api/v1/auth/me", auth, handlers.GetCurrentUser(userRepo))
-			router.POST("/api/v1/auth/token", auth, handlers.TokenLogin(cfg, userRepo))
-		}
-	}
-
-	if auth != nil && bucketRepo != nil {
-		secretKey := ""
-		if cfg != nil {
-			secretKey = cfg.AccessSecretKey
-		}
-		router.POST("/api/v1/buckets", auth, handlers.CreateBucket(bucketRepo, sourceRepo, secretKey))
-		router.GET("/api/v1/buckets", auth, handlers.ListBuckets(bucketRepo, grantRepo))
-		router.DELETE("/api/v1/buckets/:id", auth, handlers.DeleteBucket(bucketRepo, grantRepo))
-		router.PATCH("/api/v1/buckets/:id/distribution", auth, handlers.UpdateBucketDistribution(bucketRepo, grantRepo))
-
-		// Bucket grant (sharing) routes.
-		if grantRepo != nil && userRepo != nil {
-			router.POST("/api/v1/buckets/:id/grants", auth, handlers.CreateGrant(bucketRepo, grantRepo, userRepo))
-			router.GET("/api/v1/buckets/:id/grants", auth, handlers.ListGrants(bucketRepo, grantRepo, userRepo))
-			router.PATCH("/api/v1/buckets/:id/grants/:grant_id", auth, handlers.UpdateGrant(bucketRepo, grantRepo))
-			router.DELETE("/api/v1/buckets/:id/grants/:grant_id", auth, handlers.DeleteGrant(bucketRepo, grantRepo))
-		}
-
-		if sourceRepo != nil && fileRepo != nil {
-			chunkSize := 0
-			if cfg != nil {
-				chunkSize = cfg.Upload.ChunkSize
-			}
-			router.POST("/api/v1/buckets/:id/upload", auth, handlers.UploadFile(bucketRepo, sourceRepo, fileRepo, grantRepo, chunkSize))
-			router.GET("/api/v1/buckets/:id/files", auth, handlers.ListFiles(bucketRepo, fileRepo, grantRepo))
-			router.GET("/api/v1/buckets/:id/files/:file_id/download", auth, handlers.DownloadFile(bucketRepo, sourceRepo, fileRepo, grantRepo))
-			router.DELETE("/api/v1/buckets/:id/files/:file_id", auth, handlers.DeleteFile(bucketRepo, sourceRepo, fileRepo, grantRepo))
-			if shareLinkRepo != nil {
-				router.POST("/api/v1/buckets/:id/files/:file_id/share", auth, handlers.CreateShareLink(bucketRepo, fileRepo, shareLinkRepo, grantRepo))
-				router.GET("/api/v1/buckets/:id/files/:file_id/shares", auth, handlers.ListShareLinks(bucketRepo, fileRepo, shareLinkRepo, grantRepo))
-				router.DELETE("/api/v1/shares/:id", auth, handlers.DeleteShareLink(shareLinkRepo))
-			}
-		}
-	}
-
-	if auth != nil && sourceRepo != nil {
-		router.POST("/api/v1/sources/gdrive", auth, handlers.CreateGDriveSource(sourceRepo))
-		router.POST("/api/v1/sources/telegram", auth, handlers.CreateTelegramSource(sourceRepo))
-		router.POST("/api/v1/sources/s3", auth, handlers.CreateS3Source(sourceRepo))
-		router.GET("/api/v1/sources", auth, handlers.ListSources(sourceRepo))
-		router.GET("/api/v1/sources/:id/info", auth, handlers.GetSourceInfo(sourceRepo))
-		router.GET("/api/v1/sources/:id/files/:file_id/download", auth, handlers.DownloadSourceFile(sourceRepo))
-		router.DELETE("/api/v1/sources/:id", auth, handlers.DeleteSource(sourceRepo, bucketRepo))
-	}
-
-	// Public share link route (no auth required).
-	if shareLinkRepo != nil && bucketRepo != nil && sourceRepo != nil && fileRepo != nil {
-		router.GET("/share/:token", handlers.GetSharedFile(shareLinkRepo, bucketRepo, sourceRepo, fileRepo))
-	}
-
-	router.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
-	router.GET("/metrics", gin.WrapH(promhttp.Handler()))
-	if bucketRepo != nil && sourceRepo != nil && fileRepo != nil {
-		secretKey := ""
-		if cfg != nil {
-			secretKey = cfg.AccessSecretKey
-		}
-		chunkSize := 0
-		if cfg != nil {
-			chunkSize = cfg.Upload.ChunkSize
-		}
-		s3Auth := handlers.AWS4Auth(bucketRepo, secretKey)
-		router.HEAD("/api/s3/:bucket/*object", s3Auth, handlers.HeadObject(bucketRepo, fileRepo))
-		router.GET("/api/s3/:bucket/*object", s3Auth, handlers.GetObjectOrParts(bucketRepo, sourceRepo, fileRepo, mpRepo))
-		router.GET("/api/s3/:bucket", s3Auth, handlers.ListObjectsOrUploads(bucketRepo, fileRepo, mpRepo))
-		router.PUT("/api/s3/:bucket/*object", s3Auth, handlers.PutObjectOrPart(bucketRepo, sourceRepo, fileRepo, mpRepo, chunkSize))
-		router.POST("/api/s3/:bucket", s3Auth, handlers.PostBucket(bucketRepo, sourceRepo, fileRepo))
-		router.POST("/api/s3/:bucket/*object", s3Auth, handlers.PostObject(bucketRepo, sourceRepo, fileRepo, mpRepo, chunkSize))
-		router.DELETE("/api/s3/:bucket/*object", s3Auth, handlers.DeleteObjectOrAbort(bucketRepo, sourceRepo, fileRepo, mpRepo))
-	}
-	return router
 }

--- a/api-go/internal/app/router_dependencies.go
+++ b/api-go/internal/app/router_dependencies.go
@@ -1,0 +1,65 @@
+package app
+
+import (
+	"github.com/example/sfree/api-go/internal/config"
+	"github.com/example/sfree/api-go/internal/db"
+	"github.com/example/sfree/api-go/internal/handlers"
+	"github.com/example/sfree/api-go/internal/repository"
+	"github.com/gin-gonic/gin"
+)
+
+type routerDependencies struct {
+	auth          gin.HandlerFunc
+	userRepo      *repository.UserRepository
+	bucketRepo    *repository.BucketRepository
+	sourceRepo    *repository.SourceRepository
+	fileRepo      *repository.FileRepository
+	shareLinkRepo *repository.ShareLinkRepository
+	mpRepo        *repository.MultipartUploadRepository
+	grantRepo     *repository.BucketGrantRepository
+}
+
+func newRouterDependencies(m *db.Mongo, cfg *config.Config) *routerDependencies {
+	deps := &routerDependencies{}
+	if m == nil {
+		return deps
+	}
+
+	var err error
+	deps.userRepo, err = repository.NewUserRepository(m.DB)
+	if err == nil {
+		deps.auth = handlers.Auth(deps.userRepo, routerJWTSecret(cfg))
+	}
+	deps.bucketRepo, _ = repository.NewBucketRepository(m.DB)
+	deps.sourceRepo, _ = repository.NewSourceRepository(m.DB, routerAccessSecret(cfg))
+	deps.fileRepo, _ = repository.NewFileRepository(m.DB)
+	deps.mpRepo, _ = repository.NewMultipartUploadRepository(m.DB)
+	deps.shareLinkRepo, _ = repository.NewShareLinkRepository(m.DB)
+	deps.grantRepo, _ = repository.NewBucketGrantRepository(m.DB)
+
+	return deps
+}
+
+func routerJWTSecret(cfg *config.Config) string {
+	if cfg == nil {
+		return ""
+	}
+	if cfg.JWTSecret != "" {
+		return cfg.JWTSecret
+	}
+	return cfg.AccessSecretKey
+}
+
+func routerAccessSecret(cfg *config.Config) string {
+	if cfg == nil {
+		return ""
+	}
+	return cfg.AccessSecretKey
+}
+
+func routerUploadChunkSize(cfg *config.Config) int {
+	if cfg == nil {
+		return 0
+	}
+	return cfg.Upload.ChunkSize
+}

--- a/api-go/internal/app/router_routes.go
+++ b/api-go/internal/app/router_routes.go
@@ -1,0 +1,123 @@
+package app
+
+import (
+	"github.com/example/sfree/api-go/internal/config"
+	"github.com/example/sfree/api-go/internal/db"
+	"github.com/example/sfree/api-go/internal/handlers"
+	"github.com/gin-gonic/gin"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	swaggerFiles "github.com/swaggo/files"
+	ginSwagger "github.com/swaggo/gin-swagger"
+)
+
+func registerProbeRoutes(router *gin.Engine, m *db.Mongo) {
+	router.GET("/readyz", handlers.Readyz)
+	router.GET("/healthz", handlers.Healthz)
+	router.GET("/publication/ready", handlers.PublicationReady)
+	router.GET("/dbz", handlers.DBProbe(m))
+}
+
+func registerRESTRoutes(router *gin.Engine, cfg *config.Config, deps *routerDependencies) {
+	registerUserRoutes(router, deps)
+	registerAuthRoutes(router, cfg, deps)
+	registerBucketRoutes(router, cfg, deps)
+	registerSourceRoutes(router, deps)
+}
+
+func registerUserRoutes(router *gin.Engine, deps *routerDependencies) {
+	if deps.auth == nil || deps.userRepo == nil {
+		return
+	}
+	router.POST("/api/v1/users", handlers.CreateUser(deps.userRepo))
+}
+
+func registerAuthRoutes(router *gin.Engine, cfg *config.Config, deps *routerDependencies) {
+	if cfg == nil || deps.userRepo == nil {
+		return
+	}
+	router.GET("/api/v1/auth/github", handlers.GitHubLogin(cfg))
+	router.GET("/api/v1/auth/github/callback", handlers.GitHubCallback(cfg, deps.userRepo))
+	if deps.auth == nil {
+		return
+	}
+	router.GET("/api/v1/auth/me", deps.auth, handlers.GetCurrentUser(deps.userRepo))
+	router.POST("/api/v1/auth/token", deps.auth, handlers.TokenLogin(cfg, deps.userRepo))
+}
+
+func registerBucketRoutes(router *gin.Engine, cfg *config.Config, deps *routerDependencies) {
+	if deps.auth == nil || deps.bucketRepo == nil {
+		return
+	}
+	router.POST("/api/v1/buckets", deps.auth, handlers.CreateBucket(deps.bucketRepo, deps.sourceRepo, routerAccessSecret(cfg)))
+	router.GET("/api/v1/buckets", deps.auth, handlers.ListBuckets(deps.bucketRepo, deps.grantRepo))
+	router.DELETE("/api/v1/buckets/:id", deps.auth, handlers.DeleteBucket(deps.bucketRepo, deps.grantRepo))
+	router.PATCH("/api/v1/buckets/:id/distribution", deps.auth, handlers.UpdateBucketDistribution(deps.bucketRepo, deps.grantRepo))
+
+	registerBucketGrantRoutes(router, deps)
+	registerBucketFileRoutes(router, cfg, deps)
+}
+
+func registerBucketGrantRoutes(router *gin.Engine, deps *routerDependencies) {
+	if deps.grantRepo == nil || deps.userRepo == nil {
+		return
+	}
+	router.POST("/api/v1/buckets/:id/grants", deps.auth, handlers.CreateGrant(deps.bucketRepo, deps.grantRepo, deps.userRepo))
+	router.GET("/api/v1/buckets/:id/grants", deps.auth, handlers.ListGrants(deps.bucketRepo, deps.grantRepo, deps.userRepo))
+	router.PATCH("/api/v1/buckets/:id/grants/:grant_id", deps.auth, handlers.UpdateGrant(deps.bucketRepo, deps.grantRepo))
+	router.DELETE("/api/v1/buckets/:id/grants/:grant_id", deps.auth, handlers.DeleteGrant(deps.bucketRepo, deps.grantRepo))
+}
+
+func registerBucketFileRoutes(router *gin.Engine, cfg *config.Config, deps *routerDependencies) {
+	if deps.sourceRepo == nil || deps.fileRepo == nil {
+		return
+	}
+	router.POST("/api/v1/buckets/:id/upload", deps.auth, handlers.UploadFile(deps.bucketRepo, deps.sourceRepo, deps.fileRepo, deps.grantRepo, routerUploadChunkSize(cfg)))
+	router.GET("/api/v1/buckets/:id/files", deps.auth, handlers.ListFiles(deps.bucketRepo, deps.fileRepo, deps.grantRepo))
+	router.GET("/api/v1/buckets/:id/files/:file_id/download", deps.auth, handlers.DownloadFile(deps.bucketRepo, deps.sourceRepo, deps.fileRepo, deps.grantRepo))
+	router.DELETE("/api/v1/buckets/:id/files/:file_id", deps.auth, handlers.DeleteFile(deps.bucketRepo, deps.sourceRepo, deps.fileRepo, deps.grantRepo))
+	if deps.shareLinkRepo == nil {
+		return
+	}
+	router.POST("/api/v1/buckets/:id/files/:file_id/share", deps.auth, handlers.CreateShareLink(deps.bucketRepo, deps.fileRepo, deps.shareLinkRepo, deps.grantRepo))
+	router.GET("/api/v1/buckets/:id/files/:file_id/shares", deps.auth, handlers.ListShareLinks(deps.bucketRepo, deps.fileRepo, deps.shareLinkRepo, deps.grantRepo))
+	router.DELETE("/api/v1/shares/:id", deps.auth, handlers.DeleteShareLink(deps.shareLinkRepo))
+}
+
+func registerSourceRoutes(router *gin.Engine, deps *routerDependencies) {
+	if deps.auth == nil || deps.sourceRepo == nil {
+		return
+	}
+	router.POST("/api/v1/sources/gdrive", deps.auth, handlers.CreateGDriveSource(deps.sourceRepo))
+	router.POST("/api/v1/sources/telegram", deps.auth, handlers.CreateTelegramSource(deps.sourceRepo))
+	router.POST("/api/v1/sources/s3", deps.auth, handlers.CreateS3Source(deps.sourceRepo))
+	router.GET("/api/v1/sources", deps.auth, handlers.ListSources(deps.sourceRepo))
+	router.GET("/api/v1/sources/:id/info", deps.auth, handlers.GetSourceInfo(deps.sourceRepo))
+	router.GET("/api/v1/sources/:id/files/:file_id/download", deps.auth, handlers.DownloadSourceFile(deps.sourceRepo))
+	router.DELETE("/api/v1/sources/:id", deps.auth, handlers.DeleteSource(deps.sourceRepo, deps.bucketRepo))
+}
+
+func registerPublicShareRoutes(router *gin.Engine, deps *routerDependencies) {
+	if deps.shareLinkRepo == nil || deps.bucketRepo == nil || deps.sourceRepo == nil || deps.fileRepo == nil {
+		return
+	}
+	router.GET("/share/:token", handlers.GetSharedFile(deps.shareLinkRepo, deps.bucketRepo, deps.sourceRepo, deps.fileRepo))
+}
+
+func registerDocsMetricsRoutes(router *gin.Engine) {
+	router.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
+	router.GET("/metrics", gin.WrapH(promhttp.Handler()))
+}
+
+func registerS3Routes(router *gin.Engine, cfg *config.Config, deps *routerDependencies) {
+	if deps.bucketRepo == nil || deps.sourceRepo == nil || deps.fileRepo == nil {
+		return
+	}
+	s3Auth := handlers.AWS4Auth(deps.bucketRepo, routerAccessSecret(cfg))
+	router.HEAD("/api/s3/:bucket/*object", s3Auth, handlers.HeadObject(deps.bucketRepo, deps.fileRepo))
+	router.GET("/api/s3/:bucket/*object", s3Auth, handlers.GetObjectOrParts(deps.bucketRepo, deps.sourceRepo, deps.fileRepo, deps.mpRepo))
+	router.GET("/api/s3/:bucket", s3Auth, handlers.ListObjectsOrUploads(deps.bucketRepo, deps.fileRepo, deps.mpRepo))
+	router.PUT("/api/s3/:bucket/*object", s3Auth, handlers.PutObjectOrPart(deps.bucketRepo, deps.sourceRepo, deps.fileRepo, deps.mpRepo, routerUploadChunkSize(cfg)))
+	router.POST("/api/s3/:bucket", s3Auth, handlers.PostBucket(deps.bucketRepo, deps.sourceRepo, deps.fileRepo))
+	router.POST("/api/s3/:bucket/*object", s3Auth, handlers.PostObject(deps.bucketRepo, deps.sourceRepo, deps.fileRepo, deps.mpRepo, routerUploadChunkSize(cfg)))
+	router.DELETE("/api/s3/:bucket/*object", s3Auth, handlers.DeleteObjectOrAbort(deps.bucketRepo, deps.sourceRepo, deps.fileRepo, deps.mpRepo))
+}

--- a/api-go/internal/app/router_test.go
+++ b/api-go/internal/app/router_test.go
@@ -4,6 +4,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/gin-gonic/gin"
 )
 
 func TestSetupRouter(t *testing.T) {
@@ -17,4 +19,48 @@ func TestSetupRouter(t *testing.T) {
 			t.Errorf("expected 200 for %s, got %d", e, w.Code)
 		}
 	}
+}
+
+func TestSetupRouterNilMongoRouteSet(t *testing.T) {
+	r := SetupRouter(nil, nil)
+
+	expectedRoutes := []struct {
+		method string
+		path   string
+	}{
+		{http.MethodGet, "/readyz"},
+		{http.MethodGet, "/healthz"},
+		{http.MethodGet, "/publication/ready"},
+		{http.MethodGet, "/dbz"},
+		{http.MethodGet, "/swagger/*any"},
+		{http.MethodGet, "/metrics"},
+	}
+	for _, expected := range expectedRoutes {
+		if !hasRoute(r, expected.method, expected.path) {
+			t.Fatalf("expected %s %s to be registered", expected.method, expected.path)
+		}
+	}
+
+	unexpectedRoutes := []struct {
+		method string
+		path   string
+	}{
+		{http.MethodPost, "/api/v1/buckets"},
+		{http.MethodGet, "/share/:token"},
+		{http.MethodHead, "/api/s3/:bucket/*object"},
+	}
+	for _, unexpected := range unexpectedRoutes {
+		if hasRoute(r, unexpected.method, unexpected.path) {
+			t.Fatalf("did not expect %s %s to be registered", unexpected.method, unexpected.path)
+		}
+	}
+}
+
+func hasRoute(r *gin.Engine, method, path string) bool {
+	for _, route := range r.Routes() {
+		if route.Method == method && route.Path == path {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
## Summary
- Keep `SetupRouter` as the public entry point while moving middleware setup into a focused helper.
- Move Mongo-backed repository/auth construction into `routerDependencies`.
- Register REST, public share, docs/metrics, and S3 route families through separate app-level helpers.
- Add nil-Mongo route-set coverage for always-on routes and Mongo-gated route families.

## Validation
- `git diff --cached --check` before commit
- Route path scan against `origin/main` router registration
- Local `go test` / `golangci-lint` intentionally not run; this issue requires runtime validation in Woodpecker only.