### PR TITLE
THE-449: Enforce api-go lint in Woodpecker

### DIFF
--- a/.woodpecker/api-go.yml
+++ b/.woodpecker/api-go.yml
@@ -13,6 +13,12 @@ when:
         - api-go/**
 
 steps:
+  - name: lint
+    image: golangci/golangci-lint:v2.11.4-alpine
+    commands:
+      - cd api-go
+      - golangci-lint run
+
   - name: unit tests
     image: public.ecr.aws/docker/library/golang:1.24
     commands:

--- a/api-go/internal/handlers/oauth.go
+++ b/api-go/internal/handlers/oauth.go
@@ -77,7 +77,9 @@ func GitHubCallback(cfg *config.Config, userRepo *repository.UserRepository) gin
 			c.Status(http.StatusInternalServerError)
 			return
 		}
-		defer resp.Body.Close()
+		defer func() {
+			_ = resp.Body.Close()
+		}()
 
 		var ghUser githubUser
 		if err := json.NewDecoder(resp.Body).Decode(&ghUser); err != nil {

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -7,7 +7,7 @@ Actions workflows to this repository.
 
 | Pipeline | Paths | `pull_request` | `push` to `main` | Behavior |
 | --- | --- | --- | --- | --- |
-| `.woodpecker/api-go.yml` | `.woodpecker/api-go.yml`, `api-go/**` | Yes | Yes | Runs Go unit tests plus Python and Go E2E suites against the local S3-compatible MinIO source. Pushes to `main` also publish the backend image. |
+| `.woodpecker/api-go.yml` | `.woodpecker/api-go.yml`, `api-go/**` | Yes | Yes | Runs `golangci-lint run`, Go unit tests, and Python and Go E2E suites against the local S3-compatible MinIO source. Pushes to `main` also publish the backend image. |
 | `.woodpecker/webui.yml` | `.woodpecker/webui.yml`, `webui/**` | Yes | Yes | Runs frontend dependency install, lint, production build, and Chromium Playwright E2E validation with `npm run test:e2e`. Pushes to `main` also publish the frontend image. |
 | `.woodpecker/smoke.yml` | `.woodpecker/smoke.yml`, `docker-compose.yml`, `scripts/woodpecker-smoke.sh`, `api-go/**`, `webui/**` | Yes | Yes | Starts the root Compose stack in Woodpecker, creates a user and MinIO-backed source, creates a bucket, uploads and downloads a file with the CLI, and verifies S3-compatible credential download bytes. |
 


### PR DESCRIPTION
## Summary
- Adds a dedicated api-go Woodpecker lint step that runs `golangci-lint run` before unit and E2E validation.
- Updates the CI matrix docs to include the backend lint gate.

## Image choice
- Uses `golangci/golangci-lint:v2.11.4-alpine`, a pinned official golangci-lint v2 Docker image compatible with the existing `version: 2` linter config.

## Verification
- `git diff --check`
- Did not run Docker, Playwright, Go tests, or golangci-lint locally per QA resource policy; Woodpecker is the validation authority for this CI change.

Refs THE-449