### PR TITLE
THE-445 Preserve multipart chunk checksums

### DIFF
--- a/api-go/internal/handlers/s3_multipart.go
+++ b/api-go/internal/handlers/s3_multipart.go
@@ -380,8 +380,6 @@ func completeMultipartUpload(c *gin.Context, bucketRepo *repository.BucketReposi
 	}
 
 	// Validate all requested parts exist and ETags match.
-	var allChunks []repository.FileChunk
-	chunkOrder := 0
 	for _, rp := range req.Parts {
 		up, exists := partMap[rp.PartNumber]
 		if !exists {
@@ -395,17 +393,8 @@ func completeMultipartUpload(c *gin.Context, bucketRepo *repository.BucketReposi
 			writeS3Error(c, http.StatusBadRequest, "InvalidPart", fmt.Sprintf("ETag mismatch for part %d", rp.PartNumber))
 			return
 		}
-		// Append this part's chunks with renumbered order.
-		for _, ch := range up.Chunks {
-			allChunks = append(allChunks, repository.FileChunk{
-				SourceID: ch.SourceID,
-				Name:     ch.Name,
-				Order:    chunkOrder,
-				Size:     ch.Size,
-			})
-			chunkOrder++
-		}
 	}
+	allChunks := completedMultipartChunks(req.Parts, partMap)
 
 	// Create or update the final file.
 	fileDoc := repository.File{
@@ -475,6 +464,20 @@ func completeMultipartUpload(c *gin.Context, bucketRepo *repository.BucketReposi
 		Key:      mu.ObjectKey,
 		ETag:     etag,
 	})
+}
+
+func completedMultipartChunks(parts []completionPart, partMap map[int]repository.UploadPart) []repository.FileChunk {
+	var allChunks []repository.FileChunk
+	chunkOrder := 0
+	for _, rp := range parts {
+		up := partMap[rp.PartNumber]
+		for _, ch := range up.Chunks {
+			ch.Order = chunkOrder
+			allChunks = append(allChunks, ch)
+			chunkOrder++
+		}
+	}
+	return allChunks
 }
 
 func abortMultipartUpload(c *gin.Context, sourceRepo *repository.SourceRepository, mpRepo *repository.MultipartUploadRepository) {

--- a/api-go/internal/handlers/s3_multipart_test.go
+++ b/api-go/internal/handlers/s3_multipart_test.go
@@ -7,7 +7,9 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/example/sfree/api-go/internal/repository"
 	"github.com/gin-gonic/gin"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
 func TestPostObjectNilRepos(t *testing.T) {
@@ -171,6 +173,40 @@ func TestCompleteMultipartUploadResultXML(t *testing.T) {
 	s := string(data)
 	if !bytes.Contains(data, []byte("<ETag>&#34;abc-2&#34;</ETag>")) && !bytes.Contains(data, []byte(`<ETag>"abc-2"</ETag>`)) {
 		t.Fatalf("missing or wrong ETag in XML: %s", s)
+	}
+}
+
+func TestCompletedMultipartChunksPreservesChecksums(t *testing.T) {
+	t.Parallel()
+
+	sourceID := primitive.NewObjectID()
+	partMap := map[int]repository.UploadPart{
+		1: {
+			Chunks: []repository.FileChunk{
+				{SourceID: sourceID, Name: "part-1-chunk-1", Order: 17, Size: 5, Checksum: "checksum-a"},
+				{SourceID: sourceID, Name: "part-1-chunk-2", Order: 18, Size: 6, Checksum: "checksum-b"},
+			},
+		},
+		2: {
+			Chunks: []repository.FileChunk{
+				{SourceID: sourceID, Name: "part-2-chunk-1", Order: 3, Size: 7, Checksum: "checksum-c"},
+			},
+		},
+	}
+
+	chunks := completedMultipartChunks([]completionPart{{PartNumber: 1}, {PartNumber: 2}}, partMap)
+	if len(chunks) != 3 {
+		t.Fatalf("expected 3 chunks, got %d", len(chunks))
+	}
+
+	wantChecksums := []string{"checksum-a", "checksum-b", "checksum-c"}
+	for i, want := range wantChecksums {
+		if chunks[i].Checksum != want {
+			t.Fatalf("chunk %d checksum: got %q, want %q", i, chunks[i].Checksum, want)
+		}
+		if chunks[i].Order != i {
+			t.Fatalf("chunk %d order: got %d, want %d", i, chunks[i].Order, i)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- Preserve uploaded `FileChunk` metadata when completing S3 multipart uploads while still renumbering chunk order.
- Add a focused regression test for checksum propagation through multipart completion chunk assembly.

## Tests
- Not run locally per agent resource policy; Woodpecker should run the backend suite.