### PR TITLE
THE-446 Replay source upload bodies on retry

### DIFF
--- a/api-go/internal/resilience/wrapper.go
+++ b/api-go/internal/resilience/wrapper.go
@@ -1,6 +1,7 @@
 package resilience
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"log/slog"
@@ -70,6 +71,16 @@ func (w *wrapper) Upload(ctx context.Context, name string, r io.Reader) (string,
 		return "", err
 	}
 
+	var payload []byte
+	if w.retryCfg.MaxRetries > 0 {
+		var err error
+		payload, err = io.ReadAll(r)
+		if err != nil {
+			w.cb.RecordFailure()
+			return "", err
+		}
+	}
+
 	var lastErr error
 	for attempt := 0; attempt <= w.retryCfg.MaxRetries; attempt++ {
 		if attempt > 0 {
@@ -92,8 +103,12 @@ func (w *wrapper) Upload(ctx context.Context, name string, r io.Reader) (string,
 			}
 		}
 
+		body := r
+		if payload != nil {
+			body = bytes.NewReader(payload)
+		}
 		reqCtx, cancel := context.WithTimeout(ctx, w.cfg.Timeout)
-		result, err := w.inner.Upload(reqCtx, name, r)
+		result, err := w.inner.Upload(reqCtx, name, body)
 		cancel()
 
 		if err == nil {

--- a/api-go/internal/resilience/wrapper.go
+++ b/api-go/internal/resilience/wrapper.go
@@ -66,15 +66,53 @@ type wrapper struct {
 	retryCfg RetryConfig
 }
 
+type uploadBodyReplay interface {
+	Reader() (io.Reader, error)
+}
+
+type seekableUploadBody struct {
+	r     io.ReadSeeker
+	start int64
+}
+
+func (b seekableUploadBody) Reader() (io.Reader, error) {
+	if _, err := b.r.Seek(b.start, io.SeekStart); err != nil {
+		return nil, err
+	}
+	return b.r, nil
+}
+
+type bufferedUploadBody []byte
+
+func (b bufferedUploadBody) Reader() (io.Reader, error) {
+	return bytes.NewReader(b), nil
+}
+
+func newUploadBodyReplay(r io.Reader) (uploadBodyReplay, error) {
+	if rs, ok := r.(io.ReadSeeker); ok {
+		start, err := rs.Seek(0, io.SeekCurrent)
+		if err != nil {
+			return nil, err
+		}
+		return seekableUploadBody{r: rs, start: start}, nil
+	}
+
+	payload, err := io.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+	return bufferedUploadBody(payload), nil
+}
+
 func (w *wrapper) Upload(ctx context.Context, name string, r io.Reader) (string, error) {
 	if err := w.cb.Allow(); err != nil {
 		return "", err
 	}
 
-	var payload []byte
+	var replay uploadBodyReplay
 	if w.retryCfg.MaxRetries > 0 {
 		var err error
-		payload, err = io.ReadAll(r)
+		replay, err = newUploadBodyReplay(r)
 		if err != nil {
 			w.cb.RecordFailure()
 			return "", err
@@ -104,8 +142,13 @@ func (w *wrapper) Upload(ctx context.Context, name string, r io.Reader) (string,
 		}
 
 		body := r
-		if payload != nil {
-			body = bytes.NewReader(payload)
+		if replay != nil {
+			var err error
+			body, err = replay.Reader()
+			if err != nil {
+				w.cb.RecordFailure()
+				return "", err
+			}
 		}
 		reqCtx, cancel := context.WithTimeout(ctx, w.cfg.Timeout)
 		result, err := w.inner.Upload(reqCtx, name, body)

--- a/api-go/internal/resilience/wrapper_test.go
+++ b/api-go/internal/resilience/wrapper_test.go
@@ -272,6 +272,60 @@ func TestWrapperRetryUploadReplaysBody(t *testing.T) {
 	}
 }
 
+type countingReadSeeker struct {
+	*strings.Reader
+	readCalls atomic.Int32
+}
+
+func (r *countingReadSeeker) Read(p []byte) (int, error) {
+	r.readCalls.Add(1)
+	return r.Reader.Read(p)
+}
+
+type firstAttemptUploadClient struct {
+	body *countingReadSeeker
+}
+
+func (c *firstAttemptUploadClient) Upload(ctx context.Context, name string, r io.Reader) (string, error) {
+	if c.body.readCalls.Load() != 0 {
+		return "", errors.New("upload body was read before first attempt")
+	}
+	if _, err := io.ReadAll(r); err != nil {
+		return "", err
+	}
+	return "uploaded-" + name, nil
+}
+
+func (c *firstAttemptUploadClient) Download(ctx context.Context, name string) (io.ReadCloser, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (c *firstAttemptUploadClient) Delete(ctx context.Context, name string) error {
+	return errors.New("not implemented")
+}
+
+func TestWrapperRetryUploadDoesNotPreReadSeekableBody(t *testing.T) {
+	body := &countingReadSeeker{Reader: strings.NewReader("chunk-payload")}
+	inner := &firstAttemptUploadClient{body: body}
+	cfg := WrapperConfig{
+		Timeout:          time.Second,
+		FailureThreshold: 10,
+		RecoveryTimeout:  time.Second,
+		MaxRetries:       1,
+		RetryBaseDelay:   1 * time.Millisecond,
+		RetryMaxDelay:    10 * time.Millisecond,
+	}
+	w := Wrap(inner, cfg)
+
+	name, err := w.Upload(context.Background(), "file.txt", body)
+	if err != nil {
+		t.Fatalf("expected upload without pre-reading seekable body, got %v", err)
+	}
+	if name != "uploaded-file.txt" {
+		t.Fatalf("unexpected name: %s", name)
+	}
+}
+
 func TestWrapperRetryDownloadSucceeds(t *testing.T) {
 	inner := &flakeyClient{failCount: 1}
 	cfg := WrapperConfig{

--- a/api-go/internal/resilience/wrapper_test.go
+++ b/api-go/internal/resilience/wrapper_test.go
@@ -141,7 +141,10 @@ func TestWrapperCircuitBreakerRecovers(t *testing.T) {
 
 	ctx := context.Background()
 	for i := 0; i < 2; i++ {
-		w.Upload(ctx, "fail.txt", strings.NewReader("data"))
+		_, err := w.Upload(ctx, "fail.txt", strings.NewReader("data"))
+		if err == nil {
+			t.Fatalf("request %d: expected error", i+1)
+		}
 	}
 
 	// Circuit is open.
@@ -168,9 +171,8 @@ func TestWrapperCircuitBreakerRecovers(t *testing.T) {
 
 // flakeyClient fails a configurable number of times then succeeds.
 type flakeyClient struct {
-	failCount   int
-	callCount   atomic.Int32
-	permanentOK bool
+	failCount int
+	callCount atomic.Int32
 }
 
 func (f *flakeyClient) Upload(ctx context.Context, name string, r io.Reader) (string, error) {

--- a/api-go/internal/resilience/wrapper_test.go
+++ b/api-go/internal/resilience/wrapper_test.go
@@ -221,6 +221,57 @@ func TestWrapperRetryUploadSucceeds(t *testing.T) {
 	}
 }
 
+type bodyDrainingUploadClient struct {
+	want      string
+	callCount atomic.Int32
+}
+
+func (c *bodyDrainingUploadClient) Upload(ctx context.Context, name string, r io.Reader) (string, error) {
+	got, err := io.ReadAll(r)
+	if err != nil {
+		return "", err
+	}
+	if string(got) != c.want {
+		return "", errors.New("upload retry body did not match original payload")
+	}
+	if c.callCount.Add(1) == 1 {
+		return "", errors.New("transient failure after reading body")
+	}
+	return "uploaded-" + name, nil
+}
+
+func (c *bodyDrainingUploadClient) Download(ctx context.Context, name string) (io.ReadCloser, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (c *bodyDrainingUploadClient) Delete(ctx context.Context, name string) error {
+	return errors.New("not implemented")
+}
+
+func TestWrapperRetryUploadReplaysBody(t *testing.T) {
+	inner := &bodyDrainingUploadClient{want: "chunk-payload"}
+	cfg := WrapperConfig{
+		Timeout:          time.Second,
+		FailureThreshold: 10,
+		RecoveryTimeout:  time.Second,
+		MaxRetries:       1,
+		RetryBaseDelay:   1 * time.Millisecond,
+		RetryMaxDelay:    10 * time.Millisecond,
+	}
+	w := Wrap(inner, cfg)
+
+	name, err := w.Upload(context.Background(), "file.txt", strings.NewReader("chunk-payload"))
+	if err != nil {
+		t.Fatalf("expected retry success with replayed body, got %v", err)
+	}
+	if name != "uploaded-file.txt" {
+		t.Fatalf("unexpected name: %s", name)
+	}
+	if got := int(inner.callCount.Load()); got != 2 {
+		t.Fatalf("expected 2 upload calls, got %d", got)
+	}
+}
+
 func TestWrapperRetryDownloadSucceeds(t *testing.T) {
 	inner := &flakeyClient{failCount: 1}
 	cfg := WrapperConfig{


### PR DESCRIPTION
## Summary
- Replay retry-enabled upload request bodies without pre-reading seekable readers before the first attempt.
- Rewind `io.ReadSeeker` upload bodies per attempt, matching the existing chunk upload boundary that passes `bytes.NewReader(chunkData)`.
- Keep a buffering fallback for non-seekable readers because they cannot be replayed safely after a consumed failed attempt.
- Add regression coverage for retry replay after a drained failed attempt and for avoiding pre-read on seekable bodies.
- Fix the existing resilience wrapper test lint findings reported by Woodpecker.

## Validation
- `git diff --check origin/main...HEAD`
- Local Go tests, Docker, Playwright, and `golangci-lint` not run per heartbeat resource policy; Woodpecker should run backend validation.

Closes THE-446