### PR TITLE
THE-447: Enforce one file document per bucket object name

### DIFF
--- a/api-go/internal/handlers/bucket.go
+++ b/api-go/internal/handlers/bucket.go
@@ -413,12 +413,17 @@ func UploadFile(bucketRepo *repository.BucketRepository, sourceRepo *repository.
 			CreatedAt: time.Now().UTC(),
 			Chunks:    chunks,
 		}
-		created, err := fileRepo.Create(ctx, fileDoc)
+		created, previousFile, err := fileRepo.ReplaceByName(ctx, fileDoc)
 		if err != nil {
 			_ = manager.DeleteFileChunks(ctx, sourceRepo, chunks)
 			slog.ErrorContext(ctx, "upload file: save file", slog.String("error", err.Error()))
 			c.Status(http.StatusInternalServerError)
 			return
+		}
+		if previousFile != nil {
+			if err := deleteFileChunksIfUnreferenced(ctx, sourceRepo, fileRepo, previousFile.Chunks); err != nil {
+				slog.WarnContext(ctx, "upload file: delete old chunks", slog.String("error", err.Error()))
+			}
 		}
 		c.JSON(http.StatusOK, uploadFileResponse{
 			ID:        created.ID.Hex(),

--- a/api-go/internal/handlers/s3.go
+++ b/api-go/internal/handlers/s3.go
@@ -751,16 +751,6 @@ func PutObject(bucketRepo *repository.BucketRepository, sourceRepo *repository.S
 			writeS3Error(c, http.StatusBadRequest, "InvalidRequest", "")
 			return
 		}
-		var existingFile *repository.File
-		existingFile, err = fileRepo.GetByName(ctx, bucketDoc.ID, name)
-		if err != nil && err != mongo.ErrNoDocuments {
-			slog.ErrorContext(ctx, "put object: get existing file", slog.String("error", err.Error()))
-			writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
-			return
-		}
-		if err == mongo.ErrNoDocuments {
-			existingFile = nil
-		}
 		selector := manager.SelectorForBucket(bucketDoc, sources)
 		chunks, err := manager.UploadFileChunksWithStrategy(ctx, c.Request.Body, sources, chunkSize, nil, selector)
 		if err != nil {
@@ -770,25 +760,17 @@ func PutObject(bucketRepo *repository.BucketRepository, sourceRepo *repository.S
 		}
 
 		fileDoc := repository.File{BucketID: bucketDoc.ID, Name: name, CreatedAt: time.Now().UTC(), Chunks: chunks}
-		if existingFile == nil {
-			if _, err := fileRepo.Create(ctx, fileDoc); err != nil {
-				_ = manager.DeleteFileChunks(ctx, sourceRepo, chunks)
-				slog.ErrorContext(ctx, "put object: save file", slog.String("error", err.Error()))
-				writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
-				return
-			}
-			c.Status(http.StatusOK)
-			return
-		}
-		fileDoc.ID = existingFile.ID
-		if _, err := fileRepo.UpdateByID(ctx, fileDoc); err != nil {
+		_, previousFile, err := fileRepo.ReplaceByName(ctx, fileDoc)
+		if err != nil {
 			_ = manager.DeleteFileChunks(ctx, sourceRepo, chunks)
-			slog.ErrorContext(ctx, "put object: update file", slog.String("error", err.Error()))
+			slog.ErrorContext(ctx, "put object: save file", slog.String("error", err.Error()))
 			writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
 			return
 		}
-		if err := deleteFileChunksIfUnreferenced(ctx, sourceRepo, fileRepo, existingFile.Chunks); err != nil {
-			slog.WarnContext(ctx, "put object: delete old chunks", slog.String("error", err.Error()))
+		if previousFile != nil {
+			if err := deleteFileChunksIfUnreferenced(ctx, sourceRepo, fileRepo, previousFile.Chunks); err != nil {
+				slog.WarnContext(ctx, "put object: delete old chunks", slog.String("error", err.Error()))
+			}
 		}
 		c.Status(http.StatusOK)
 	}
@@ -861,39 +843,20 @@ func CopyObject(bucketRepo *repository.BucketRepository, sourceRepo *repository.
 		now := time.Now().UTC()
 		chunks := append([]repository.FileChunk(nil), sourceFile.Chunks...)
 		copyFile := repository.File{BucketID: destBucket.ID, Name: destKey, CreatedAt: now, Chunks: chunks}
-		existingFile, err := fileRepo.GetByName(ctx, destBucket.ID, destKey)
-		if err != nil && err != mongo.ErrNoDocuments {
-			slog.ErrorContext(ctx, "copy object: get existing file", slog.String("error", err.Error()))
+		currentFile, previousFile, err := fileRepo.ReplaceByName(ctx, copyFile)
+		if err != nil {
+			slog.ErrorContext(ctx, "copy object: save file", slog.String("error", err.Error()))
 			writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
 			return
 		}
-		if err == mongo.ErrNoDocuments {
-			existingFile = nil
-		}
-		if existingFile == nil {
-			created, err := fileRepo.Create(ctx, copyFile)
-			if err != nil {
-				slog.ErrorContext(ctx, "copy object: create file", slog.String("error", err.Error()))
-				writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
-				return
-			}
-			copyFile = *created
-		} else {
-			copyFile.ID = existingFile.ID
-			updated, err := fileRepo.UpdateByID(ctx, copyFile)
-			if err != nil {
-				slog.ErrorContext(ctx, "copy object: update file", slog.String("error", err.Error()))
-				writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
-				return
-			}
-			copyFile = *updated
-			if err := deleteFileChunksIfUnreferenced(ctx, sourceRepo, fileRepo, existingFile.Chunks); err != nil {
+		if previousFile != nil {
+			if err := deleteFileChunksIfUnreferenced(ctx, sourceRepo, fileRepo, previousFile.Chunks); err != nil {
 				slog.WarnContext(ctx, "copy object: delete old chunks", slog.String("error", err.Error()))
 			}
 		}
 		c.XML(http.StatusOK, copyObjectResult{
 			Xmlns:        "http://s3.amazonaws.com/doc/2006-03-01/",
-			ETag:         objectETag(copyFile),
+			ETag:         objectETag(*currentFile),
 			LastModified: now.Format(time.RFC3339),
 		})
 	}

--- a/api-go/internal/handlers/s3_multipart.go
+++ b/api-go/internal/handlers/s3_multipart.go
@@ -407,36 +407,21 @@ func completeMultipartUpload(c *gin.Context, bucketRepo *repository.BucketReposi
 		}
 	}
 
-	// Create or update the final file.
 	fileDoc := repository.File{
 		BucketID:  bucketDoc.ID,
 		Name:      mu.ObjectKey,
 		CreatedAt: time.Now().UTC(),
 		Chunks:    allChunks,
 	}
-
-	existingFile, err := fileRepo.GetByName(ctx, bucketDoc.ID, mu.ObjectKey)
-	if err != nil && err != mongo.ErrNoDocuments {
-		slog.ErrorContext(ctx, "complete multipart: check existing", slog.String("error", err.Error()))
+	_, previousFile, err := fileRepo.ReplaceByName(ctx, fileDoc)
+	if err != nil {
+		slog.ErrorContext(ctx, "complete multipart: save file", slog.String("error", err.Error()))
 		writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
 		return
 	}
-
-	if existingFile != nil {
-		fileDoc.ID = existingFile.ID
-		if _, err := fileRepo.UpdateByID(ctx, fileDoc); err != nil {
-			slog.ErrorContext(ctx, "complete multipart: update file", slog.String("error", err.Error()))
-			writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
-			return
-		}
-		if delErr := deleteFileChunksIfUnreferenced(ctx, sourceRepo, fileRepo, existingFile.Chunks); delErr != nil {
+	if previousFile != nil {
+		if delErr := deleteFileChunksIfUnreferenced(ctx, sourceRepo, fileRepo, previousFile.Chunks); delErr != nil {
 			slog.WarnContext(ctx, "complete multipart: delete old chunks", slog.String("error", delErr.Error()))
-		}
-	} else {
-		if _, err := fileRepo.Create(ctx, fileDoc); err != nil {
-			slog.ErrorContext(ctx, "complete multipart: create file", slog.String("error", err.Error()))
-			writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
-			return
 		}
 	}
 

--- a/api-go/internal/repository/file.go
+++ b/api-go/internal/repository/file.go
@@ -33,6 +33,8 @@ type FileRepository struct {
 	coll *mongo.Collection
 }
 
+const fileBucketNameUniqueIndex = "bucket_id_name_unique"
+
 func NewFileRepository(db *mongo.Database) (*FileRepository, error) {
 	coll := db.Collection("files")
 	_, err := coll.Indexes().CreateOne(context.Background(), mongo.IndexModel{
@@ -41,13 +43,82 @@ func NewFileRepository(db *mongo.Database) (*FileRepository, error) {
 	if err != nil {
 		return nil, err
 	}
-	_, err = coll.Indexes().CreateOne(context.Background(), mongo.IndexModel{
-		Keys: bson.D{{Key: "bucket_id", Value: 1}, {Key: "name", Value: 1}},
-	})
-	if err != nil {
+	if err := ensureUniqueFileBucketNameIndex(context.Background(), coll); err != nil {
 		return nil, err
 	}
 	return &FileRepository{coll: coll}, nil
+}
+
+type indexInfo struct {
+	Name   string `bson:"name"`
+	Key    bson.D `bson:"key"`
+	Unique bool   `bson:"unique,omitempty"`
+}
+
+func ensureUniqueFileBucketNameIndex(ctx context.Context, coll *mongo.Collection) error {
+	cursor, err := coll.Indexes().List(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = cursor.Close(ctx) }()
+
+	hasUnique := false
+	var dropNames []string
+	for cursor.Next(ctx) {
+		var idx indexInfo
+		if err := cursor.Decode(&idx); err != nil {
+			return err
+		}
+		if !isFileBucketNameIndex(idx.Key) {
+			continue
+		}
+		if idx.Unique {
+			hasUnique = true
+			continue
+		}
+		dropNames = append(dropNames, idx.Name)
+	}
+	if err := cursor.Err(); err != nil {
+		return err
+	}
+	for _, name := range dropNames {
+		if _, err := coll.Indexes().DropOne(ctx, name); err != nil {
+			return err
+		}
+	}
+	if hasUnique {
+		return nil
+	}
+	_, err = coll.Indexes().CreateOne(ctx, mongo.IndexModel{
+		Keys: bson.D{{Key: "bucket_id", Value: 1}, {Key: "name", Value: 1}},
+		Options: options.Index().
+			SetName(fileBucketNameUniqueIndex).
+			SetUnique(true),
+	})
+	return err
+}
+
+func isFileBucketNameIndex(key bson.D) bool {
+	return len(key) == 2 &&
+		key[0].Key == "bucket_id" &&
+		key[1].Key == "name" &&
+		indexValueIsOne(key[0].Value) &&
+		indexValueIsOne(key[1].Value)
+}
+
+func indexValueIsOne(value any) bool {
+	switch v := value.(type) {
+	case int:
+		return v == 1
+	case int32:
+		return v == 1
+	case int64:
+		return v == 1
+	case float64:
+		return v == 1
+	default:
+		return false
+	}
 }
 
 func (r *FileRepository) Create(ctx context.Context, f File) (*File, error) {
@@ -185,4 +256,59 @@ func (r *FileRepository) UpdateByID(ctx context.Context, f File) (*File, error) 
 		return nil, mongo.ErrNoDocuments
 	}
 	return &f, nil
+}
+
+func (r *FileRepository) ReplaceByName(ctx context.Context, f File) (*File, *File, error) {
+	f.CreatedAt = f.CreatedAt.UTC()
+	if f.ID.IsZero() {
+		f.ID = primitive.NewObjectID()
+	}
+	current := f
+
+	previous, err := r.replaceByName(ctx, current, true)
+	if err == nil {
+		current.ID = previous.ID
+		return &current, previous, nil
+	}
+	if err == mongo.ErrNoDocuments {
+		return &current, nil, nil
+	}
+	if !mongo.IsDuplicateKeyError(err) {
+		return nil, nil, err
+	}
+
+	previous, err = r.replaceByName(ctx, current, false)
+	if err != nil {
+		return nil, nil, err
+	}
+	current.ID = previous.ID
+	return &current, previous, nil
+}
+
+func (r *FileRepository) replaceByName(ctx context.Context, f File, upsert bool) (*File, error) {
+	update := bson.M{
+		"$set": bson.M{
+			"bucket_id":  f.BucketID,
+			"name":       f.Name,
+			"created_at": f.CreatedAt,
+			"chunks":     f.Chunks,
+		},
+	}
+	if upsert {
+		update["$setOnInsert"] = bson.M{"_id": f.ID}
+	}
+
+	var previous File
+	err := r.coll.FindOneAndUpdate(
+		ctx,
+		bson.M{"bucket_id": f.BucketID, "name": f.Name},
+		update,
+		options.FindOneAndUpdate().
+			SetReturnDocument(options.Before).
+			SetUpsert(upsert),
+	).Decode(&previous)
+	if err != nil {
+		return nil, err
+	}
+	return &previous, nil
 }

--- a/api-go/internal/repository/file_test.go
+++ b/api-go/internal/repository/file_test.go
@@ -1,0 +1,141 @@
+//go:build integration
+// +build integration
+
+package repository
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/example/sfree/api-go/internal/config"
+	"github.com/example/sfree/api-go/internal/db"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+func TestFileRepositoryUniqueBucketNameAndReplace(t *testing.T) {
+	_, repo := newFileRepositoryTestDB(t)
+
+	ctx := context.Background()
+	bucketID := primitive.NewObjectID()
+	sourceID := primitive.NewObjectID()
+	name := "object-" + primitive.NewObjectID().Hex()
+	firstChunks := []FileChunk{{SourceID: sourceID, Name: "chunk-a", Order: 0, Size: 5}}
+
+	created, previous, err := repo.ReplaceByName(ctx, File{
+		BucketID:  bucketID,
+		Name:      name,
+		CreatedAt: time.Now(),
+		Chunks:    firstChunks,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if previous != nil {
+		t.Fatalf("expected no previous file, got %+v", previous)
+	}
+	if created.ID.IsZero() {
+		t.Fatal("expected generated file id")
+	}
+
+	_, err = repo.Create(ctx, File{
+		BucketID:  bucketID,
+		Name:      name,
+		CreatedAt: time.Now(),
+		Chunks:    []FileChunk{{SourceID: sourceID, Name: "duplicate", Order: 0, Size: 9}},
+	})
+	if !mongo.IsDuplicateKeyError(err) {
+		t.Fatalf("expected duplicate key error, got %v", err)
+	}
+
+	secondChunks := []FileChunk{{SourceID: sourceID, Name: "chunk-b", Order: 0, Size: 7}}
+	updated, previous, err := repo.ReplaceByName(ctx, File{
+		BucketID:  bucketID,
+		Name:      name,
+		CreatedAt: time.Now(),
+		Chunks:    secondChunks,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if previous == nil {
+		t.Fatal("expected previous file on overwrite")
+	}
+	if previous.ID != created.ID || updated.ID != created.ID {
+		t.Fatalf("expected overwrite to preserve id: created=%s previous=%s updated=%s", created.ID.Hex(), previous.ID.Hex(), updated.ID.Hex())
+	}
+	if len(previous.Chunks) != 1 || previous.Chunks[0].Name != "chunk-a" {
+		t.Fatalf("expected previous chunks, got %+v", previous.Chunks)
+	}
+
+	got, err := repo.GetByName(ctx, bucketID, name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ID != created.ID || len(got.Chunks) != 1 || got.Chunks[0].Name != "chunk-b" {
+		t.Fatalf("unexpected authoritative file: %+v", got)
+	}
+
+	files, err := repo.ListByBucket(ctx, bucketID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 1 {
+		t.Fatalf("expected one file document, got %d", len(files))
+	}
+}
+
+func TestFileRepositoryMigratesLegacyBucketNameIndex(t *testing.T) {
+	testDB, _ := newFileRepositoryTestDB(t)
+	ctx := context.Background()
+	coll := testDB.Collection("files")
+	_, err := coll.Indexes().DropOne(ctx, fileBucketNameUniqueIndex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = coll.Indexes().CreateOne(ctx, mongo.IndexModel{
+		Keys: bson.D{{Key: "bucket_id", Value: 1}, {Key: "name", Value: 1}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	repo, err := NewFileRepository(testDB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bucketID := primitive.NewObjectID()
+	name := "legacy-" + primitive.NewObjectID().Hex()
+	_, err = repo.Create(ctx, File{BucketID: bucketID, Name: name, CreatedAt: time.Now()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = repo.Create(ctx, File{BucketID: bucketID, Name: name, CreatedAt: time.Now()})
+	if !mongo.IsDuplicateKeyError(err) {
+		t.Fatalf("expected duplicate key error after legacy index migration, got %v", err)
+	}
+}
+
+func newFileRepositoryTestDB(t *testing.T) (*mongo.Database, *FileRepository) {
+	t.Helper()
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	mongoConn, err := db.Connect(context.Background(), cfg.Mongo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	testDB := mongoConn.Client.Database("sfree_file_repository_" + primitive.NewObjectID().Hex())
+	t.Cleanup(func() {
+		_ = testDB.Drop(context.Background())
+		_ = mongoConn.Close(context.Background())
+	})
+	repo, err := NewFileRepository(testDB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return testDB, repo
+}


### PR DESCRIPTION
## Summary
- add a unique Mongo index for `files` on `(bucket_id, name)` with a narrow migration for the legacy non-unique same-key index
- add `FileRepository.ReplaceByName` for race-safe object metadata replacement with previous-document return for chunk cleanup
- move S3 PUT, CopyObject, multipart completion, and UI upload onto the single replace-by-name write path
- add integration coverage for duplicate-name rejection, overwrite semantics, and legacy index migration

## Validation
- `gofmt` on changed Go files
- `git diff --check`
- Did not run Go tests locally due agent policy forbidding CPU-bound validation; Woodpecker should run backend validation.