### PR TITLE
THE-448 Move S3 object mutations into manager

### DIFF
--- a/api-go/internal/handlers/bucket.go
+++ b/api-go/internal/handlers/bucket.go
@@ -409,7 +409,7 @@ func UploadFile(bucketRepo *repository.BucketRepository, sourceRepo *repository.
 			return
 		}
 		if previousFile != nil {
-			if err := deleteFileChunksIfUnreferenced(ctx, sourceRepo, fileRepo, previousFile.Chunks); err != nil {
+			if err := manager.DeleteFileChunksIfUnreferenced(ctx, sourceRepo, fileRepo, previousFile.Chunks); err != nil {
 				slog.WarnContext(ctx, "upload file: delete old chunks", slog.String("error", err.Error()))
 			}
 		}

--- a/api-go/internal/handlers/bucket.go
+++ b/api-go/internal/handlers/bucket.go
@@ -580,7 +580,7 @@ func DeleteFile(bucketRepo *repository.BucketRepository, sourceRepo *repository.
 			c.Status(http.StatusInternalServerError)
 			return
 		}
-		if err := deleteFileChunksIfUnreferenced(ctx, sourceRepo, fileRepo, fileDoc.Chunks); err != nil {
+		if err := manager.DeleteFileChunksIfUnreferenced(ctx, sourceRepo, fileRepo, fileDoc.Chunks); err != nil {
 			slog.ErrorContext(ctx, "delete file: delete chunk", slog.String("error", err.Error()))
 			c.Status(http.StatusInternalServerError)
 			return

--- a/api-go/internal/handlers/s3.go
+++ b/api-go/internal/handlers/s3.go
@@ -2,8 +2,6 @@ package handlers
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/xml"
 	"errors"
 	"io"
@@ -233,28 +231,6 @@ func writeS3Error(c *gin.Context, status int, code, message string) {
 	c.XML(status, s3Error{Code: code, Message: message})
 }
 
-func deleteFileChunksIfUnreferenced(ctx context.Context, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository, chunks []repository.FileChunk) error {
-	seen := make(map[string]struct{}, len(chunks))
-	for _, chunk := range chunks {
-		ref := chunk.SourceID.Hex() + "/" + chunk.Name
-		if _, ok := seen[ref]; ok {
-			continue
-		}
-		seen[ref] = struct{}{}
-		count, err := fileRepo.CountByChunk(ctx, chunk.SourceID, chunk.Name)
-		if err != nil {
-			return err
-		}
-		if count > 0 {
-			continue
-		}
-		if err := manager.DeleteFileChunks(ctx, sourceRepo, []repository.FileChunk{chunk}); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 func parseCopySource(raw string) (string, string, bool) {
 	raw = strings.TrimSpace(raw)
 	raw = strings.TrimPrefix(raw, "/")
@@ -272,40 +248,6 @@ func parseCopySource(raw string) (string, string, bool) {
 		return "", "", false
 	}
 	return bucket, key, true
-}
-
-func deleteObjectByName(ctx context.Context, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository, bucketID primitive.ObjectID, name string) (bool, error) {
-	fileDoc, err := fileRepo.GetByName(ctx, bucketID, name)
-	if err != nil {
-		if err == mongo.ErrNoDocuments {
-			return false, nil
-		}
-		return false, err
-	}
-	if err := fileRepo.Delete(ctx, fileDoc.ID); err != nil {
-		if err == mongo.ErrNoDocuments {
-			return false, nil
-		}
-		return false, err
-	}
-	if err := deleteFileChunksIfUnreferenced(ctx, sourceRepo, fileRepo, fileDoc.Chunks); err != nil {
-		slog.WarnContext(ctx, "delete object: delete chunks", slog.String("error", err.Error()))
-	}
-	return true, nil
-}
-
-func objectETag(file repository.File) string {
-	h := sha256.New()
-	_, _ = h.Write([]byte(file.Name))
-	_, _ = h.Write([]byte(file.CreatedAt.UTC().Format(time.RFC3339Nano)))
-	for _, chunk := range file.Chunks {
-		_, _ = h.Write([]byte(chunk.SourceID.Hex()))
-		_, _ = h.Write([]byte(chunk.Name))
-		_, _ = h.Write([]byte(strconv.Itoa(chunk.Order)))
-		_, _ = h.Write([]byte(":"))
-		_, _ = h.Write([]byte(strconv.FormatInt(chunk.Size, 10)))
-	}
-	return "\"" + hex.EncodeToString(h.Sum(nil)) + "\""
 }
 
 func parseListMaxKeys(c *gin.Context) (int, bool) {
@@ -333,7 +275,7 @@ func fileListBucketEntry(file repository.File) listBucketEntry {
 	return listBucketEntry{
 		Key:          file.Name,
 		LastModified: file.CreatedAt.UTC().Format(time.RFC3339),
-		ETag:         objectETag(file),
+		ETag:         manager.ObjectETag(file),
 		Size:         size,
 		StorageClass: "STANDARD",
 	}
@@ -590,7 +532,7 @@ func lookupObject(c *gin.Context, bucketRepo objectBucketReader, fileRepo object
 
 func setObjectHeaders(c *gin.Context, fileDoc *repository.File, total int64) {
 	c.Header("Accept-Ranges", "bytes")
-	c.Header("ETag", objectETag(*fileDoc))
+	c.Header("ETag", manager.ObjectETag(*fileDoc))
 	c.Header("Last-Modified", fileDoc.CreatedAt.UTC().Format(http.TimeFormat))
 	c.Header("Content-Length", strconv.FormatInt(total, 10))
 	c.Header("Content-Type", "application/octet-stream")
@@ -714,63 +656,34 @@ func getObject(bucketRepo objectBucketReader, sourceRepo *repository.SourceRepos
 // @Failure 500 {string} string ""
 // @Router /api/s3/{bucket}/{object} [put]
 func PutObject(bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository, chunkSize int) gin.HandlerFunc {
+	objectSvc := manager.NewObjectService(sourceRepo, fileRepo, nil)
 	return func(c *gin.Context) {
 		ctx := c.Request.Context()
 		if bucketRepo == nil || sourceRepo == nil || fileRepo == nil {
 			c.Status(http.StatusServiceUnavailable)
 			return
 		}
-		bucketKey := c.Param("bucket")
 		name := strings.TrimPrefix(c.Param("object"), "/")
 		if name == "" {
 			writeS3Error(c, http.StatusBadRequest, "InvalidRequest", "")
 			return
 		}
-		bucketDoc, err := bucketRepo.GetByKey(ctx, bucketKey)
+		bucketDoc, ok := lookupBucket(c, bucketRepo)
+		if !ok {
+			return
+		}
+		result, err := objectSvc.PutObject(ctx, bucketDoc, name, c.Request.Body, chunkSize)
 		if err != nil {
-			if err == mongo.ErrNoDocuments {
-				writeS3Error(c, http.StatusNotFound, "NoSuchBucket", "")
+			if errors.Is(err, manager.ErrNoSources) {
+				writeS3Error(c, http.StatusBadRequest, "InvalidRequest", "")
 				return
 			}
-			slog.ErrorContext(ctx, "put object: get bucket", slog.String("error", err.Error()))
+			slog.ErrorContext(ctx, "put object: mutate object", slog.String("error", err.Error()))
 			writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
 			return
 		}
-		accessKey := c.GetString("accessKey")
-		if accessKey == "" || bucketDoc.AccessKey != accessKey {
-			writeS3Error(c, http.StatusNotFound, "NoSuchBucket", "")
-			return
-		}
-		sources, err := sourceRepo.ListByIDs(ctx, bucketDoc.SourceIDs)
-		if err != nil {
-			slog.ErrorContext(ctx, "put object: list sources", slog.String("error", err.Error()))
-			writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
-			return
-		}
-		if len(sources) == 0 {
-			writeS3Error(c, http.StatusBadRequest, "InvalidRequest", "")
-			return
-		}
-		selector := manager.SelectorForBucket(bucketDoc, sources)
-		chunks, err := manager.UploadFileChunksWithStrategy(ctx, c.Request.Body, sources, chunkSize, nil, selector)
-		if err != nil {
-			slog.ErrorContext(ctx, "put object: upload chunks", slog.String("error", err.Error()))
-			writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
-			return
-		}
-
-		fileDoc := repository.File{BucketID: bucketDoc.ID, Name: name, CreatedAt: time.Now().UTC(), Chunks: chunks}
-		_, previousFile, err := fileRepo.ReplaceByName(ctx, fileDoc)
-		if err != nil {
-			_ = manager.DeleteFileChunks(ctx, sourceRepo, chunks)
-			slog.ErrorContext(ctx, "put object: save file", slog.String("error", err.Error()))
-			writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
-			return
-		}
-		if previousFile != nil {
-			if err := deleteFileChunksIfUnreferenced(ctx, sourceRepo, fileRepo, previousFile.Chunks); err != nil {
-				slog.WarnContext(ctx, "put object: delete old chunks", slog.String("error", err.Error()))
-			}
+		if result.CleanupErr != nil {
+			slog.WarnContext(ctx, "put object: delete old chunks", slog.String("error", result.CleanupErr.Error()))
 		}
 		c.Status(http.StatusOK)
 	}
@@ -787,6 +700,7 @@ func PutObject(bucketRepo *repository.BucketRepository, sourceRepo *repository.S
 // @Failure 500 {string} string ""
 // @Router /api/s3/{bucket}/{object} [put]
 func CopyObject(bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository) gin.HandlerFunc {
+	objectSvc := manager.NewObjectService(sourceRepo, fileRepo, nil)
 	return func(c *gin.Context) {
 		ctx := c.Request.Context()
 		if bucketRepo == nil || sourceRepo == nil || fileRepo == nil {
@@ -825,39 +739,26 @@ func CopyObject(bucketRepo *repository.BucketRepository, sourceRepo *repository.
 			writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
 			return
 		}
-		if sourceBucket.ID != destBucket.ID && sourceBucket.UserID != destBucket.UserID {
-			writeS3Error(c, http.StatusForbidden, "AccessDenied", "")
-			return
-		}
-		sourceFile, err := fileRepo.GetByName(ctx, sourceBucket.ID, sourceKey)
+		result, err := objectSvc.CopyObject(ctx, sourceBucket, destBucket, sourceKey, destKey)
 		if err != nil {
-			if err == mongo.ErrNoDocuments {
+			switch {
+			case errors.Is(err, manager.ErrAccessDenied):
+				writeS3Error(c, http.StatusForbidden, "AccessDenied", "")
+			case errors.Is(err, manager.ErrObjectNotFound):
 				writeS3Error(c, http.StatusNotFound, "NoSuchKey", "")
-				return
+			default:
+				slog.ErrorContext(ctx, "copy object: mutate object", slog.String("error", err.Error()))
+				writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
 			}
-			slog.ErrorContext(ctx, "copy object: get source file", slog.String("error", err.Error()))
-			writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
 			return
 		}
-
-		now := time.Now().UTC()
-		chunks := append([]repository.FileChunk(nil), sourceFile.Chunks...)
-		copyFile := repository.File{BucketID: destBucket.ID, Name: destKey, CreatedAt: now, Chunks: chunks}
-		currentFile, previousFile, err := fileRepo.ReplaceByName(ctx, copyFile)
-		if err != nil {
-			slog.ErrorContext(ctx, "copy object: save file", slog.String("error", err.Error()))
-			writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
-			return
-		}
-		if previousFile != nil {
-			if err := deleteFileChunksIfUnreferenced(ctx, sourceRepo, fileRepo, previousFile.Chunks); err != nil {
-				slog.WarnContext(ctx, "copy object: delete old chunks", slog.String("error", err.Error()))
-			}
+		if result.CleanupErr != nil {
+			slog.WarnContext(ctx, "copy object: delete old chunks", slog.String("error", result.CleanupErr.Error()))
 		}
 		c.XML(http.StatusOK, copyObjectResult{
 			Xmlns:        "http://s3.amazonaws.com/doc/2006-03-01/",
-			ETag:         objectETag(*currentFile),
-			LastModified: now.Format(time.RFC3339),
+			ETag:         manager.ObjectETag(result.File),
+			LastModified: result.File.CreatedAt.UTC().Format(time.RFC3339),
 		})
 	}
 }
@@ -872,6 +773,7 @@ func CopyObject(bucketRepo *repository.BucketRepository, sourceRepo *repository.
 // @Failure 500 {string} string ""
 // @Router /api/s3/{bucket}/{object} [delete]
 func DeleteObject(bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository) gin.HandlerFunc {
+	objectSvc := manager.NewObjectService(sourceRepo, fileRepo, nil)
 	return func(c *gin.Context) {
 		ctx := c.Request.Context()
 		if bucketRepo == nil || sourceRepo == nil || fileRepo == nil {
@@ -899,16 +801,21 @@ func DeleteObject(bucketRepo *repository.BucketRepository, sourceRepo *repositor
 			c.Status(http.StatusNoContent)
 			return
 		}
-		if _, err := deleteObjectByName(ctx, sourceRepo, fileRepo, bucketDoc.ID, name); err != nil {
+		result, err := objectSvc.DeleteObject(ctx, bucketDoc.ID, name)
+		if err != nil {
 			slog.ErrorContext(ctx, "delete object: delete file", slog.String("error", err.Error()))
 			writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
 			return
+		}
+		if result.CleanupErr != nil {
+			slog.WarnContext(ctx, "delete object: delete chunks", slog.String("error", result.CleanupErr.Error()))
 		}
 		c.Status(http.StatusNoContent)
 	}
 }
 
 func DeleteObjects(bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository) gin.HandlerFunc {
+	objectSvc := manager.NewObjectService(sourceRepo, fileRepo, nil)
 	return func(c *gin.Context) {
 		ctx := c.Request.Context()
 		if bucketRepo == nil || sourceRepo == nil || fileRepo == nil {
@@ -950,7 +857,8 @@ func DeleteObjects(bucketRepo *repository.BucketRepository, sourceRepo *reposito
 				})
 				continue
 			}
-			if _, err := deleteObjectByName(ctx, sourceRepo, fileRepo, bucketDoc.ID, key); err != nil {
+			deleteResult, err := objectSvc.DeleteObject(ctx, bucketDoc.ID, key)
+			if err != nil {
 				slog.ErrorContext(ctx, "delete objects: delete file", slog.String("key", key), slog.String("error", err.Error()))
 				result.Errors = append(result.Errors, deleteObjectError{
 					Key:     key,
@@ -958,6 +866,9 @@ func DeleteObjects(bucketRepo *repository.BucketRepository, sourceRepo *reposito
 					Message: "Internal error deleting object",
 				})
 				continue
+			}
+			if deleteResult.CleanupErr != nil {
+				slog.WarnContext(ctx, "delete objects: delete chunks", slog.String("key", key), slog.String("error", deleteResult.CleanupErr.Error()))
 			}
 			if !req.Quiet {
 				result.Deleted = append(result.Deleted, deletedObjectResult{Key: key})

--- a/api-go/internal/handlers/s3_multipart.go
+++ b/api-go/internal/handlers/s3_multipart.go
@@ -1,9 +1,8 @@
 package handlers
 
 import (
-	"crypto/md5"
-	"encoding/hex"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -115,7 +114,7 @@ func PostObject(bucketRepo *repository.BucketRepository, sourceRepo *repository.
 			return
 		}
 		if _, ok := c.GetQuery("uploadId"); ok {
-			completeMultipartUpload(c, bucketRepo, sourceRepo, fileRepo, mpRepo, chunkSize)
+			completeMultipartUpload(c, bucketRepo, sourceRepo, fileRepo, mpRepo)
 			return
 		}
 		writeS3Error(c, http.StatusBadRequest, "InvalidRequest", "missing uploads or uploadId parameter")
@@ -331,7 +330,7 @@ func uploadPart(c *gin.Context, bucketRepo *repository.BucketRepository, sourceR
 	c.Status(http.StatusOK)
 }
 
-func completeMultipartUpload(c *gin.Context, bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository, mpRepo *repository.MultipartUploadRepository, chunkSize int) {
+func completeMultipartUpload(c *gin.Context, bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository, mpRepo *repository.MultipartUploadRepository) {
 	ctx := c.Request.Context()
 	uploadID := c.Query("uploadId")
 
@@ -350,104 +349,53 @@ func completeMultipartUpload(c *gin.Context, bucketRepo *repository.BucketReposi
 	if !ok {
 		return
 	}
-	if mu.BucketID != bucketDoc.ID {
-		writeS3Error(c, http.StatusNotFound, "NoSuchUpload", "")
-		return
-	}
 
 	var req completeMultipartUploadRequest
 	if err := xml.NewDecoder(c.Request.Body).Decode(&req); err != nil {
 		writeS3Error(c, http.StatusBadRequest, "MalformedXML", "could not parse CompleteMultipartUpload body")
 		return
 	}
-	if len(req.Parts) == 0 {
-		writeS3Error(c, http.StatusBadRequest, "InvalidRequest", "at least one part is required")
-		return
-	}
-
-	// Validate part numbers are ascending.
-	for i := 1; i < len(req.Parts); i++ {
-		if req.Parts[i].PartNumber <= req.Parts[i-1].PartNumber {
-			writeS3Error(c, http.StatusBadRequest, "InvalidPartOrder", "part numbers must be in ascending order")
-			return
-		}
-	}
-
-	// Build lookup of uploaded parts.
-	partMap := make(map[int]repository.UploadPart, len(mu.Parts))
-	for _, p := range mu.Parts {
-		partMap[p.PartNumber] = p
-	}
-
-	// Validate all requested parts exist and ETags match.
+	requestedParts := make([]manager.CompleteMultipartPart, 0, len(req.Parts))
 	for _, rp := range req.Parts {
-		up, exists := partMap[rp.PartNumber]
-		if !exists {
-			writeS3Error(c, http.StatusBadRequest, "InvalidPart", fmt.Sprintf("part %d not uploaded", rp.PartNumber))
-			return
-		}
-		// Normalize ETags for comparison (strip quotes).
-		reqETag := strings.Trim(rp.ETag, "\"")
-		upETag := strings.Trim(up.ETag, "\"")
-		if reqETag != upETag {
-			writeS3Error(c, http.StatusBadRequest, "InvalidPart", fmt.Sprintf("ETag mismatch for part %d", rp.PartNumber))
-			return
-		}
+		requestedParts = append(requestedParts, manager.CompleteMultipartPart{PartNumber: rp.PartNumber, ETag: rp.ETag})
 	}
-	allChunks := completedMultipartChunks(req.Parts, partMap)
 
-	fileDoc := repository.File{
-		BucketID:  bucketDoc.ID,
-		Name:      mu.ObjectKey,
-		CreatedAt: time.Now().UTC(),
-		Chunks:    allChunks,
-	}
-	_, previousFile, err := fileRepo.ReplaceByName(ctx, fileDoc)
+	objectSvc := manager.NewObjectService(sourceRepo, fileRepo, mpRepo)
+	result, err := objectSvc.CompleteMultipartUploadRecord(ctx, bucketDoc.ID, mu, requestedParts)
 	if err != nil {
-		slog.ErrorContext(ctx, "complete multipart: save file", slog.String("error", err.Error()))
-		writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
+		switch {
+		case errors.Is(err, manager.ErrMultipartUploadNotFound):
+			writeS3Error(c, http.StatusNotFound, "NoSuchUpload", "")
+		case errors.Is(err, manager.ErrMultipartUploadHasNoParts):
+			writeS3Error(c, http.StatusBadRequest, "InvalidRequest", "at least one part is required")
+		case errors.Is(err, manager.ErrMultipartUploadPartOrder):
+			writeS3Error(c, http.StatusBadRequest, "InvalidPartOrder", "part numbers must be in ascending order")
+		case errors.Is(err, manager.ErrMultipartUploadInvalidPart):
+			var partErr manager.InvalidMultipartPartError
+			if errors.As(err, &partErr) {
+				message := fmt.Sprintf("part %d not uploaded", partErr.PartNumber)
+				if partErr.Reason == "etag mismatch" {
+					message = fmt.Sprintf("ETag mismatch for part %d", partErr.PartNumber)
+				}
+				writeS3Error(c, http.StatusBadRequest, "InvalidPart", message)
+				return
+			}
+			writeS3Error(c, http.StatusBadRequest, "InvalidPart", "")
+		default:
+			slog.ErrorContext(ctx, "complete multipart: mutate object", slog.String("error", err.Error()))
+			writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
+		}
 		return
 	}
-	if previousFile != nil {
-		if delErr := deleteFileChunksIfUnreferenced(ctx, sourceRepo, fileRepo, previousFile.Chunks); delErr != nil {
-			slog.WarnContext(ctx, "complete multipart: delete old chunks", slog.String("error", delErr.Error()))
-		}
+	for _, cleanupErr := range result.CleanupErrs {
+		slog.WarnContext(ctx, "complete multipart: cleanup", slog.String("error", cleanupErr.Error()))
 	}
-
-	// Delete chunks for parts that were uploaded but NOT referenced in the completion request.
-	requestedParts := make(map[int]bool, len(req.Parts))
-	for _, rp := range req.Parts {
-		requestedParts[rp.PartNumber] = true
-	}
-	for _, p := range mu.Parts {
-		if !requestedParts[p.PartNumber] {
-			if delErr := manager.DeleteFileChunks(ctx, sourceRepo, p.Chunks); delErr != nil {
-				slog.WarnContext(ctx, "complete multipart: delete unreferenced part", slog.String("error", delErr.Error()))
-			}
-		}
-	}
-
-	// Clean up the multipart upload record.
-	if err := mpRepo.Delete(ctx, uploadID); err != nil {
-		slog.WarnContext(ctx, "complete multipart: delete upload record", slog.String("error", err.Error()))
-	}
-
-	// Compute multipart ETag: md5-of-part-md5s-N
-	h := md5.New()
-	for _, rp := range req.Parts {
-		up := partMap[rp.PartNumber]
-		partHash := strings.Trim(up.ETag, "\"")
-		raw, _ := hex.DecodeString(partHash)
-		_, _ = h.Write(raw)
-	}
-	etag := fmt.Sprintf("\"%s-%d\"", hex.EncodeToString(h.Sum(nil)), len(req.Parts))
-
 	c.XML(http.StatusOK, completeMultipartUploadResult{
 		Xmlns:    "http://s3.amazonaws.com/doc/2006-03-01/",
-		Location: fmt.Sprintf("/%s/%s", c.Param("bucket"), mu.ObjectKey),
+		Location: fmt.Sprintf("/%s/%s", c.Param("bucket"), result.Upload.ObjectKey),
 		Bucket:   c.Param("bucket"),
-		Key:      mu.ObjectKey,
-		ETag:     etag,
+		Key:      result.Upload.ObjectKey,
+		ETag:     result.ETag,
 	})
 }
 

--- a/api-go/internal/handlers/s3_multipart.go
+++ b/api-go/internal/handlers/s3_multipart.go
@@ -1,6 +1,8 @@
 package handlers
 
 import (
+	"crypto/md5"
+	"encoding/hex"
 	"encoding/xml"
 	"errors"
 	"fmt"

--- a/api-go/internal/manager/s3_object.go
+++ b/api-go/internal/manager/s3_object.go
@@ -1,0 +1,343 @@
+package manager
+
+import (
+	"context"
+	"crypto/md5"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/example/sfree/api-go/internal/repository"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+var (
+	ErrNoSources                  = errors.New("no sources configured")
+	ErrObjectNotFound             = errors.New("object not found")
+	ErrAccessDenied               = errors.New("access denied")
+	ErrMultipartUploadNotFound    = errors.New("multipart upload not found")
+	ErrMultipartUploadHasNoParts  = errors.New("multipart upload completion requires at least one part")
+	ErrMultipartUploadPartOrder   = errors.New("multipart upload parts must be in ascending order")
+	ErrMultipartUploadInvalidPart = errors.New("multipart upload invalid part")
+)
+
+type InvalidMultipartPartError struct {
+	PartNumber int
+	Reason     string
+}
+
+func (e InvalidMultipartPartError) Error() string {
+	return fmt.Sprintf("%v: part %d %s", ErrMultipartUploadInvalidPart, e.PartNumber, e.Reason)
+}
+
+func (e InvalidMultipartPartError) Unwrap() error {
+	return ErrMultipartUploadInvalidPart
+}
+
+type CompleteMultipartPart struct {
+	PartNumber int
+	ETag       string
+}
+
+type PutObjectResult struct {
+	File       repository.File
+	CleanupErr error
+}
+
+type CopyObjectResult struct {
+	File       repository.File
+	CleanupErr error
+}
+
+type DeleteObjectResult struct {
+	Deleted    bool
+	CleanupErr error
+}
+
+type CompleteMultipartUploadResult struct {
+	File        repository.File
+	Upload      repository.MultipartUpload
+	ETag        string
+	CleanupErrs []error
+}
+
+type objectSourceStore interface {
+	ListByIDs(ctx context.Context, ids []primitive.ObjectID) ([]repository.Source, error)
+}
+
+type ChunkReferenceCounter interface {
+	CountByChunk(ctx context.Context, sourceID primitive.ObjectID, name string) (int64, error)
+}
+
+type objectFileStore interface {
+	ChunkReferenceCounter
+	GetByName(ctx context.Context, bucketID primitive.ObjectID, name string) (*repository.File, error)
+	ReplaceByName(ctx context.Context, f repository.File) (*repository.File, *repository.File, error)
+	Delete(ctx context.Context, id primitive.ObjectID) error
+}
+
+type objectMultipartStore interface {
+	GetByUploadID(ctx context.Context, uploadID string) (*repository.MultipartUpload, error)
+	Delete(ctx context.Context, uploadID string) error
+}
+
+type objectChunkUploader func(ctx context.Context, r io.Reader, sources []repository.Source, chunkSize int, selector SourceSelector) ([]repository.FileChunk, error)
+type objectChunkDeleter func(ctx context.Context, chunks []repository.FileChunk) error
+
+type ObjectService struct {
+	sources      objectSourceStore
+	files        objectFileStore
+	multipart    objectMultipartStore
+	uploadChunks objectChunkUploader
+	deleteChunks objectChunkDeleter
+	now          func() time.Time
+}
+
+func NewObjectService(sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository, mpRepo *repository.MultipartUploadRepository) *ObjectService {
+	svc := &ObjectService{
+		sources:   sourceRepo,
+		files:     fileRepo,
+		multipart: mpRepo,
+		uploadChunks: func(ctx context.Context, r io.Reader, sources []repository.Source, chunkSize int, selector SourceSelector) ([]repository.FileChunk, error) {
+			return UploadFileChunksWithStrategy(ctx, r, sources, chunkSize, nil, selector)
+		},
+		now: func() time.Time {
+			return time.Now().UTC()
+		},
+	}
+	svc.deleteChunks = func(ctx context.Context, chunks []repository.FileChunk) error {
+		return DeleteFileChunks(ctx, sourceRepo, chunks)
+	}
+	return svc
+}
+
+func (s *ObjectService) PutObject(ctx context.Context, bucket *repository.Bucket, name string, body io.Reader, chunkSize int) (PutObjectResult, error) {
+	sources, err := s.sources.ListByIDs(ctx, bucket.SourceIDs)
+	if err != nil {
+		return PutObjectResult{}, err
+	}
+	if len(sources) == 0 {
+		return PutObjectResult{}, ErrNoSources
+	}
+
+	chunks, err := s.uploadChunks(ctx, body, sources, chunkSize, SelectorForBucket(bucket, sources))
+	if err != nil {
+		return PutObjectResult{}, err
+	}
+
+	fileDoc := repository.File{BucketID: bucket.ID, Name: name, CreatedAt: s.now(), Chunks: chunks}
+	currentFile, previousFile, err := s.files.ReplaceByName(ctx, fileDoc)
+	if err != nil {
+		_ = s.deleteChunks(ctx, chunks)
+		return PutObjectResult{}, err
+	}
+	var cleanupErr error
+	if previousFile != nil {
+		cleanupErr = s.deleteFileChunksIfUnreferenced(ctx, previousFile.Chunks)
+	}
+	return PutObjectResult{File: *currentFile, CleanupErr: cleanupErr}, nil
+}
+
+func (s *ObjectService) CopyObject(ctx context.Context, sourceBucket, destBucket *repository.Bucket, sourceKey, destKey string) (CopyObjectResult, error) {
+	if sourceBucket.ID != destBucket.ID && sourceBucket.UserID != destBucket.UserID {
+		return CopyObjectResult{}, ErrAccessDenied
+	}
+
+	sourceFile, err := s.files.GetByName(ctx, sourceBucket.ID, sourceKey)
+	if err != nil {
+		if err == mongo.ErrNoDocuments {
+			return CopyObjectResult{}, ErrObjectNotFound
+		}
+		return CopyObjectResult{}, err
+	}
+
+	chunks := append([]repository.FileChunk(nil), sourceFile.Chunks...)
+	copyFile := repository.File{BucketID: destBucket.ID, Name: destKey, CreatedAt: s.now(), Chunks: chunks}
+	currentFile, previousFile, err := s.files.ReplaceByName(ctx, copyFile)
+	if err != nil {
+		return CopyObjectResult{}, err
+	}
+	var cleanupErr error
+	if previousFile != nil {
+		cleanupErr = s.deleteFileChunksIfUnreferenced(ctx, previousFile.Chunks)
+	}
+	return CopyObjectResult{File: *currentFile, CleanupErr: cleanupErr}, nil
+}
+
+func (s *ObjectService) DeleteObject(ctx context.Context, bucketID primitive.ObjectID, name string) (DeleteObjectResult, error) {
+	fileDoc, err := s.files.GetByName(ctx, bucketID, name)
+	if err != nil {
+		if err == mongo.ErrNoDocuments {
+			return DeleteObjectResult{}, nil
+		}
+		return DeleteObjectResult{}, err
+	}
+	if err := s.files.Delete(ctx, fileDoc.ID); err != nil {
+		if err == mongo.ErrNoDocuments {
+			return DeleteObjectResult{}, nil
+		}
+		return DeleteObjectResult{}, err
+	}
+	return DeleteObjectResult{
+		Deleted:    true,
+		CleanupErr: s.deleteFileChunksIfUnreferenced(ctx, fileDoc.Chunks),
+	}, nil
+}
+
+func (s *ObjectService) CompleteMultipartUpload(ctx context.Context, bucketID primitive.ObjectID, uploadID string, requestedParts []CompleteMultipartPart) (CompleteMultipartUploadResult, error) {
+	mu, err := s.multipart.GetByUploadID(ctx, uploadID)
+	if err != nil {
+		if err == mongo.ErrNoDocuments {
+			return CompleteMultipartUploadResult{}, ErrMultipartUploadNotFound
+		}
+		return CompleteMultipartUploadResult{}, err
+	}
+	return s.CompleteMultipartUploadRecord(ctx, bucketID, mu, requestedParts)
+}
+
+func (s *ObjectService) CompleteMultipartUploadRecord(ctx context.Context, bucketID primitive.ObjectID, mu *repository.MultipartUpload, requestedParts []CompleteMultipartPart) (CompleteMultipartUploadResult, error) {
+	if mu == nil {
+		return CompleteMultipartUploadResult{}, ErrMultipartUploadNotFound
+	}
+	if mu.BucketID != bucketID {
+		return CompleteMultipartUploadResult{}, ErrMultipartUploadNotFound
+	}
+	if len(requestedParts) == 0 {
+		return CompleteMultipartUploadResult{}, ErrMultipartUploadHasNoParts
+	}
+	for i := 1; i < len(requestedParts); i++ {
+		if requestedParts[i].PartNumber <= requestedParts[i-1].PartNumber {
+			return CompleteMultipartUploadResult{}, ErrMultipartUploadPartOrder
+		}
+	}
+
+	partMap := make(map[int]repository.UploadPart, len(mu.Parts))
+	for _, p := range mu.Parts {
+		partMap[p.PartNumber] = p
+	}
+
+	var allChunks []repository.FileChunk
+	chunkOrder := 0
+	for _, rp := range requestedParts {
+		up, exists := partMap[rp.PartNumber]
+		if !exists {
+			return CompleteMultipartUploadResult{}, InvalidMultipartPartError{PartNumber: rp.PartNumber, Reason: "not uploaded"}
+		}
+		if strings.Trim(rp.ETag, "\"") != strings.Trim(up.ETag, "\"") {
+			return CompleteMultipartUploadResult{}, InvalidMultipartPartError{PartNumber: rp.PartNumber, Reason: "etag mismatch"}
+		}
+		for _, ch := range up.Chunks {
+			allChunks = append(allChunks, repository.FileChunk{
+				SourceID: ch.SourceID,
+				Name:     ch.Name,
+				Order:    chunkOrder,
+				Size:     ch.Size,
+				Checksum: ch.Checksum,
+			})
+			chunkOrder++
+		}
+	}
+
+	fileDoc := repository.File{
+		BucketID:  bucketID,
+		Name:      mu.ObjectKey,
+		CreatedAt: s.now(),
+		Chunks:    allChunks,
+	}
+	saved, previousFile, err := s.files.ReplaceByName(ctx, fileDoc)
+	if err != nil {
+		return CompleteMultipartUploadResult{}, err
+	}
+
+	var cleanupErrs []error
+	if previousFile != nil {
+		if err := s.deleteFileChunksIfUnreferenced(ctx, previousFile.Chunks); err != nil {
+			cleanupErrs = append(cleanupErrs, err)
+		}
+	}
+
+	requested := make(map[int]bool, len(requestedParts))
+	for _, rp := range requestedParts {
+		requested[rp.PartNumber] = true
+	}
+	for _, p := range mu.Parts {
+		if !requested[p.PartNumber] {
+			if err := s.deleteChunks(ctx, p.Chunks); err != nil {
+				cleanupErrs = append(cleanupErrs, err)
+			}
+		}
+	}
+	if err := s.multipart.Delete(ctx, mu.UploadID); err != nil {
+		cleanupErrs = append(cleanupErrs, err)
+	}
+
+	return CompleteMultipartUploadResult{
+		File:        *saved,
+		Upload:      *mu,
+		ETag:        multipartETag(requestedParts, partMap),
+		CleanupErrs: cleanupErrs,
+	}, nil
+}
+
+func (s *ObjectService) deleteFileChunksIfUnreferenced(ctx context.Context, chunks []repository.FileChunk) error {
+	return deleteFileChunksIfUnreferenced(ctx, s.files, s.deleteChunks, chunks)
+}
+
+func DeleteFileChunksIfUnreferenced(ctx context.Context, sourceRepo *repository.SourceRepository, fileStore ChunkReferenceCounter, chunks []repository.FileChunk) error {
+	return deleteFileChunksIfUnreferenced(ctx, fileStore, func(ctx context.Context, chunks []repository.FileChunk) error {
+		return DeleteFileChunks(ctx, sourceRepo, chunks)
+	}, chunks)
+}
+
+func deleteFileChunksIfUnreferenced(ctx context.Context, files ChunkReferenceCounter, deleteChunks objectChunkDeleter, chunks []repository.FileChunk) error {
+	seen := make(map[string]struct{}, len(chunks))
+	for _, chunk := range chunks {
+		ref := chunk.SourceID.Hex() + "/" + chunk.Name
+		if _, ok := seen[ref]; ok {
+			continue
+		}
+		seen[ref] = struct{}{}
+		count, err := files.CountByChunk(ctx, chunk.SourceID, chunk.Name)
+		if err != nil {
+			return err
+		}
+		if count > 0 {
+			continue
+		}
+		if err := deleteChunks(ctx, []repository.FileChunk{chunk}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func ObjectETag(file repository.File) string {
+	h := sha256.New()
+	_, _ = h.Write([]byte(file.Name))
+	_, _ = h.Write([]byte(file.CreatedAt.UTC().Format(time.RFC3339Nano)))
+	for _, chunk := range file.Chunks {
+		_, _ = h.Write([]byte(chunk.SourceID.Hex()))
+		_, _ = h.Write([]byte(chunk.Name))
+		_, _ = h.Write([]byte(strconv.Itoa(chunk.Order)))
+		_, _ = h.Write([]byte(":"))
+		_, _ = h.Write([]byte(strconv.FormatInt(chunk.Size, 10)))
+	}
+	return "\"" + hex.EncodeToString(h.Sum(nil)) + "\""
+}
+
+func multipartETag(requestedParts []CompleteMultipartPart, partMap map[int]repository.UploadPart) string {
+	h := md5.New()
+	for _, rp := range requestedParts {
+		up := partMap[rp.PartNumber]
+		partHash := strings.Trim(up.ETag, "\"")
+		raw, _ := hex.DecodeString(partHash)
+		_, _ = h.Write(raw)
+	}
+	return fmt.Sprintf("\"%s-%d\"", hex.EncodeToString(h.Sum(nil)), len(requestedParts))
+}

--- a/api-go/internal/manager/s3_object_test.go
+++ b/api-go/internal/manager/s3_object_test.go
@@ -177,6 +177,44 @@ func TestObjectServicePutObjectUpdatesFileAndDeletesOldChunks(t *testing.T) {
 	}
 }
 
+func TestObjectServicePutObjectCreateFailureDeletesUploadedChunks(t *testing.T) {
+	bucketID := primitive.NewObjectID()
+	files := newFakeObjectFiles()
+	files.createErr = errors.New("create failed")
+	var deleted []repository.FileChunk
+	svc := testObjectService(files, &deleted)
+
+	_, err := svc.PutObject(context.Background(), &repository.Bucket{ID: bucketID}, "object.txt", bytes.NewBufferString("data"), 5)
+	if err == nil {
+		t.Fatal("expected PutObject create error")
+	}
+	if len(deleted) != 1 || deleted[0].Name != "new-chunk" {
+		t.Fatalf("expected uploaded chunk cleanup after create failure, got %#v", deleted)
+	}
+}
+
+func TestObjectServicePutObjectUpdateFailureDeletesUploadedChunks(t *testing.T) {
+	bucketID := primitive.NewObjectID()
+	existing := repository.File{
+		ID:       primitive.NewObjectID(),
+		BucketID: bucketID,
+		Name:     "object.txt",
+		Chunks:   []repository.FileChunk{{SourceID: primitive.NewObjectID(), Name: "old-chunk", Size: 9}},
+	}
+	files := newFakeObjectFiles(existing)
+	files.updateErr = errors.New("update failed")
+	var deleted []repository.FileChunk
+	svc := testObjectService(files, &deleted)
+
+	_, err := svc.PutObject(context.Background(), &repository.Bucket{ID: bucketID}, "object.txt", bytes.NewBufferString("data"), 5)
+	if err == nil {
+		t.Fatal("expected PutObject update error")
+	}
+	if len(deleted) != 1 || deleted[0].Name != "new-chunk" {
+		t.Fatalf("expected uploaded chunk cleanup after update failure, got %#v", deleted)
+	}
+}
+
 func TestObjectServiceCopyObjectPreservesChunksAndCleansOverwrittenDestination(t *testing.T) {
 	userID := primitive.NewObjectID()
 	sourceBucketID := primitive.NewObjectID()

--- a/api-go/internal/manager/s3_object_test.go
+++ b/api-go/internal/manager/s3_object_test.go
@@ -180,7 +180,7 @@ func TestObjectServicePutObjectUpdatesFileAndDeletesOldChunks(t *testing.T) {
 func TestObjectServicePutObjectCreateFailureDeletesUploadedChunks(t *testing.T) {
 	bucketID := primitive.NewObjectID()
 	files := newFakeObjectFiles()
-	files.createErr = errors.New("create failed")
+	files.replaceErr = errors.New("replace failed")
 	var deleted []repository.FileChunk
 	svc := testObjectService(files, &deleted)
 
@@ -193,7 +193,7 @@ func TestObjectServicePutObjectCreateFailureDeletesUploadedChunks(t *testing.T) 
 	}
 }
 
-func TestObjectServicePutObjectUpdateFailureDeletesUploadedChunks(t *testing.T) {
+func TestObjectServicePutObjectOverwriteFailureDeletesUploadedChunks(t *testing.T) {
 	bucketID := primitive.NewObjectID()
 	existing := repository.File{
 		ID:       primitive.NewObjectID(),
@@ -202,16 +202,16 @@ func TestObjectServicePutObjectUpdateFailureDeletesUploadedChunks(t *testing.T) 
 		Chunks:   []repository.FileChunk{{SourceID: primitive.NewObjectID(), Name: "old-chunk", Size: 9}},
 	}
 	files := newFakeObjectFiles(existing)
-	files.updateErr = errors.New("update failed")
+	files.replaceErr = errors.New("replace failed")
 	var deleted []repository.FileChunk
 	svc := testObjectService(files, &deleted)
 
 	_, err := svc.PutObject(context.Background(), &repository.Bucket{ID: bucketID}, "object.txt", bytes.NewBufferString("data"), 5)
 	if err == nil {
-		t.Fatal("expected PutObject update error")
+		t.Fatal("expected PutObject overwrite error")
 	}
 	if len(deleted) != 1 || deleted[0].Name != "new-chunk" {
-		t.Fatalf("expected uploaded chunk cleanup after update failure, got %#v", deleted)
+		t.Fatalf("expected uploaded chunk cleanup after overwrite failure, got %#v", deleted)
 	}
 }
 

--- a/api-go/internal/manager/s3_object_test.go
+++ b/api-go/internal/manager/s3_object_test.go
@@ -1,0 +1,304 @@
+package manager
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/example/sfree/api-go/internal/repository"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+type fakeObjectSources struct {
+	sources []repository.Source
+	err     error
+}
+
+func (f *fakeObjectSources) ListByIDs(context.Context, []primitive.ObjectID) ([]repository.Source, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return append([]repository.Source(nil), f.sources...), nil
+}
+
+type fakeObjectFiles struct {
+	byName     map[string]repository.File
+	countErr   error
+	replaceErr error
+	deleteErr  error
+}
+
+func newFakeObjectFiles(files ...repository.File) *fakeObjectFiles {
+	f := &fakeObjectFiles{byName: make(map[string]repository.File)}
+	for _, file := range files {
+		if file.ID.IsZero() {
+			file.ID = primitive.NewObjectID()
+		}
+		f.byName[fileKey(file.BucketID, file.Name)] = file
+	}
+	return f
+}
+
+func (f *fakeObjectFiles) ReplaceByName(_ context.Context, file repository.File) (*repository.File, *repository.File, error) {
+	if f.replaceErr != nil {
+		return nil, nil, f.replaceErr
+	}
+	if file.ID.IsZero() {
+		file.ID = primitive.NewObjectID()
+	}
+	key := fileKey(file.BucketID, file.Name)
+	previous, ok := f.byName[key]
+	if ok {
+		file.ID = previous.ID
+		f.byName[key] = file
+		return &file, &previous, nil
+	}
+	f.byName[key] = file
+	return &file, nil, nil
+}
+
+func (f *fakeObjectFiles) GetByName(_ context.Context, bucketID primitive.ObjectID, name string) (*repository.File, error) {
+	file, ok := f.byName[fileKey(bucketID, name)]
+	if !ok {
+		return nil, mongo.ErrNoDocuments
+	}
+	return &file, nil
+}
+
+func (f *fakeObjectFiles) Delete(_ context.Context, id primitive.ObjectID) error {
+	if f.deleteErr != nil {
+		return f.deleteErr
+	}
+	for key, file := range f.byName {
+		if file.ID == id {
+			delete(f.byName, key)
+			return nil
+		}
+	}
+	return mongo.ErrNoDocuments
+}
+
+func (f *fakeObjectFiles) CountByChunk(_ context.Context, sourceID primitive.ObjectID, name string) (int64, error) {
+	if f.countErr != nil {
+		return 0, f.countErr
+	}
+	var count int64
+	for _, file := range f.byName {
+		for _, chunk := range file.Chunks {
+			if chunk.SourceID == sourceID && chunk.Name == name {
+				count++
+				break
+			}
+		}
+	}
+	return count, nil
+}
+
+type fakeMultipartUploads struct {
+	uploads map[string]repository.MultipartUpload
+	delErr  error
+}
+
+func (f *fakeMultipartUploads) GetByUploadID(_ context.Context, uploadID string) (*repository.MultipartUpload, error) {
+	upload, ok := f.uploads[uploadID]
+	if !ok {
+		return nil, mongo.ErrNoDocuments
+	}
+	return &upload, nil
+}
+
+func (f *fakeMultipartUploads) Delete(_ context.Context, uploadID string) error {
+	if f.delErr != nil {
+		return f.delErr
+	}
+	if _, ok := f.uploads[uploadID]; !ok {
+		return mongo.ErrNoDocuments
+	}
+	delete(f.uploads, uploadID)
+	return nil
+}
+
+func fileKey(bucketID primitive.ObjectID, name string) string {
+	return bucketID.Hex() + "/" + name
+}
+
+func testObjectService(files *fakeObjectFiles, deleted *[]repository.FileChunk) *ObjectService {
+	now := time.Date(2026, 4, 21, 12, 0, 0, 0, time.UTC)
+	return &ObjectService{
+		sources: &fakeObjectSources{sources: []repository.Source{{ID: primitive.NewObjectID()}}},
+		files:   files,
+		uploadChunks: func(_ context.Context, r io.Reader, _ []repository.Source, _ int, _ SourceSelector) ([]repository.FileChunk, error) {
+			if _, err := io.Copy(io.Discard, r); err != nil {
+				return nil, err
+			}
+			return []repository.FileChunk{{SourceID: primitive.NewObjectID(), Name: "new-chunk", Size: 4}}, nil
+		},
+		deleteChunks: func(_ context.Context, chunks []repository.FileChunk) error {
+			*deleted = append(*deleted, chunks...)
+			return nil
+		},
+		now: func() time.Time {
+			return now
+		},
+	}
+}
+
+func TestObjectServicePutObjectUpdatesFileAndDeletesOldChunks(t *testing.T) {
+	bucketID := primitive.NewObjectID()
+	oldSourceID := primitive.NewObjectID()
+	existing := repository.File{
+		ID:        primitive.NewObjectID(),
+		BucketID:  bucketID,
+		Name:      "object.txt",
+		CreatedAt: time.Now().UTC(),
+		Chunks:    []repository.FileChunk{{SourceID: oldSourceID, Name: "old-chunk", Size: 9}},
+	}
+	files := newFakeObjectFiles(existing)
+	var deleted []repository.FileChunk
+	svc := testObjectService(files, &deleted)
+
+	result, err := svc.PutObject(context.Background(), &repository.Bucket{ID: bucketID}, "object.txt", bytes.NewBufferString("data"), 5)
+	if err != nil {
+		t.Fatalf("PutObject returned error: %v", err)
+	}
+	if result.File.ID != existing.ID {
+		t.Fatalf("expected update to preserve file id")
+	}
+	if len(result.File.Chunks) != 1 || result.File.Chunks[0].Name != "new-chunk" {
+		t.Fatalf("expected saved file to use uploaded chunk, got %#v", result.File.Chunks)
+	}
+	if len(deleted) != 1 || deleted[0].Name != "old-chunk" {
+		t.Fatalf("expected old chunk cleanup, got %#v", deleted)
+	}
+}
+
+func TestObjectServiceCopyObjectPreservesChunksAndCleansOverwrittenDestination(t *testing.T) {
+	userID := primitive.NewObjectID()
+	sourceBucketID := primitive.NewObjectID()
+	destBucketID := primitive.NewObjectID()
+	sourceChunk := repository.FileChunk{SourceID: primitive.NewObjectID(), Name: "source-chunk", Size: 12}
+	oldDestChunk := repository.FileChunk{SourceID: primitive.NewObjectID(), Name: "old-dest-chunk", Size: 8}
+	files := newFakeObjectFiles(
+		repository.File{ID: primitive.NewObjectID(), BucketID: sourceBucketID, Name: "source.txt", Chunks: []repository.FileChunk{sourceChunk}},
+		repository.File{ID: primitive.NewObjectID(), BucketID: destBucketID, Name: "dest.txt", Chunks: []repository.FileChunk{oldDestChunk}},
+	)
+	var deleted []repository.FileChunk
+	svc := testObjectService(files, &deleted)
+
+	result, err := svc.CopyObject(
+		context.Background(),
+		&repository.Bucket{ID: sourceBucketID, UserID: userID},
+		&repository.Bucket{ID: destBucketID, UserID: userID},
+		"source.txt",
+		"dest.txt",
+	)
+	if err != nil {
+		t.Fatalf("CopyObject returned error: %v", err)
+	}
+	if len(result.File.Chunks) != 1 || result.File.Chunks[0].Name != sourceChunk.Name {
+		t.Fatalf("expected copied file to reference source chunk, got %#v", result.File.Chunks)
+	}
+	if len(deleted) != 1 || deleted[0].Name != oldDestChunk.Name {
+		t.Fatalf("expected overwritten destination chunk cleanup, got %#v", deleted)
+	}
+}
+
+func TestObjectServiceCopyObjectRejectsCrossUserBuckets(t *testing.T) {
+	svc := testObjectService(newFakeObjectFiles(), &[]repository.FileChunk{})
+
+	_, err := svc.CopyObject(
+		context.Background(),
+		&repository.Bucket{ID: primitive.NewObjectID(), UserID: primitive.NewObjectID()},
+		&repository.Bucket{ID: primitive.NewObjectID(), UserID: primitive.NewObjectID()},
+		"source.txt",
+		"dest.txt",
+	)
+	if !errors.Is(err, ErrAccessDenied) {
+		t.Fatalf("expected access denied, got %v", err)
+	}
+}
+
+func TestObjectServiceDeleteObjectRemovesMetadataAndUnreferencedChunks(t *testing.T) {
+	bucketID := primitive.NewObjectID()
+	chunk := repository.FileChunk{SourceID: primitive.NewObjectID(), Name: "delete-me", Size: 3}
+	files := newFakeObjectFiles(repository.File{ID: primitive.NewObjectID(), BucketID: bucketID, Name: "object.txt", Chunks: []repository.FileChunk{chunk}})
+	var deleted []repository.FileChunk
+	svc := testObjectService(files, &deleted)
+
+	result, err := svc.DeleteObject(context.Background(), bucketID, "object.txt")
+	if err != nil {
+		t.Fatalf("DeleteObject returned error: %v", err)
+	}
+	if !result.Deleted {
+		t.Fatalf("expected DeleteObject to report deletion")
+	}
+	if len(deleted) != 1 || deleted[0].Name != chunk.Name {
+		t.Fatalf("expected deleted chunk cleanup, got %#v", deleted)
+	}
+	if _, err := files.GetByName(context.Background(), bucketID, "object.txt"); !errors.Is(err, mongo.ErrNoDocuments) {
+		t.Fatalf("expected metadata delete, got %v", err)
+	}
+}
+
+func TestObjectServiceCompleteMultipartUploadBuildsFinalFileAndCleansUnusedChunks(t *testing.T) {
+	bucketID := primitive.NewObjectID()
+	oldChunk := repository.FileChunk{SourceID: primitive.NewObjectID(), Name: "old-file-chunk", Size: 2}
+	part1ChunkA := repository.FileChunk{SourceID: primitive.NewObjectID(), Name: "part-1a", Size: 5, Checksum: "sum-a"}
+	part1ChunkB := repository.FileChunk{SourceID: primitive.NewObjectID(), Name: "part-1b", Size: 6, Checksum: "sum-b"}
+	part2Chunk := repository.FileChunk{SourceID: primitive.NewObjectID(), Name: "part-2", Size: 7}
+	files := newFakeObjectFiles(repository.File{
+		ID:       primitive.NewObjectID(),
+		BucketID: bucketID,
+		Name:     "object.txt",
+		Chunks:   []repository.FileChunk{oldChunk},
+	})
+	var deleted []repository.FileChunk
+	svc := testObjectService(files, &deleted)
+	svc.multipart = &fakeMultipartUploads{uploads: map[string]repository.MultipartUpload{
+		"upload-1": {
+			BucketID:  bucketID,
+			ObjectKey: "object.txt",
+			UploadID:  "upload-1",
+			Parts: []repository.UploadPart{
+				{PartNumber: 1, ETag: `"d41d8cd98f00b204e9800998ecf8427e"`, Chunks: []repository.FileChunk{part1ChunkA, part1ChunkB}},
+				{PartNumber: 2, ETag: `"0cc175b9c0f1b6a831c399e269772661"`, Chunks: []repository.FileChunk{part2Chunk}},
+			},
+		},
+	}}
+
+	result, err := svc.CompleteMultipartUpload(context.Background(), bucketID, "upload-1", []CompleteMultipartPart{
+		{PartNumber: 1, ETag: "d41d8cd98f00b204e9800998ecf8427e"},
+	})
+	if err != nil {
+		t.Fatalf("CompleteMultipartUpload returned error: %v", err)
+	}
+	if result.File.Name != "object.txt" {
+		t.Fatalf("expected final object name, got %q", result.File.Name)
+	}
+	if len(result.File.Chunks) != 2 {
+		t.Fatalf("expected two final chunks, got %#v", result.File.Chunks)
+	}
+	if result.File.Chunks[0].Order != 0 || result.File.Chunks[1].Order != 1 {
+		t.Fatalf("expected chunks to be renumbered, got %#v", result.File.Chunks)
+	}
+	if result.File.Chunks[0].Checksum != part1ChunkA.Checksum {
+		t.Fatalf("expected checksum to be preserved")
+	}
+	if len(deleted) != 2 {
+		t.Fatalf("expected old file chunk and unreferenced part cleanup, got %#v", deleted)
+	}
+	if deleted[0].Name != oldChunk.Name || deleted[1].Name != part2Chunk.Name {
+		t.Fatalf("unexpected cleanup order: %#v", deleted)
+	}
+	if !strings.HasSuffix(result.ETag, `-1"`) {
+		t.Fatalf("unexpected multipart etag: %s", result.ETag)
+	}
+	if _, err := svc.multipart.GetByUploadID(context.Background(), "upload-1"); !errors.Is(err, mongo.ErrNoDocuments) {
+		t.Fatalf("expected multipart upload record cleanup, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `manager.ObjectService` for S3 object PUT, copy, delete, and multipart completion mutation rules.
- Slim S3 handlers down to request parsing, bucket/access validation, S3 error mapping, and XML responses.
- Add manager-level unit coverage for overwrite cleanup, copy access rules, delete cleanup, and multipart completion chunk assembly.
- Refreshed against current `main` after THE-446 merged and dropped the unrelated QA audit doc commit from this PR to keep scope narrow.

## Validation
- Did not run Go tests/builds locally per limited-resource instruction; Woodpecker should run backend validation.
- Did not run local formatting/check validation during the latest branch refresh under the same policy; previous implementation commits had been formatted, and Woodpecker is the validation gate.