### PR TITLE
THE-457: Fix non-resilience api-go lint violations

### DIFF
--- a/api-go/cmd/sfree-cli/buckets.go
+++ b/api-go/cmd/sfree-cli/buckets.go
@@ -46,9 +46,13 @@ var bucketsListCmd = &cobra.Command{
 			return nil
 		}
 		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-		fmt.Fprintln(w, "ID\tKEY\tACCESS KEY\tCREATED")
+		if _, err := fmt.Fprintln(w, "ID\tKEY\tACCESS KEY\tCREATED"); err != nil {
+			return err
+		}
 		for _, b := range buckets {
-			fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", b.ID, b.Key, b.AccessKey, b.CreatedAt)
+			if _, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", b.ID, b.Key, b.AccessKey, b.CreatedAt); err != nil {
+				return err
+			}
 		}
 		return w.Flush()
 	},

--- a/api-go/cmd/sfree-cli/client.go
+++ b/api-go/cmd/sfree-cli/client.go
@@ -25,7 +25,9 @@ func apiGet(path string, out interface{}) error {
 	if err != nil {
 		return fmt.Errorf("request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("server returned %d: %s", resp.StatusCode, string(body))
@@ -53,7 +55,9 @@ func apiPost(path string, body interface{}, out interface{}) error {
 	if err != nil {
 		return fmt.Errorf("request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 	if resp.StatusCode != http.StatusOK {
 		respBody, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("server returned %d: %s", resp.StatusCode, string(respBody))
@@ -73,21 +77,23 @@ func apiUpload(path string, filePath string, out interface{}) error {
 	if err != nil {
 		return fmt.Errorf("opening file: %w", err)
 	}
-	defer f.Close()
+	defer func() {
+		_ = f.Close()
+	}()
 
 	pr, pw := io.Pipe()
 	writer := multipart.NewWriter(pw)
 	go func() {
 		part, err := writer.CreateFormFile("file", filepath.Base(filePath))
 		if err != nil {
-			pw.CloseWithError(err)
+			_ = pw.CloseWithError(err)
 			return
 		}
 		if _, err := io.Copy(part, f); err != nil {
-			pw.CloseWithError(err)
+			_ = pw.CloseWithError(err)
 			return
 		}
-		pw.CloseWithError(writer.Close())
+		_ = pw.CloseWithError(writer.Close())
 	}()
 
 	url := serverURL() + path
@@ -101,7 +107,9 @@ func apiUpload(path string, filePath string, out interface{}) error {
 	if err != nil {
 		return fmt.Errorf("request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("server returned %d: %s", resp.StatusCode, string(body))
@@ -127,7 +135,9 @@ func apiDownload(path string, dest string) error {
 	if err != nil {
 		return fmt.Errorf("request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("server returned %d: %s", resp.StatusCode, string(body))
@@ -136,9 +146,12 @@ func apiDownload(path string, dest string) error {
 	if err != nil {
 		return fmt.Errorf("creating output file: %w", err)
 	}
-	defer out.Close()
 	if _, err := io.Copy(out, resp.Body); err != nil {
+		_ = out.Close()
 		return fmt.Errorf("writing file: %w", err)
+	}
+	if err := out.Close(); err != nil {
+		return fmt.Errorf("closing output file: %w", err)
 	}
 	return nil
 }

--- a/api-go/cmd/sfree-cli/files.go
+++ b/api-go/cmd/sfree-cli/files.go
@@ -80,9 +80,13 @@ var filesListCmd = &cobra.Command{
 			return nil
 		}
 		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-		fmt.Fprintln(w, "ID\tNAME\tSIZE\tCREATED")
+		if _, err := fmt.Fprintln(w, "ID\tNAME\tSIZE\tCREATED"); err != nil {
+			return err
+		}
 		for _, f := range files {
-			fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", f.ID, f.Name, humanSize(f.Size), f.CreatedAt)
+			if _, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", f.ID, f.Name, humanSize(f.Size), f.CreatedAt); err != nil {
+				return err
+			}
 		}
 		return w.Flush()
 	},
@@ -136,7 +140,9 @@ func apiDelete(path string) error {
 	if err != nil {
 		return fmt.Errorf("request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("server returned %d: %s", resp.StatusCode, string(body))

--- a/api-go/cmd/sfree-cli/sources.go
+++ b/api-go/cmd/sfree-cli/sources.go
@@ -33,9 +33,13 @@ var sourcesListCmd = &cobra.Command{
 			return nil
 		}
 		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-		fmt.Fprintln(w, "ID\tNAME\tTYPE\tCREATED")
+		if _, err := fmt.Fprintln(w, "ID\tNAME\tTYPE\tCREATED"); err != nil {
+			return err
+		}
 		for _, s := range sources {
-			fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", s.ID, s.Name, s.Type, s.CreatedAt)
+			if _, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", s.ID, s.Name, s.Type, s.CreatedAt); err != nil {
+				return err
+			}
 		}
 		return w.Flush()
 	},

--- a/api-go/internal/s3sigv4/validator.go
+++ b/api-go/internal/s3sigv4/validator.go
@@ -442,7 +442,7 @@ func awsPercentEncodePath(path string) string {
 		if isUnreserved(c) || c == '/' {
 			b.WriteByte(c)
 		} else {
-			b.WriteString(fmt.Sprintf("%%%02X", c))
+			_, _ = fmt.Fprintf(&b, "%%%02X", c)
 		}
 	}
 	return b.String()
@@ -498,7 +498,7 @@ func awsPercentEncodeQuery(s string) string {
 		if isUnreserved(c) {
 			b.WriteByte(c)
 		} else {
-			b.WriteString(fmt.Sprintf("%%%02X", c))
+			_, _ = fmt.Fprintf(&b, "%%%02X", c)
 		}
 	}
 	return b.String()


### PR DESCRIPTION
## Summary
- handle scoped `fmt.Fprint*` and `Close` errcheck findings in the api-go CLI
- replace the two SigV4 `WriteString(fmt.Sprintf(...))` patterns with `fmt.Fprintf(...)`

## Scope Notes
- Links [THE-455](/THE/issues/THE-455) / [THE-457](/THE/issues/THE-457)
- Resilience test lint remains owned by [THE-446](/THE/issues/THE-446)
- No changes to `api-go/.golangci.yml`
- No changes to `api-go/internal/resilience/wrapper.go` or `api-go/internal/resilience/wrapper_test.go`

## Validation
- `gofmt` on touched Go files
- `git diff --check`
- Did not run local `golangci-lint`, Docker, Playwright, or Go tests per task instructions; Woodpecker is the validation authority.