### PR TITLE
THE-459 Route source utilities through source client factory

### DIFF
--- a/api-go/internal/handlers/source.go
+++ b/api-go/internal/handlers/source.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/example/sfree/api-go/internal/gdrive"
+	"github.com/example/sfree/api-go/internal/manager"
 	"github.com/example/sfree/api-go/internal/repository"
 	"github.com/example/sfree/api-go/internal/s3compat"
 	"github.com/example/sfree/api-go/internal/telegram"
@@ -284,6 +284,10 @@ func DeleteSource(repo *repository.SourceRepository, bucketRepo *repository.Buck
 // @Security BasicAuth
 // @Router /api/v1/sources/{id}/info [get]
 func GetSourceInfo(repo *repository.SourceRepository) gin.HandlerFunc {
+	return getSourceInfo(repo, nil)
+}
+
+func getSourceInfo(repo *repository.SourceRepository, factory manager.SourceClientFactory) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		ctx := c.Request.Context()
 		if repo == nil {
@@ -313,84 +317,29 @@ func GetSourceInfo(repo *repository.SourceRepository) gin.HandlerFunc {
 			c.Status(http.StatusNotFound)
 			return
 		}
-		switch src.Type {
-		case repository.SourceTypeGDrive:
-			cli, err := gdrive.NewClient(c.Request.Context(), []byte(src.Key))
-			if err != nil {
-				slog.ErrorContext(ctx, "get source info: create client", slog.String("error", err.Error()))
-				c.Status(http.StatusInternalServerError)
+		info, err := manager.InspectSource(c.Request.Context(), src, factory)
+		if err != nil {
+			if err == manager.ErrUnsupportedSourceType {
+				c.Status(http.StatusBadRequest)
 				return
 			}
-			files, err := cli.ListFiles(c.Request.Context())
-			if err != nil {
-				slog.ErrorContext(ctx, "get source info: list files", slog.String("error", err.Error()))
-				c.Status(http.StatusInternalServerError)
-				return
-			}
-			total, used, free, err := cli.StorageInfo(c.Request.Context())
-			if err != nil {
-				slog.ErrorContext(ctx, "get source info: storage info", slog.String("error", err.Error()))
-				c.Status(http.StatusInternalServerError)
-				return
-			}
-			respFiles := make([]sourceInfoFile, 0, len(files))
-			for _, f := range files {
-				respFiles = append(respFiles, sourceInfoFile{ID: f.ID, Name: f.Name, Size: f.Size})
-			}
-			c.JSON(http.StatusOK, sourceInfoResponse{
-				ID:           src.ID.Hex(),
-				Name:         src.Name,
-				Type:         string(src.Type),
-				Files:        respFiles,
-				StorageTotal: total,
-				StorageUsed:  used,
-				StorageFree:  free,
-			})
-		case repository.SourceTypeTelegram:
-			c.JSON(http.StatusOK, sourceInfoResponse{
-				ID:           src.ID.Hex(),
-				Name:         src.Name,
-				Type:         string(src.Type),
-				Files:        []sourceInfoFile{},
-				StorageTotal: 0,
-				StorageUsed:  0,
-				StorageFree:  0,
-			})
-		case repository.SourceTypeS3:
-			cfg, err := s3compat.ParseConfig(src.Key)
-			if err != nil {
-				slog.ErrorContext(ctx, "get source info: parse s3 source config", slog.String("error", err.Error()))
-				c.Status(http.StatusInternalServerError)
-				return
-			}
-			cli, err := s3compat.NewClient(c.Request.Context(), cfg)
-			if err != nil {
-				slog.ErrorContext(ctx, "get source info: create s3 client", slog.String("error", err.Error()))
-				c.Status(http.StatusInternalServerError)
-				return
-			}
-			files, used, err := cli.ListObjects(c.Request.Context())
-			if err != nil {
-				slog.ErrorContext(ctx, "get source info: list s3 objects", slog.String("error", err.Error()))
-				c.Status(http.StatusInternalServerError)
-				return
-			}
-			respFiles := make([]sourceInfoFile, 0, len(files))
-			for _, f := range files {
-				respFiles = append(respFiles, sourceInfoFile{ID: f.Key, Name: f.Key, Size: f.Size})
-			}
-			c.JSON(http.StatusOK, sourceInfoResponse{
-				ID:           src.ID.Hex(),
-				Name:         src.Name,
-				Type:         string(src.Type),
-				Files:        respFiles,
-				StorageTotal: 0,
-				StorageUsed:  used,
-				StorageFree:  0,
-			})
-		default:
-			c.Status(http.StatusBadRequest)
+			slog.ErrorContext(ctx, "get source info: inspect source", slog.String("error", err.Error()))
+			c.Status(http.StatusInternalServerError)
+			return
 		}
+		respFiles := make([]sourceInfoFile, 0, len(info.Files))
+		for _, f := range info.Files {
+			respFiles = append(respFiles, sourceInfoFile{ID: f.ID, Name: f.Name, Size: f.Size})
+		}
+		c.JSON(http.StatusOK, sourceInfoResponse{
+			ID:           src.ID.Hex(),
+			Name:         src.Name,
+			Type:         string(src.Type),
+			Files:        respFiles,
+			StorageTotal: info.StorageTotal,
+			StorageUsed:  info.StorageUsed,
+			StorageFree:  info.StorageFree,
+		})
 	}
 }
 
@@ -408,6 +357,10 @@ func GetSourceInfo(repo *repository.SourceRepository) gin.HandlerFunc {
 // @Security BasicAuth
 // @Router /api/v1/sources/{id}/files/{file_id}/download [get]
 func DownloadSourceFile(sourceRepo *repository.SourceRepository) gin.HandlerFunc {
+	return downloadSourceFile(sourceRepo, nil)
+}
+
+func downloadSourceFile(sourceRepo *repository.SourceRepository, factory manager.SourceClientFactory) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		if sourceRepo == nil {
 			slog.ErrorContext(c.Request.Context(), "download source file: repository is nil")
@@ -442,43 +395,18 @@ func DownloadSourceFile(sourceRepo *repository.SourceRepository) gin.HandlerFunc
 			return
 		}
 
-		var body io.ReadCloser
 		filename := fileID
-
-		switch src.Type {
-		case repository.SourceTypeGDrive:
-			cli, err := gdrive.NewClient(c.Request.Context(), []byte(src.Key))
-			if err != nil {
-				slog.ErrorContext(c.Request.Context(), "download source file: create gdrive client", slog.String("error", err.Error()))
-				c.Status(http.StatusInternalServerError)
+		body, err := manager.DownloadSourceFile(c.Request.Context(), src, fileID, factory)
+		if err != nil {
+			if err == manager.ErrUnsupportedSourceType {
+				c.JSON(http.StatusBadRequest, gin.H{"error": "download not supported for this source type"})
 				return
 			}
-			body, err = cli.Download(c.Request.Context(), fileID)
-			if err != nil {
-				slog.ErrorContext(c.Request.Context(), "download source file: gdrive download", slog.String("error", err.Error()))
-				c.Status(http.StatusInternalServerError)
-				return
-			}
-		case repository.SourceTypeS3:
-			cfg, err := s3compat.ParseConfig(src.Key)
-			if err != nil {
-				slog.ErrorContext(c.Request.Context(), "download source file: parse s3 config", slog.String("error", err.Error()))
-				c.Status(http.StatusInternalServerError)
-				return
-			}
-			cli, err := s3compat.NewClient(c.Request.Context(), cfg)
-			if err != nil {
-				slog.ErrorContext(c.Request.Context(), "download source file: create s3 client", slog.String("error", err.Error()))
-				c.Status(http.StatusInternalServerError)
-				return
-			}
-			body, err = cli.Download(c.Request.Context(), fileID)
-			if err != nil {
-				slog.ErrorContext(c.Request.Context(), "download source file: s3 download", slog.String("error", err.Error()))
-				c.Status(http.StatusInternalServerError)
-				return
-			}
-		default:
+			slog.ErrorContext(c.Request.Context(), "download source file: download", slog.String("error", err.Error()))
+			c.Status(http.StatusInternalServerError)
+			return
+		}
+		if body == nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "download not supported for this source type"})
 			return
 		}

--- a/api-go/internal/manager/file.go
+++ b/api-go/internal/manager/file.go
@@ -30,13 +30,15 @@ var ErrChecksumMismatch = errors.New("checksum mismatch")
 
 var tracer = telemetry.Tracer("sfree/manager")
 
-type sourceClient interface {
+type SourceClient interface {
 	Upload(ctx context.Context, name string, r io.Reader) (string, error)
 	Download(ctx context.Context, name string) (io.ReadCloser, error)
 	Delete(ctx context.Context, name string) error
 }
 
-type SourceClientFactory func(ctx context.Context, src *repository.Source) (sourceClient, error)
+type sourceClient = SourceClient
+
+type SourceClientFactory func(ctx context.Context, src *repository.Source) (SourceClient, error)
 
 type SourceSelector interface {
 	NextSource(sources []repository.Source) (int, repository.Source, error)
@@ -136,7 +138,7 @@ func SelectorForBucket(bucket *repository.Bucket, sources []repository.Source) S
 // 5-failure threshold, 30s recovery).
 var ResilienceConfig = resilience.DefaultWrapperConfig()
 
-func NewSourceClient(ctx context.Context, src *repository.Source) (sourceClient, error) {
+func NewSourceClient(ctx context.Context, src *repository.Source) (SourceClient, error) {
 	if src == nil {
 		return nil, errors.New("nil source")
 	}

--- a/api-go/internal/manager/file_test.go
+++ b/api-go/internal/manager/file_test.go
@@ -9,16 +9,24 @@ import (
 	"io"
 	"testing"
 
+	"github.com/example/sfree/api-go/internal/gdrive"
 	"github.com/example/sfree/api-go/internal/repository"
+	"github.com/example/sfree/api-go/internal/s3compat"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
 type stubSourceClient struct {
-	uploaded    [][]byte
-	uploadErr   error
-	downloadErr error
-	deleted     []string
-	deleteErr   error
+	uploaded     [][]byte
+	uploadErr    error
+	downloadErr  error
+	deleted      []string
+	deleteErr    error
+	gdriveFiles  []gdrive.File
+	storageTotal int64
+	storageUsed  int64
+	storageFree  int64
+	s3Objects    []s3compat.ObjectInfo
+	s3Used       int64
 }
 
 func (c *stubSourceClient) Upload(_ context.Context, _ string, r io.Reader) (string, error) {
@@ -40,6 +48,18 @@ func (c *stubSourceClient) Download(_ context.Context, name string) (io.ReadClos
 func (c *stubSourceClient) Delete(_ context.Context, name string) error {
 	c.deleted = append(c.deleted, name)
 	return c.deleteErr
+}
+
+func (c *stubSourceClient) ListFiles(_ context.Context) ([]gdrive.File, error) {
+	return c.gdriveFiles, nil
+}
+
+func (c *stubSourceClient) StorageInfo(_ context.Context) (int64, int64, int64, error) {
+	return c.storageTotal, c.storageUsed, c.storageFree, nil
+}
+
+func (c *stubSourceClient) ListObjects(_ context.Context) ([]s3compat.ObjectInfo, int64, error) {
+	return c.s3Objects, c.s3Used, nil
 }
 
 func TestSourceClientCacheReusesClients(t *testing.T) {
@@ -380,6 +400,97 @@ func TestNewSourceClientUnsupportedType(t *testing.T) {
 	_, err := NewSourceClient(context.Background(), src)
 	if !errors.Is(err, ErrUnsupportedSourceType) {
 		t.Fatalf("expected ErrUnsupportedSourceType, got %v", err)
+	}
+}
+
+func TestInspectSourceUsesFactoryForGDrive(t *testing.T) {
+	t.Parallel()
+	src := &repository.Source{ID: primitive.NewObjectID(), Type: repository.SourceTypeGDrive}
+	calls := 0
+	factory := func(_ context.Context, got *repository.Source) (SourceClient, error) {
+		calls++
+		if got != src {
+			t.Fatal("expected source pointer to be passed to factory")
+		}
+		return &stubSourceClient{
+			gdriveFiles:  []gdrive.File{{ID: "file-id", Name: "file.txt", Size: 42}},
+			storageTotal: 100,
+			storageUsed:  42,
+			storageFree:  58,
+		}, nil
+	}
+
+	info, err := InspectSource(context.Background(), src, factory)
+	if err != nil {
+		t.Fatalf("inspect source: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected factory to be called once, got %d", calls)
+	}
+	if len(info.Files) != 1 || info.Files[0].ID != "file-id" || info.Files[0].Name != "file.txt" || info.Files[0].Size != 42 {
+		t.Fatalf("unexpected files: %#v", info.Files)
+	}
+	if info.StorageTotal != 100 || info.StorageUsed != 42 || info.StorageFree != 58 {
+		t.Fatalf("unexpected storage info: %#v", info)
+	}
+}
+
+func TestInspectSourceUsesFactoryForS3(t *testing.T) {
+	t.Parallel()
+	src := &repository.Source{ID: primitive.NewObjectID(), Type: repository.SourceTypeS3}
+	calls := 0
+	factory := func(_ context.Context, got *repository.Source) (SourceClient, error) {
+		calls++
+		if got != src {
+			t.Fatal("expected source pointer to be passed to factory")
+		}
+		return &stubSourceClient{
+			s3Objects: []s3compat.ObjectInfo{{Key: "object-key", Size: 12}},
+			s3Used:    12,
+		}, nil
+	}
+
+	info, err := InspectSource(context.Background(), src, factory)
+	if err != nil {
+		t.Fatalf("inspect source: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected factory to be called once, got %d", calls)
+	}
+	if len(info.Files) != 1 || info.Files[0].ID != "object-key" || info.Files[0].Name != "object-key" || info.Files[0].Size != 12 {
+		t.Fatalf("unexpected files: %#v", info.Files)
+	}
+	if info.StorageUsed != 12 || info.StorageTotal != 0 || info.StorageFree != 0 {
+		t.Fatalf("unexpected storage info: %#v", info)
+	}
+}
+
+func TestDownloadSourceFileUsesFactory(t *testing.T) {
+	t.Parallel()
+	src := &repository.Source{ID: primitive.NewObjectID(), Type: repository.SourceTypeS3}
+	calls := 0
+	factory := func(_ context.Context, got *repository.Source) (SourceClient, error) {
+		calls++
+		if got != src {
+			t.Fatal("expected source pointer to be passed to factory")
+		}
+		return &stubSourceClient{}, nil
+	}
+
+	rc, err := DownloadSourceFile(context.Background(), src, "source-object", factory)
+	if err != nil {
+		t.Fatalf("download source file: %v", err)
+	}
+	defer func() { _ = rc.Close() }()
+	data, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatalf("read download: %v", err)
+	}
+	if string(data) != "source-object" {
+		t.Fatalf("unexpected body %q", data)
+	}
+	if calls != 1 {
+		t.Fatalf("expected factory to be called once, got %d", calls)
 	}
 }
 

--- a/api-go/internal/manager/file_test.go
+++ b/api-go/internal/manager/file_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/example/sfree/api-go/internal/gdrive"
 	"github.com/example/sfree/api-go/internal/repository"
+	"github.com/example/sfree/api-go/internal/resilience"
 	"github.com/example/sfree/api-go/internal/s3compat"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
@@ -492,6 +493,64 @@ func TestDownloadSourceFileUsesFactory(t *testing.T) {
 	if calls != 1 {
 		t.Fatalf("expected factory to be called once, got %d", calls)
 	}
+}
+
+func TestDownloadSourceFileKeepsWrappedStreamContextOpen(t *testing.T) {
+	t.Parallel()
+	src := &repository.Source{ID: primitive.NewObjectID(), Type: repository.SourceTypeS3}
+	factory := func(_ context.Context, _ *repository.Source) (SourceClient, error) {
+		cfg := resilience.DefaultWrapperConfig()
+		cfg.MaxRetries = 0
+		return resilience.Wrap(&contextAwareDownloadClient{payload: []byte("streamed-data")}, cfg), nil
+	}
+
+	rc, err := DownloadSourceFile(context.Background(), src, "source-object", factory)
+	if err != nil {
+		t.Fatalf("download source file: %v", err)
+	}
+	data, readErr := io.ReadAll(rc)
+	closeErr := rc.Close()
+	if readErr != nil {
+		t.Fatalf("read download: %v", readErr)
+	}
+	if closeErr != nil {
+		t.Fatalf("close download: %v", closeErr)
+	}
+	if string(data) != "streamed-data" {
+		t.Fatalf("unexpected body %q", data)
+	}
+}
+
+type contextAwareDownloadClient struct {
+	payload []byte
+}
+
+func (c *contextAwareDownloadClient) Upload(_ context.Context, _ string, _ io.Reader) (string, error) {
+	return "", nil
+}
+
+func (c *contextAwareDownloadClient) Download(ctx context.Context, _ string) (io.ReadCloser, error) {
+	return &contextAwareReadCloser{ctx: ctx, reader: bytes.NewReader(c.payload)}, nil
+}
+
+func (c *contextAwareDownloadClient) Delete(_ context.Context, _ string) error {
+	return nil
+}
+
+type contextAwareReadCloser struct {
+	ctx    context.Context
+	reader *bytes.Reader
+}
+
+func (r *contextAwareReadCloser) Read(p []byte) (int, error) {
+	if err := r.ctx.Err(); err != nil {
+		return 0, err
+	}
+	return r.reader.Read(p)
+}
+
+func (r *contextAwareReadCloser) Close() error {
+	return nil
 }
 
 func TestStreamFileNoChunks(t *testing.T) {

--- a/api-go/internal/manager/source.go
+++ b/api-go/internal/manager/source.go
@@ -1,0 +1,104 @@
+package manager
+
+import (
+	"context"
+	"errors"
+	"io"
+
+	"github.com/example/sfree/api-go/internal/gdrive"
+	"github.com/example/sfree/api-go/internal/repository"
+	"github.com/example/sfree/api-go/internal/s3compat"
+)
+
+type SourceInfoFile struct {
+	ID   string
+	Name string
+	Size int64
+}
+
+type SourceInfo struct {
+	Files        []SourceInfoFile
+	StorageTotal int64
+	StorageUsed  int64
+	StorageFree  int64
+}
+
+func InspectSource(ctx context.Context, src *repository.Source, factory SourceClientFactory) (SourceInfo, error) {
+	if src == nil {
+		return SourceInfo{}, errors.New("nil source")
+	}
+	switch src.Type {
+	case repository.SourceTypeGDrive:
+		cli, err := sourceClientFor(ctx, src, factory)
+		if err != nil {
+			return SourceInfo{}, err
+		}
+		infoClient, ok := cli.(interface {
+			ListFiles(context.Context) ([]gdrive.File, error)
+			StorageInfo(context.Context) (int64, int64, int64, error)
+		})
+		if !ok {
+			return SourceInfo{}, ErrUnsupportedSourceType
+		}
+		files, err := infoClient.ListFiles(ctx)
+		if err != nil {
+			return SourceInfo{}, err
+		}
+		total, used, free, err := infoClient.StorageInfo(ctx)
+		if err != nil {
+			return SourceInfo{}, err
+		}
+		respFiles := make([]SourceInfoFile, 0, len(files))
+		for _, f := range files {
+			respFiles = append(respFiles, SourceInfoFile{ID: f.ID, Name: f.Name, Size: f.Size})
+		}
+		return SourceInfo{Files: respFiles, StorageTotal: total, StorageUsed: used, StorageFree: free}, nil
+	case repository.SourceTypeTelegram:
+		return SourceInfo{Files: []SourceInfoFile{}}, nil
+	case repository.SourceTypeS3:
+		cli, err := sourceClientFor(ctx, src, factory)
+		if err != nil {
+			return SourceInfo{}, err
+		}
+		infoClient, ok := cli.(interface {
+			ListObjects(context.Context) ([]s3compat.ObjectInfo, int64, error)
+		})
+		if !ok {
+			return SourceInfo{}, ErrUnsupportedSourceType
+		}
+		files, used, err := infoClient.ListObjects(ctx)
+		if err != nil {
+			return SourceInfo{}, err
+		}
+		respFiles := make([]SourceInfoFile, 0, len(files))
+		for _, f := range files {
+			respFiles = append(respFiles, SourceInfoFile{ID: f.Key, Name: f.Key, Size: f.Size})
+		}
+		return SourceInfo{Files: respFiles, StorageUsed: used}, nil
+	default:
+		return SourceInfo{}, ErrUnsupportedSourceType
+	}
+}
+
+func DownloadSourceFile(ctx context.Context, src *repository.Source, fileID string, factory SourceClientFactory) (io.ReadCloser, error) {
+	if src == nil {
+		return nil, errors.New("nil source")
+	}
+	switch src.Type {
+	case repository.SourceTypeGDrive, repository.SourceTypeS3:
+		cli, err := sourceClientFor(ctx, src, factory)
+		if err != nil {
+			return nil, err
+		}
+		return cli.Download(ctx, fileID)
+	default:
+		return nil, ErrUnsupportedSourceType
+	}
+}
+
+func sourceClientFor(ctx context.Context, src *repository.Source, factory SourceClientFactory) (SourceClient, error) {
+	if factory == nil {
+		factory = NewSourceClient
+	}
+	return factory(ctx, src)
+}

--- a/api-go/internal/manager/source.go
+++ b/api-go/internal/manager/source.go
@@ -90,6 +90,11 @@ func DownloadSourceFile(ctx context.Context, src *repository.Source, fileID stri
 		if err != nil {
 			return nil, err
 		}
+		if streamClient, ok := cli.(interface {
+			DownloadStream(context.Context, string) (io.ReadCloser, error)
+		}); ok {
+			return streamClient.DownloadStream(ctx, fileID)
+		}
 		return cli.Download(ctx, fileID)
 	default:
 		return nil, ErrUnsupportedSourceType

--- a/api-go/internal/resilience/wrapper.go
+++ b/api-go/internal/resilience/wrapper.go
@@ -2,10 +2,16 @@ package resilience
 
 import (
 	"context"
+	"errors"
 	"io"
 	"log/slog"
 	"time"
+
+	"github.com/example/sfree/api-go/internal/gdrive"
+	"github.com/example/sfree/api-go/internal/s3compat"
 )
+
+var ErrUnsupportedOperation = errors.New("unsupported source client operation")
 
 // Client mirrors the source client interface (Upload, Download, Delete).
 type Client interface {
@@ -196,4 +202,148 @@ func (w *wrapper) Delete(ctx context.Context, name string) error {
 
 	w.cb.RecordFailure()
 	return lastErr
+}
+
+func (w *wrapper) ListFiles(ctx context.Context) ([]gdrive.File, error) {
+	inner, ok := w.inner.(interface {
+		ListFiles(context.Context) ([]gdrive.File, error)
+	})
+	if !ok {
+		return nil, ErrUnsupportedOperation
+	}
+	if err := w.cb.Allow(); err != nil {
+		return nil, err
+	}
+
+	var lastErr error
+	for attempt := 0; attempt <= w.retryCfg.MaxRetries; attempt++ {
+		if attempt > 0 {
+			delay := Backoff(attempt-1, w.retryCfg)
+			slog.WarnContext(ctx, "retrying list files",
+				slog.Int("attempt", attempt),
+				slog.Duration("backoff", delay),
+				slog.String("last_error", lastErr.Error()),
+			)
+			select {
+			case <-time.After(delay):
+			case <-ctx.Done():
+				w.cb.RecordFailure()
+				return nil, ctx.Err()
+			}
+			if err := w.cb.Allow(); err != nil {
+				return nil, err
+			}
+		}
+
+		reqCtx, cancel := context.WithTimeout(ctx, w.cfg.Timeout)
+		files, err := inner.ListFiles(reqCtx)
+		cancel()
+		if err == nil {
+			w.cb.RecordSuccess()
+			return files, nil
+		}
+		lastErr = err
+		if !isRetryable(err) {
+			break
+		}
+	}
+
+	w.cb.RecordFailure()
+	return nil, lastErr
+}
+
+func (w *wrapper) StorageInfo(ctx context.Context) (int64, int64, int64, error) {
+	inner, ok := w.inner.(interface {
+		StorageInfo(context.Context) (int64, int64, int64, error)
+	})
+	if !ok {
+		return 0, 0, 0, ErrUnsupportedOperation
+	}
+	if err := w.cb.Allow(); err != nil {
+		return 0, 0, 0, err
+	}
+
+	var lastErr error
+	for attempt := 0; attempt <= w.retryCfg.MaxRetries; attempt++ {
+		if attempt > 0 {
+			delay := Backoff(attempt-1, w.retryCfg)
+			slog.WarnContext(ctx, "retrying storage info",
+				slog.Int("attempt", attempt),
+				slog.Duration("backoff", delay),
+				slog.String("last_error", lastErr.Error()),
+			)
+			select {
+			case <-time.After(delay):
+			case <-ctx.Done():
+				w.cb.RecordFailure()
+				return 0, 0, 0, ctx.Err()
+			}
+			if err := w.cb.Allow(); err != nil {
+				return 0, 0, 0, err
+			}
+		}
+
+		reqCtx, cancel := context.WithTimeout(ctx, w.cfg.Timeout)
+		total, used, free, err := inner.StorageInfo(reqCtx)
+		cancel()
+		if err == nil {
+			w.cb.RecordSuccess()
+			return total, used, free, nil
+		}
+		lastErr = err
+		if !isRetryable(err) {
+			break
+		}
+	}
+
+	w.cb.RecordFailure()
+	return 0, 0, 0, lastErr
+}
+
+func (w *wrapper) ListObjects(ctx context.Context) ([]s3compat.ObjectInfo, int64, error) {
+	inner, ok := w.inner.(interface {
+		ListObjects(context.Context) ([]s3compat.ObjectInfo, int64, error)
+	})
+	if !ok {
+		return nil, 0, ErrUnsupportedOperation
+	}
+	if err := w.cb.Allow(); err != nil {
+		return nil, 0, err
+	}
+
+	var lastErr error
+	for attempt := 0; attempt <= w.retryCfg.MaxRetries; attempt++ {
+		if attempt > 0 {
+			delay := Backoff(attempt-1, w.retryCfg)
+			slog.WarnContext(ctx, "retrying list objects",
+				slog.Int("attempt", attempt),
+				slog.Duration("backoff", delay),
+				slog.String("last_error", lastErr.Error()),
+			)
+			select {
+			case <-time.After(delay):
+			case <-ctx.Done():
+				w.cb.RecordFailure()
+				return nil, 0, ctx.Err()
+			}
+			if err := w.cb.Allow(); err != nil {
+				return nil, 0, err
+			}
+		}
+
+		reqCtx, cancel := context.WithTimeout(ctx, w.cfg.Timeout)
+		objects, used, err := inner.ListObjects(reqCtx)
+		cancel()
+		if err == nil {
+			w.cb.RecordSuccess()
+			return objects, used, nil
+		}
+		lastErr = err
+		if !isRetryable(err) {
+			break
+		}
+	}
+
+	w.cb.RecordFailure()
+	return nil, 0, lastErr
 }

--- a/api-go/internal/resilience/wrapper.go
+++ b/api-go/internal/resilience/wrapper.go
@@ -160,6 +160,49 @@ func (w *wrapper) Download(ctx context.Context, name string) (io.ReadCloser, err
 	return nil, lastErr
 }
 
+func (w *wrapper) DownloadStream(ctx context.Context, name string) (io.ReadCloser, error) {
+	if err := w.cb.Allow(); err != nil {
+		return nil, err
+	}
+
+	var lastErr error
+	for attempt := 0; attempt <= w.retryCfg.MaxRetries; attempt++ {
+		if attempt > 0 {
+			delay := Backoff(attempt-1, w.retryCfg)
+			slog.WarnContext(ctx, "retrying streamed download",
+				slog.String("name", name),
+				slog.Int("attempt", attempt),
+				slog.Duration("backoff", delay),
+				slog.String("last_error", lastErr.Error()),
+			)
+			select {
+			case <-time.After(delay):
+			case <-ctx.Done():
+				w.cb.RecordFailure()
+				return nil, ctx.Err()
+			}
+			if err := w.cb.Allow(); err != nil {
+				return nil, err
+			}
+		}
+
+		reqCtx, cancel := context.WithCancel(ctx)
+		rc, err := w.inner.Download(reqCtx, name)
+		if err == nil {
+			w.cb.RecordSuccess()
+			return &cancelOnCloseReadCloser{ReadCloser: rc, cancel: cancel}, nil
+		}
+		cancel()
+		lastErr = err
+		if !isRetryable(err) {
+			break
+		}
+	}
+
+	w.cb.RecordFailure()
+	return nil, lastErr
+}
+
 func (w *wrapper) Delete(ctx context.Context, name string) error {
 	if err := w.cb.Allow(); err != nil {
 		return err
@@ -202,6 +245,17 @@ func (w *wrapper) Delete(ctx context.Context, name string) error {
 
 	w.cb.RecordFailure()
 	return lastErr
+}
+
+type cancelOnCloseReadCloser struct {
+	io.ReadCloser
+	cancel context.CancelFunc
+}
+
+func (r *cancelOnCloseReadCloser) Close() error {
+	err := r.ReadCloser.Close()
+	r.cancel()
+	return err
 }
 
 func (w *wrapper) ListFiles(ctx context.Context) ([]gdrive.File, error) {


### PR DESCRIPTION
## Summary
- route source info and direct source downloads through manager helpers backed by `SourceClientFactory`
- expose source info operations on the resilient wrapper for GDrive/S3 where the underlying clients support them
- add focused manager tests covering injected factories for source info and direct downloads

## Tests
- `go test ./internal/manager -run 'TestInspectSourceUsesFactory|TestDownloadSourceFileUsesFactory|TestNewSourceClientUnsupportedType'`
- `go test ./internal/handlers -run 'TestGetSourceInfoNilRepo|TestGetSourceInfoInvalidIDParam|TestDownloadSourceFileNilRepo|TestDownloadSourceFileNoUserID|TestDownloadSourceFileInvalidSourceID'`
- `go test ./internal/resilience -run '^$'`

Issue: THE-459