### PR TITLE
Fix upload failure chunk cleanup

### DIFF
--- a/api-go/internal/manager/file.go
+++ b/api-go/internal/manager/file.go
@@ -460,6 +460,7 @@ func UploadFileChunksWithStrategy(ctx context.Context, r io.Reader, sources []re
 		if readErr != nil && readErr != io.EOF {
 			span.RecordError(readErr)
 			span.SetStatus(codes.Error, "read failed")
+			cleanupUploadedChunks(ctx, chunks, clientCache)
 			return nil, readErr
 		}
 		if n == 0 {
@@ -473,6 +474,7 @@ func UploadFileChunksWithStrategy(ctx context.Context, r io.Reader, sources []re
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, "source selection failed")
+			cleanupUploadedChunks(ctx, chunks, clientCache)
 			return nil, err
 		}
 
@@ -530,6 +532,7 @@ func UploadFileChunksWithStrategy(ctx context.Context, r io.Reader, sources []re
 			chunkSpan.End()
 			span.RecordError(uploadErr)
 			span.SetStatus(codes.Error, fmt.Sprintf("chunk %d upload failed on all sources", idx))
+			cleanupUploadedChunks(ctx, chunks, clientCache)
 			return nil, uploadErr
 		}
 		chunkSpan.End()
@@ -552,6 +555,23 @@ func UploadFileChunksWithStrategy(ctx context.Context, r io.Reader, sources []re
 		attribute.Int("chunks.failovers", failoverCount),
 	)
 	return chunks, nil
+}
+
+func cleanupUploadedChunks(ctx context.Context, chunks []repository.FileChunk, clientCache *sourceClientCache) {
+	for _, ch := range chunks {
+		cli, err := clientCache.get(ctx, repository.Source{ID: ch.SourceID})
+		if err != nil {
+			slog.WarnContext(ctx, "upload cleanup: get client", slog.String("error", err.Error()))
+			continue
+		}
+		if err := cli.Delete(ctx, ch.Name); err != nil {
+			slog.WarnContext(ctx, "upload cleanup: delete chunk",
+				slog.String("source_id", ch.SourceID.Hex()),
+				slog.String("chunk", ch.Name),
+				slog.String("error", err.Error()),
+			)
+		}
+	}
 }
 
 // pickSourceClient selects the next source and returns its cached client.

--- a/api-go/internal/manager/file_test.go
+++ b/api-go/internal/manager/file_test.go
@@ -19,6 +19,8 @@ import (
 type stubSourceClient struct {
 	uploaded     [][]byte
 	uploadErr    error
+	uploadErrAt  int
+	uploadCalls  int
 	downloadErr  error
 	deleted      []string
 	deleteErr    error
@@ -30,11 +32,27 @@ type stubSourceClient struct {
 	s3Used       int64
 }
 
+type readOnceThenError struct {
+	data []byte
+	err  error
+	done bool
+}
+
+func (r *readOnceThenError) Read(p []byte) (int, error) {
+	if r.done {
+		return 0, r.err
+	}
+	r.done = true
+	return copy(p, r.data), nil
+}
+
 func (c *stubSourceClient) Upload(_ context.Context, _ string, r io.Reader) (string, error) {
-	if c.uploadErr != nil {
+	if c.uploadErr != nil && c.uploadCalls >= c.uploadErrAt {
+		c.uploadCalls++
 		return "", c.uploadErr
 	}
 	data, _ := io.ReadAll(r)
+	c.uploadCalls++
 	c.uploaded = append(c.uploaded, data)
 	return string(data), nil
 }
@@ -192,6 +210,47 @@ func TestUploadFileChunksUploadError(t *testing.T) {
 	}, &RoundRobinSelector{})
 	if !errors.Is(err, uploadErr) {
 		t.Fatalf("expected upload error, got %v", err)
+	}
+}
+
+func TestUploadFileChunksCleansUploadedChunksOnLaterUploadError(t *testing.T) {
+	t.Parallel()
+	uploadErr := errors.New("upload failed")
+	src := repository.Source{ID: primitive.NewObjectID()}
+	stub := &stubSourceClient{uploadErr: uploadErr, uploadErrAt: 1}
+
+	chunks, err := UploadFileChunksWithStrategy(context.Background(), bytes.NewReader([]byte("abcdef")), []repository.Source{src}, 3, func(_ context.Context, _ *repository.Source) (sourceClient, error) {
+		return stub, nil
+	}, &RoundRobinSelector{})
+	if !errors.Is(err, uploadErr) {
+		t.Fatalf("expected upload error, got %v", err)
+	}
+	if chunks != nil {
+		t.Fatalf("expected no chunks returned, got %+v", chunks)
+	}
+	if len(stub.deleted) != 1 || stub.deleted[0] != "abc" {
+		t.Fatalf("expected uploaded chunk cleanup, got %+v", stub.deleted)
+	}
+}
+
+func TestUploadFileChunksCleansUploadedChunksOnLaterReadError(t *testing.T) {
+	t.Parallel()
+	readErr := errors.New("read failed")
+	src := repository.Source{ID: primitive.NewObjectID()}
+	stub := &stubSourceClient{}
+	reader := &readOnceThenError{data: []byte("abc"), err: readErr}
+
+	chunks, err := UploadFileChunksWithStrategy(context.Background(), reader, []repository.Source{src}, 3, func(_ context.Context, _ *repository.Source) (sourceClient, error) {
+		return stub, nil
+	}, &RoundRobinSelector{})
+	if !errors.Is(err, readErr) {
+		t.Fatalf("expected read error, got %v", err)
+	}
+	if chunks != nil {
+		t.Fatalf("expected no chunks returned, got %+v", chunks)
+	}
+	if len(stub.deleted) != 1 || stub.deleted[0] != "abc" {
+		t.Fatalf("expected uploaded chunk cleanup, got %+v", stub.deleted)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Clean up already uploaded chunks inside `UploadFileChunksWithStrategy` when a later read/source/upload error aborts the upload.
- Preserve the original error returned to callers while logging best-effort cleanup failures.
- Add focused manager unit coverage for a later chunk upload failure after an earlier successful chunk and for a later read failure after an earlier successful chunk.
- Refreshed against current `main` and dropped the unrelated QA audit doc changes so this PR only changes `api-go/internal/manager/file.go` and `api-go/internal/manager/file_test.go`.

## Validation
- Not run locally per task policy: `go test`, `golangci-lint`, Docker, Playwright, or other CPU-heavy validation. Woodpecker should validate the backend checks.

Paperclip: THE-458