### PR TITLE
THE-469 Make api-go test target unit-only

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,8 +101,12 @@ Run the checks that match the area you changed before opening a PR.
 ```bash
 cd api-go
 golangci-lint run
-go test ./...
+make test
 ```
+
+The default `make test` target runs unit tests only. Integration, Go E2E,
+Python E2E, and Docker-backed local E2E suites are available through their
+explicit Make targets when broader validation is needed.
 
 ### Frontend
 

--- a/api-go/AGENTS.md
+++ b/api-go/AGENTS.md
@@ -1,3 +1,3 @@
 When modifying, adding, or removing API endpoints, update the Swagger documentation by editing Go code comments and regenerating `internal/docs/docs.go`. Do not commit generated artifacts such as `swagger.yaml` or `swagger.json`; `docs.go` is the single source of truth.
 
-Run `golangci-lint run` and `go test ./...` for this module. Skip integration tests; unit tests are sufficient.
+Run `golangci-lint run` and `make test` for this module. Skip integration tests; unit tests are sufficient.

--- a/api-go/Makefile
+++ b/api-go/Makefile
@@ -10,7 +10,7 @@ run: build
 	./bin/server
 
 
-test: test-unit test-integration test-e2e
+test: test-unit
 
 
 test-unit:


### PR DESCRIPTION
## Summary
- Make `api-go` `make test` run unit tests only via `test-unit`
- Keep integration, Go E2E, Python E2E, and Docker-backed local E2E targets available explicitly
- Align contributor and agent instructions with the unit-only local target

## Verification
- Text/command review: confirmed `api-go/Makefile` now has `test: test-unit` and explicit expensive targets remain
- `git diff --check -- api-go/Makefile CONTRIBUTING.md api-go/AGENTS.md`
- Did not run Docker/E2E locally per task scope and resource policy
- Could not run `make -n test`: `make` is not installed in this environment