### PR TITLE
THE-467 Scope bucket grant mutations to route bucket

### DIFF
--- a/api-go/internal/handlers/bucket_grant.go
+++ b/api-go/internal/handlers/bucket_grant.go
@@ -208,7 +208,7 @@ func UpdateGrant(bucketRepo *repository.BucketRepository, grantRepo *repository.
 			return
 		}
 
-		if err := grantRepo.UpdateRole(ctx, grantID, role); err != nil {
+		if err := grantRepo.UpdateRole(ctx, acc.Bucket.ID, grantID, role); err != nil {
 			if err == mongo.ErrNoDocuments {
 				c.Status(http.StatusNotFound)
 				return
@@ -248,7 +248,7 @@ func DeleteGrant(bucketRepo *repository.BucketRepository, grantRepo *repository.
 			return
 		}
 
-		if err := grantRepo.Delete(ctx, grantID); err != nil {
+		if err := grantRepo.Delete(ctx, acc.Bucket.ID, grantID); err != nil {
 			if err == mongo.ErrNoDocuments {
 				c.Status(http.StatusNotFound)
 				return

--- a/api-go/internal/handlers/bucket_grant_integration_test.go
+++ b/api-go/internal/handlers/bucket_grant_integration_test.go
@@ -1,0 +1,179 @@
+//go:build integration
+// +build integration
+
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/example/sfree/api-go/internal/config"
+	"github.com/example/sfree/api-go/internal/db"
+	"github.com/example/sfree/api-go/internal/repository"
+	"github.com/gin-gonic/gin"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+func TestUpdateGrantRejectsCrossBucketGrantID(t *testing.T) {
+	ctx := context.Background()
+	bucketRepo, grantRepo := newBucketGrantHandlerTestRepos(t)
+	ownerA := primitive.NewObjectID()
+	ownerB := primitive.NewObjectID()
+	bucketA := createGrantTestBucket(t, ctx, bucketRepo, ownerA)
+	bucketB := createGrantTestBucket(t, ctx, bucketRepo, ownerB)
+	crossGrant := createGrantTestGrant(t, ctx, grantRepo, bucketB.ID, primitive.NewObjectID(), ownerB, repository.RoleViewer)
+
+	router := gin.New()
+	router.PATCH("/buckets/:id/grants/:grant_id", setUserID(ownerA.Hex()), UpdateGrant(bucketRepo, grantRepo))
+	body, _ := json.Marshal(map[string]string{"role": string(repository.RoleEditor)})
+	req, _ := http.NewRequest(
+		http.MethodPatch,
+		"/buckets/"+bucketA.ID.Hex()+"/grants/"+crossGrant.ID.Hex(),
+		bytes.NewReader(body),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for cross-bucket update, got %d", w.Code)
+	}
+	unchanged, err := grantRepo.GetByBucketAndUser(ctx, bucketB.ID, crossGrant.UserID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if unchanged.Role != repository.RoleViewer {
+		t.Fatalf("expected cross-bucket grant role to remain viewer, got %q", unchanged.Role)
+	}
+
+	sameBucketGrant := createGrantTestGrant(t, ctx, grantRepo, bucketA.ID, primitive.NewObjectID(), ownerA, repository.RoleViewer)
+	req, _ = http.NewRequest(
+		http.MethodPatch,
+		"/buckets/"+bucketA.ID.Hex()+"/grants/"+sameBucketGrant.ID.Hex(),
+		bytes.NewReader(body),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for same-bucket update, got %d", w.Code)
+	}
+	updated, err := grantRepo.GetByBucketAndUser(ctx, bucketA.ID, sameBucketGrant.UserID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.Role != repository.RoleEditor {
+		t.Fatalf("expected same-bucket grant role editor, got %q", updated.Role)
+	}
+}
+
+func TestDeleteGrantRejectsCrossBucketGrantID(t *testing.T) {
+	ctx := context.Background()
+	bucketRepo, grantRepo := newBucketGrantHandlerTestRepos(t)
+	ownerA := primitive.NewObjectID()
+	ownerB := primitive.NewObjectID()
+	bucketA := createGrantTestBucket(t, ctx, bucketRepo, ownerA)
+	bucketB := createGrantTestBucket(t, ctx, bucketRepo, ownerB)
+	crossGrant := createGrantTestGrant(t, ctx, grantRepo, bucketB.ID, primitive.NewObjectID(), ownerB, repository.RoleViewer)
+
+	router := gin.New()
+	router.DELETE("/buckets/:id/grants/:grant_id", setUserID(ownerA.Hex()), DeleteGrant(bucketRepo, grantRepo))
+	req, _ := http.NewRequest(
+		http.MethodDelete,
+		"/buckets/"+bucketA.ID.Hex()+"/grants/"+crossGrant.ID.Hex(),
+		nil,
+	)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for cross-bucket delete, got %d", w.Code)
+	}
+	if _, err := grantRepo.GetByBucketAndUser(ctx, bucketB.ID, crossGrant.UserID); err != nil {
+		t.Fatal(err)
+	}
+
+	sameBucketGrant := createGrantTestGrant(t, ctx, grantRepo, bucketA.ID, primitive.NewObjectID(), ownerA, repository.RoleViewer)
+	req, _ = http.NewRequest(
+		http.MethodDelete,
+		"/buckets/"+bucketA.ID.Hex()+"/grants/"+sameBucketGrant.ID.Hex(),
+		nil,
+	)
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for same-bucket delete, got %d", w.Code)
+	}
+	if _, err := grantRepo.GetByBucketAndUser(ctx, bucketA.ID, sameBucketGrant.UserID); err != mongo.ErrNoDocuments {
+		t.Fatalf("expected same-bucket grant to be deleted, got %v", err)
+	}
+}
+
+func newBucketGrantHandlerTestRepos(t *testing.T) (*repository.BucketRepository, *repository.BucketGrantRepository) {
+	t.Helper()
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	mongoConn, err := db.Connect(context.Background(), cfg.Mongo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	testDB := mongoConn.Client.Database("sfree_bucket_grant_handlers_" + primitive.NewObjectID().Hex())
+	t.Cleanup(func() {
+		_ = testDB.Drop(context.Background())
+		_ = mongoConn.Close(context.Background())
+	})
+	bucketRepo, err := repository.NewBucketRepository(testDB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	grantRepo, err := repository.NewBucketGrantRepository(testDB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return bucketRepo, grantRepo
+}
+
+func createGrantTestBucket(t *testing.T, ctx context.Context, repo *repository.BucketRepository, ownerID primitive.ObjectID) *repository.Bucket {
+	t.Helper()
+	suffix := primitive.NewObjectID().Hex()
+	bucket, err := repo.Create(ctx, repository.Bucket{
+		UserID:          ownerID,
+		Key:             "bucket-" + suffix,
+		AccessKey:       "access-" + suffix,
+		AccessSecretEnc: "secret-" + suffix,
+		CreatedAt:       time.Now().UTC(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return bucket
+}
+
+func createGrantTestGrant(
+	t *testing.T,
+	ctx context.Context,
+	repo *repository.BucketGrantRepository,
+	bucketID, userID, grantedBy primitive.ObjectID,
+	role repository.BucketRole,
+) *repository.BucketGrant {
+	t.Helper()
+	grant, err := repo.Create(ctx, repository.BucketGrant{
+		BucketID:  bucketID,
+		UserID:    userID,
+		Role:      role,
+		GrantedBy: grantedBy,
+		CreatedAt: time.Now().UTC(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return grant
+}

--- a/api-go/internal/repository/bucket_grant.go
+++ b/api-go/internal/repository/bucket_grant.go
@@ -129,8 +129,8 @@ func (r *BucketGrantRepository) ListByUser(ctx context.Context, userID primitive
 	return grants, cursor.Err()
 }
 
-func (r *BucketGrantRepository) UpdateRole(ctx context.Context, id primitive.ObjectID, role BucketRole) error {
-	res, err := r.coll.UpdateOne(ctx, bson.M{"_id": id}, bson.M{"$set": bson.M{"role": role}})
+func (r *BucketGrantRepository) UpdateRole(ctx context.Context, bucketID, id primitive.ObjectID, role BucketRole) error {
+	res, err := r.coll.UpdateOne(ctx, bucketGrantDocumentFilter(bucketID, id), bson.M{"$set": bson.M{"role": role}})
 	if err != nil {
 		return err
 	}
@@ -140,8 +140,8 @@ func (r *BucketGrantRepository) UpdateRole(ctx context.Context, id primitive.Obj
 	return nil
 }
 
-func (r *BucketGrantRepository) Delete(ctx context.Context, id primitive.ObjectID) error {
-	res, err := r.coll.DeleteOne(ctx, bson.M{"_id": id})
+func (r *BucketGrantRepository) Delete(ctx context.Context, bucketID, id primitive.ObjectID) error {
+	res, err := r.coll.DeleteOne(ctx, bucketGrantDocumentFilter(bucketID, id))
 	if err != nil {
 		return err
 	}
@@ -154,4 +154,8 @@ func (r *BucketGrantRepository) Delete(ctx context.Context, id primitive.ObjectI
 func (r *BucketGrantRepository) DeleteByBucket(ctx context.Context, bucketID primitive.ObjectID) error {
 	_, err := r.coll.DeleteMany(ctx, bson.M{"bucket_id": bucketID})
 	return err
+}
+
+func bucketGrantDocumentFilter(bucketID, id primitive.ObjectID) bson.M {
+	return bson.M{"bucket_id": bucketID, "_id": id}
 }

--- a/api-go/internal/repository/bucket_grant_test.go
+++ b/api-go/internal/repository/bucket_grant_test.go
@@ -1,6 +1,10 @@
 package repository
 
-import "testing"
+import (
+	"testing"
+
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
 
 func TestValidRole(t *testing.T) {
 	t.Parallel()
@@ -47,5 +51,23 @@ func TestRoleAtLeast(t *testing.T) {
 		if got := RoleAtLeast(tt.have, tt.required); got != tt.want {
 			t.Errorf("RoleAtLeast(%q, %q) = %v, want %v", tt.have, tt.required, got, tt.want)
 		}
+	}
+}
+
+func TestBucketGrantDocumentFilterScopesToBucketAndID(t *testing.T) {
+	t.Parallel()
+	bucketID := primitive.NewObjectID()
+	grantID := primitive.NewObjectID()
+
+	filter := bucketGrantDocumentFilter(bucketID, grantID)
+
+	if len(filter) != 2 {
+		t.Fatalf("expected two filter fields, got %d", len(filter))
+	}
+	if filter["bucket_id"] != bucketID {
+		t.Fatalf("expected bucket_id %s, got %v", bucketID.Hex(), filter["bucket_id"])
+	}
+	if filter["_id"] != grantID {
+		t.Fatalf("expected _id %s, got %v", grantID.Hex(), filter["_id"])
 	}
 }


### PR DESCRIPTION
## Summary
- Scope bucket grant role updates and deletes by both route bucket ID and grant ID.
- Pass the authorized route bucket from the grant handlers into repository mutations.
- Add regression coverage for cross-bucket update/delete denial and same-bucket behavior.

## Validation
- Not run locally per heartbeat instruction to avoid CPU-bound tasks on this machine; Woodpecker should validate this branch.

Closes THE-467