### PR TITLE
docs: align webui CI documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,7 +114,8 @@ npm run build    # TypeScript type-check + Vite production build
 ```
 
 Both `lint` and `build` must pass — this matches what Woodpecker CI runs on
-pull requests (see [docs/ci.md](docs/ci.md)).
+pull requests before the CI-only Playwright browser E2E step (see
+[docs/ci.md](docs/ci.md)).
 
 ### Optional: E2E Tests
 
@@ -126,6 +127,10 @@ make test-e2e-local
 `make test-e2e-local` uses `docker-compose.e2e.yml`. The `s3` E2E flow works
 with the bundled MinIO service. The Google Drive and Telegram flows require
 their corresponding credentials.
+
+Frontend Playwright E2E is a required Woodpecker check for webui changes, but
+contributors should not run it locally by default because it installs Chromium
+and executes browser-heavy tests.
 
 ## API Changes
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -8,7 +8,7 @@ Actions workflows to this repository.
 | Pipeline | Paths | `pull_request` | `push` to `main` | Behavior |
 | --- | --- | --- | --- | --- |
 | `.woodpecker/api-go.yml` | `.woodpecker/api-go.yml`, `api-go/**` | Yes | Yes | Runs Go unit tests plus Python and Go E2E suites against the local S3-compatible MinIO source. Pushes to `main` also publish the backend image. |
-| `.woodpecker/webui.yml` | `.woodpecker/webui.yml`, `webui/**` | Yes | Yes | Runs `npm ci --include=dev`, `npm run lint`, and `npm run build`. Pushes to `main` also publish the frontend image. |
+| `.woodpecker/webui.yml` | `.woodpecker/webui.yml`, `webui/**` | Yes | Yes | Runs frontend dependency install, lint, production build, and Chromium Playwright E2E validation with `npm run test:e2e`. Pushes to `main` also publish the frontend image. |
 | `.woodpecker/smoke.yml` | `.woodpecker/smoke.yml`, `docker-compose.yml`, `scripts/woodpecker-smoke.sh`, `api-go/**`, `webui/**` | Yes | Yes | Starts the root Compose stack in Woodpecker, creates a user and MinIO-backed source, creates a bucket, uploads and downloads a file with the CLI, and verifies S3-compatible credential download bytes. |
 
 ## Required Secrets
@@ -20,6 +20,18 @@ Actions workflows to this repository.
 Frontend validation and backend pull-request validation do not need live source
 E2E secrets. The backend E2E gate uses the local MinIO source so external Google
 Drive or Telegram availability cannot block otherwise healthy PRs.
+
+## Web UI E2E
+
+The webui pipeline has two required validation steps in Woodpecker:
+
+- `validate`: runs `npm ci --include=dev`, `npm run lint`, and `npm run build`.
+- `e2e tests`: runs `npm ci --include=dev`, `npm run build`,
+  `npx playwright install --with-deps chromium`, and `npm run test:e2e`.
+
+Playwright browser installation and browser-heavy E2E execution belong in
+Woodpecker. Local frontend validation should normally stop at lint and build
+unless a maintainer explicitly asks for local browser reproduction.
 
 ## Live Source E2E
 


### PR DESCRIPTION
## Summary
- Document the current `.woodpecker/webui.yml` Playwright E2E step in `docs/ci.md`
- Clarify in `CONTRIBUTING.md` that local frontend validation is lint/build, while browser-heavy Playwright E2E runs in Woodpecker

## Validation
- Reviewed against `.woodpecker/webui.yml`
- Ran `git diff --check`
- Did not run local Playwright or Docker per task instructions