### PR TITLE
Split bucket file share dialog from page

### DIFF
--- a/webui/src/features/bucket/index.ts
+++ b/webui/src/features/bucket/index.ts
@@ -1,1 +1,2 @@
 export {CreateBucketDialog} from "./ui/create-bucket-dialog";
+export {ShareFileDialog} from "./ui/share-file-dialog";

--- a/webui/src/features/bucket/ui/share-file-dialog.tsx
+++ b/webui/src/features/bucket/ui/share-file-dialog.tsx
@@ -1,0 +1,141 @@
+import {
+  Button,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+} from "@heroui/react";
+import {useEffect, useState} from "react";
+import type {FileInfo} from "../../../shared/api/buckets";
+import {
+  createShareLink,
+  deleteShareLink,
+  listShareLinks,
+} from "../../../shared/api/shares";
+import type {ShareLinkInfo} from "../../../shared/api/shares";
+
+type Props = {
+  bucketId: string;
+  file: FileInfo | null;
+  onClose: () => void;
+};
+
+export function ShareFileDialog({bucketId, file, onClose}: Props) {
+  const [shareLinks, setShareLinks] = useState<ShareLinkInfo[]>([]);
+  const [isCreatingShare, setIsCreatingShare] = useState(false);
+  const [copiedToken, setCopiedToken] = useState<string | null>(null);
+  const isOpen = file !== null;
+
+  useEffect(() => {
+    if (!file) return;
+
+    listShareLinks(bucketId, file.id)
+      .then(setShareLinks)
+      .catch(() => setShareLinks([]));
+  }, [bucketId, file]);
+
+  function handleClose() {
+    setShareLinks([]);
+    setCopiedToken(null);
+    onClose();
+  }
+
+  async function handleCreateShare() {
+    if (!file) return;
+
+    setIsCreatingShare(true);
+    try {
+      const link = await createShareLink(bucketId, file.id);
+      setShareLinks((prev) => [...prev, link]);
+    } finally {
+      setIsCreatingShare(false);
+    }
+  }
+
+  async function handleDeleteShare(shareId: string) {
+    try {
+      await deleteShareLink(shareId);
+      setShareLinks((prev) => prev.filter((l) => l.id !== shareId));
+    } catch {
+      return;
+    }
+  }
+
+  function copyShareUrl(link: ShareLinkInfo) {
+    const url = `${window.location.origin}${link.url}`;
+    navigator.clipboard.writeText(url);
+    setCopiedToken(link.token);
+    setTimeout(() => setCopiedToken(null), 2000);
+  }
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onOpenChange={(open) => {
+        if (!open) handleClose();
+      }}
+      size="lg"
+    >
+      <ModalContent>
+        {(closeModal) => (
+          <>
+            <ModalHeader>Share: {file?.name}</ModalHeader>
+            <ModalBody>
+              {shareLinks.length === 0 ? (
+                <p className="text-sm text-gray-500">
+                  No share links yet. Create one to share this file publicly.
+                </p>
+              ) : (
+                <div className="flex flex-col gap-2">
+                  {shareLinks.map((link) => (
+                    <div
+                      key={link.id}
+                      className="flex items-center gap-2 border rounded p-2 text-sm"
+                    >
+                      <code className="flex-1 truncate">
+                        {window.location.origin}{link.url}
+                      </code>
+                      <Button
+                        size="sm"
+                        variant="flat"
+                        onPress={() => copyShareUrl(link)}
+                      >
+                        {copiedToken === link.token ? "Copied!" : "Copy"}
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="flat"
+                        color="danger"
+                        onPress={() => handleDeleteShare(link.id)}
+                      >
+                        Revoke
+                      </Button>
+                      {link.expires_at && (
+                        <span className="text-xs text-gray-400">
+                          expires {new Date(link.expires_at).toLocaleString()}
+                        </span>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              )}
+            </ModalBody>
+            <ModalFooter>
+              <Button variant="light" onPress={closeModal}>
+                Close
+              </Button>
+              <Button
+                color="primary"
+                isLoading={isCreatingShare}
+                onPress={handleCreateShare}
+              >
+                Create Share Link
+              </Button>
+            </ModalFooter>
+          </>
+        )}
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/webui/src/pages/bucket/ui/bucket-page.tsx
+++ b/webui/src/pages/bucket/ui/bucket-page.tsx
@@ -1,10 +1,5 @@
 import {
   Button,
-  Modal,
-  ModalBody,
-  ModalContent,
-  ModalFooter,
-  ModalHeader,
   Spinner,
   useDisclosure,
 } from "@heroui/react";
@@ -19,17 +14,12 @@ import {
   uploadFile,
 } from "../../../shared/api/buckets";
 import type {Bucket, FileInfo} from "../../../shared/api/buckets";
-import {
-  createShareLink,
-  deleteShareLink,
-  listShareLinks,
-} from "../../../shared/api/shares";
-import type {ShareLinkInfo} from "../../../shared/api/shares";
 import {DownloadIcon, ShareIcon} from "../../../shared/icons";
 import {DeleteIcon, ArrowLeftIcon} from "@heroui/shared-icons";
 import {ConfirmDialog, EmptyState} from "../../../shared/ui";
 import {FilePreviewModal} from "../../../features/bucket/ui/file-preview-modal";
 import {ShareBucketDialog} from "../../../features/bucket/ui/share-bucket-dialog";
+import {ShareFileDialog} from "../../../features/bucket/ui/share-file-dialog";
 import {formatSize} from "../../../shared/lib/format";
 import {showErrorToast} from "../../../shared/api/error";
 
@@ -47,11 +37,7 @@ export function BucketPage() {
   const [previewFile, setPreviewFile] = useState<FileInfo | null>(null);
 
   const shareBucket = useDisclosure();
-  const shareModal = useDisclosure();
   const [shareFile, setShareFile] = useState<FileInfo | null>(null);
-  const [shareLinks, setShareLinks] = useState<ShareLinkInfo[]>([]);
-  const [isCreatingShare, setIsCreatingShare] = useState(false);
-  const [copiedToken, setCopiedToken] = useState<string | null>(null);
 
   const load = useCallback(async () => {
     if (!id) return;
@@ -109,43 +95,8 @@ export function BucketPage() {
     }
   }
 
-  async function openShareModal(file: FileInfo) {
-    if (!id) return;
+  function openShareModal(file: FileInfo) {
     setShareFile(file);
-    shareModal.onOpen();
-    try {
-      const links = await listShareLinks(id, file.id);
-      setShareLinks(links);
-    } catch {
-      setShareLinks([]);
-    }
-  }
-
-  async function handleCreateShare() {
-    if (!id || !shareFile) return;
-    setIsCreatingShare(true);
-    try {
-      const link = await createShareLink(id, shareFile.id);
-      setShareLinks((prev) => [...prev, link]);
-    } finally {
-      setIsCreatingShare(false);
-    }
-  }
-
-  async function handleDeleteShare(shareId: string) {
-    try {
-      await deleteShareLink(shareId);
-      setShareLinks((prev) => prev.filter((l) => l.id !== shareId));
-    } catch {
-      // ignore
-    }
-  }
-
-  function copyShareUrl(link: ShareLinkInfo) {
-    const url = `${window.location.origin}${link.url}`;
-    navigator.clipboard.writeText(url);
-    setCopiedToken(link.token);
-    setTimeout(() => setCopiedToken(null), 2000);
   }
 
   if (isLoading) {
@@ -315,78 +266,11 @@ export function BucketPage() {
         file={previewFile}
         bucketId={id!}
       />
-      <Modal
-        isOpen={shareModal.isOpen}
-        onOpenChange={(open) => {
-          if (!open) {
-            setShareFile(null);
-            setShareLinks([]);
-            setCopiedToken(null);
-          }
-          shareModal.onOpenChange();
-        }}
-        size="lg"
-      >
-        <ModalContent>
-          {(onClose) => (
-            <>
-              <ModalHeader>Share: {shareFile?.name}</ModalHeader>
-              <ModalBody>
-                {shareLinks.length === 0 ? (
-                  <p className="text-sm text-gray-500">
-                    No share links yet. Create one to share this file publicly.
-                  </p>
-                ) : (
-                  <div className="flex flex-col gap-2">
-                    {shareLinks.map((link) => (
-                      <div
-                        key={link.id}
-                        className="flex items-center gap-2 border rounded p-2 text-sm"
-                      >
-                        <code className="flex-1 truncate">
-                          {window.location.origin}{link.url}
-                        </code>
-                        <Button
-                          size="sm"
-                          variant="flat"
-                          onPress={() => copyShareUrl(link)}
-                        >
-                          {copiedToken === link.token ? "Copied!" : "Copy"}
-                        </Button>
-                        <Button
-                          size="sm"
-                          variant="flat"
-                          color="danger"
-                          onPress={() => handleDeleteShare(link.id)}
-                        >
-                          Revoke
-                        </Button>
-                        {link.expires_at && (
-                          <span className="text-xs text-gray-400">
-                            expires {new Date(link.expires_at).toLocaleString()}
-                          </span>
-                        )}
-                      </div>
-                    ))}
-                  </div>
-                )}
-              </ModalBody>
-              <ModalFooter>
-                <Button variant="light" onPress={onClose}>
-                  Close
-                </Button>
-                <Button
-                  color="primary"
-                  isLoading={isCreatingShare}
-                  onPress={handleCreateShare}
-                >
-                  Create Share Link
-                </Button>
-              </ModalFooter>
-            </>
-          )}
-        </ModalContent>
-      </Modal>
+      <ShareFileDialog
+        bucketId={id!}
+        file={shareFile}
+        onClose={() => setShareFile(null)}
+      />
       <ShareBucketDialog
         isOpen={shareBucket.isOpen}
         onOpenChange={shareBucket.onOpenChange}


### PR DESCRIPTION
## Summary
- Move file share-link modal rendering and link state into `ShareFileDialog`
- Keep `BucketPage` responsible only for selecting the file to share
- Export the new bucket feature component

## Verification
- `git diff --check`
- Local lint/build/E2E not run per limited-resource instructions; Woodpecker should run frontend lint/build and webui E2E.