### PR TITLE
THE-475 Centralize source client construction

### DIFF
--- a/api-go/internal/handlers/source.go
+++ b/api-go/internal/handlers/source.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -317,13 +318,19 @@ func getSourceInfo(repo *repository.SourceRepository, factory manager.SourceClie
 			c.Status(http.StatusNotFound)
 			return
 		}
-		info, err := manager.InspectSource(c.Request.Context(), src, factory)
+		infoClient, err := manager.NewSourceInfoClient(c.Request.Context(), src)
 		if err != nil {
-			if err == manager.ErrUnsupportedSourceType {
+			if errors.Is(err, manager.ErrUnsupportedSourceType) {
 				c.Status(http.StatusBadRequest)
 				return
 			}
-			slog.ErrorContext(ctx, "get source info: inspect source", slog.String("error", err.Error()))
+			slog.ErrorContext(ctx, "get source info: create client", slog.String("error", err.Error()))
+			c.Status(http.StatusInternalServerError)
+			return
+		}
+		info, err := infoClient.Info(c.Request.Context())
+		if err != nil {
+			slog.ErrorContext(ctx, "get source info: load info", slog.String("error", err.Error()))
 			c.Status(http.StatusInternalServerError)
 			return
 		}
@@ -396,12 +403,19 @@ func downloadSourceFile(sourceRepo *repository.SourceRepository, factory manager
 		}
 
 		filename := fileID
-		body, err := manager.DownloadSourceFile(c.Request.Context(), src, fileID, factory)
+
+		cli, err := manager.NewDirectSourceClient(c.Request.Context(), src)
 		if err != nil {
-			if err == manager.ErrUnsupportedSourceType {
+			if errors.Is(err, manager.ErrSourceDownloadUnsupported) || errors.Is(err, manager.ErrUnsupportedSourceType) {
 				c.JSON(http.StatusBadRequest, gin.H{"error": "download not supported for this source type"})
 				return
 			}
+			slog.ErrorContext(c.Request.Context(), "download source file: create client", slog.String("error", err.Error()))
+			c.Status(http.StatusInternalServerError)
+			return
+		}
+		body, err := cli.Download(c.Request.Context(), fileID)
+		if err != nil {
 			slog.ErrorContext(c.Request.Context(), "download source file: download", slog.String("error", err.Error()))
 			c.Status(http.StatusInternalServerError)
 			return

--- a/api-go/internal/manager/file.go
+++ b/api-go/internal/manager/file.go
@@ -10,11 +10,8 @@ import (
 	"io"
 	"log/slog"
 
-	"github.com/example/sfree/api-go/internal/gdrive"
 	"github.com/example/sfree/api-go/internal/repository"
 	"github.com/example/sfree/api-go/internal/resilience"
-	"github.com/example/sfree/api-go/internal/s3compat"
-	"github.com/example/sfree/api-go/internal/telegram"
 	"github.com/example/sfree/api-go/internal/telemetry"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.opentelemetry.io/otel/attribute"
@@ -137,40 +134,6 @@ func SelectorForBucket(bucket *repository.Bucket, sources []repository.Source) S
 // to every source client. Zero values use sensible defaults (30s timeout,
 // 5-failure threshold, 30s recovery).
 var ResilienceConfig = resilience.DefaultWrapperConfig()
-
-func NewSourceClient(ctx context.Context, src *repository.Source) (SourceClient, error) {
-	if src == nil {
-		return nil, errors.New("nil source")
-	}
-	var (
-		cli sourceClient
-		err error
-	)
-	switch src.Type {
-	case repository.SourceTypeGDrive:
-		cli, err = gdrive.NewClient(ctx, []byte(src.Key))
-	case repository.SourceTypeTelegram:
-		var tcfg telegram.Config
-		tcfg, err = telegram.ParseConfig(src.Key)
-		if err != nil {
-			return nil, err
-		}
-		cli, err = telegram.NewClient(tcfg)
-	case repository.SourceTypeS3:
-		var scfg s3compat.Config
-		scfg, err = s3compat.ParseConfig(src.Key)
-		if err != nil {
-			return nil, err
-		}
-		cli, err = s3compat.NewClient(ctx, scfg)
-	default:
-		return nil, ErrUnsupportedSourceType
-	}
-	if err != nil {
-		return nil, err
-	}
-	return resilience.Wrap(cli, ResilienceConfig), nil
-}
 
 func StreamFile(ctx context.Context, srcRepo *repository.SourceRepository, f *repository.File, w io.Writer) error {
 	return streamFileWithFactory(ctx, f, w, sourceClientFactoryFromRepository(srcRepo))

--- a/api-go/internal/manager/source_client.go
+++ b/api-go/internal/manager/source_client.go
@@ -1,0 +1,214 @@
+package manager
+
+import (
+	"context"
+	"errors"
+	"io"
+
+	"github.com/example/sfree/api-go/internal/gdrive"
+	"github.com/example/sfree/api-go/internal/repository"
+	"github.com/example/sfree/api-go/internal/resilience"
+	"github.com/example/sfree/api-go/internal/s3compat"
+	"github.com/example/sfree/api-go/internal/telegram"
+)
+
+var ErrSourceDownloadUnsupported = errors.New("source download unsupported")
+
+type SourceInfoClient interface {
+	Info(ctx context.Context) (SourceInfo, error)
+}
+
+type DirectSourceClient interface {
+	Download(ctx context.Context, name string) (io.ReadCloser, error)
+}
+
+type fullGDriveSourceClient interface {
+	sourceClient
+	ListFiles(ctx context.Context) ([]gdrive.File, error)
+	StorageInfo(ctx context.Context) (total, used, free int64, err error)
+}
+
+type fullS3SourceClient interface {
+	sourceClient
+	ListObjects(ctx context.Context) ([]s3compat.ObjectInfo, int64, error)
+}
+
+type sourceClientBuilder struct {
+	newGDriveClient   func(ctx context.Context, credsJSON []byte) (fullGDriveSourceClient, error)
+	newTelegramClient func(cfg telegram.Config) (sourceClient, error)
+	newS3Client       func(ctx context.Context, cfg s3compat.Config) (fullS3SourceClient, error)
+}
+
+func NewSourceInfoClient(ctx context.Context, src *repository.Source) (SourceInfoClient, error) {
+	return sourceClientBuilder{}.NewSourceInfoClient(ctx, src)
+}
+
+func NewDirectSourceClient(ctx context.Context, src *repository.Source) (DirectSourceClient, error) {
+	return sourceClientBuilder{}.NewDirectSourceClient(ctx, src)
+}
+
+func NewSourceClient(ctx context.Context, src *repository.Source) (sourceClient, error) {
+	return sourceClientBuilder{}.NewStorageSourceClient(ctx, src)
+}
+
+func (b sourceClientBuilder) NewSourceInfoClient(ctx context.Context, src *repository.Source) (SourceInfoClient, error) {
+	if src == nil {
+		return nil, errors.New("nil source")
+	}
+	switch src.Type {
+	case repository.SourceTypeGDrive:
+		cli, err := b.gdriveClient(ctx, []byte(src.Key))
+		if err != nil {
+			return nil, err
+		}
+		return gdriveSourceInfoClient{client: cli}, nil
+	case repository.SourceTypeTelegram:
+		return emptySourceInfoClient{}, nil
+	case repository.SourceTypeS3:
+		cfg, err := s3compat.ParseConfig(src.Key)
+		if err != nil {
+			return nil, err
+		}
+		cli, err := b.s3Client(ctx, cfg)
+		if err != nil {
+			return nil, err
+		}
+		return s3SourceInfoClient{client: cli}, nil
+	default:
+		return nil, ErrUnsupportedSourceType
+	}
+}
+
+func (b sourceClientBuilder) NewDirectSourceClient(ctx context.Context, src *repository.Source) (DirectSourceClient, error) {
+	if src == nil {
+		return nil, errors.New("nil source")
+	}
+	switch src.Type {
+	case repository.SourceTypeGDrive, repository.SourceTypeS3:
+		cli, err := b.NewStorageSourceClient(ctx, src)
+		if err != nil {
+			return nil, err
+		}
+		return directSourceClient{client: cli}, nil
+	default:
+		return nil, ErrSourceDownloadUnsupported
+	}
+}
+
+func (b sourceClientBuilder) NewStorageSourceClient(ctx context.Context, src *repository.Source) (sourceClient, error) {
+	if src == nil {
+		return nil, errors.New("nil source")
+	}
+	var (
+		cli sourceClient
+		err error
+	)
+	switch src.Type {
+	case repository.SourceTypeGDrive:
+		cli, err = b.gdriveClient(ctx, []byte(src.Key))
+	case repository.SourceTypeTelegram:
+		var cfg telegram.Config
+		cfg, err = telegram.ParseConfig(src.Key)
+		if err != nil {
+			return nil, err
+		}
+		cli, err = b.telegramClient(cfg)
+	case repository.SourceTypeS3:
+		var cfg s3compat.Config
+		cfg, err = s3compat.ParseConfig(src.Key)
+		if err != nil {
+			return nil, err
+		}
+		cli, err = b.s3Client(ctx, cfg)
+	default:
+		return nil, ErrUnsupportedSourceType
+	}
+	if err != nil {
+		return nil, err
+	}
+	return resilience.Wrap(cli, ResilienceConfig), nil
+}
+
+func (b sourceClientBuilder) gdriveClient(ctx context.Context, credsJSON []byte) (fullGDriveSourceClient, error) {
+	if b.newGDriveClient != nil {
+		return b.newGDriveClient(ctx, credsJSON)
+	}
+	return gdrive.NewClient(ctx, credsJSON)
+}
+
+func (b sourceClientBuilder) telegramClient(cfg telegram.Config) (sourceClient, error) {
+	if b.newTelegramClient != nil {
+		return b.newTelegramClient(cfg)
+	}
+	return telegram.NewClient(cfg)
+}
+
+func (b sourceClientBuilder) s3Client(ctx context.Context, cfg s3compat.Config) (fullS3SourceClient, error) {
+	if b.newS3Client != nil {
+		return b.newS3Client(ctx, cfg)
+	}
+	return s3compat.NewClient(ctx, cfg)
+}
+
+type gdriveSourceInfoClient struct {
+	client fullGDriveSourceClient
+}
+
+func (c gdriveSourceInfoClient) Info(ctx context.Context) (SourceInfo, error) {
+	files, err := c.client.ListFiles(ctx)
+	if err != nil {
+		return SourceInfo{}, err
+	}
+	total, used, free, err := c.client.StorageInfo(ctx)
+	if err != nil {
+		return SourceInfo{}, err
+	}
+	respFiles := make([]SourceInfoFile, 0, len(files))
+	for _, f := range files {
+		respFiles = append(respFiles, SourceInfoFile{ID: f.ID, Name: f.Name, Size: f.Size})
+	}
+	return SourceInfo{
+		Files:        respFiles,
+		StorageTotal: total,
+		StorageUsed:  used,
+		StorageFree:  free,
+	}, nil
+}
+
+type s3SourceInfoClient struct {
+	client fullS3SourceClient
+}
+
+func (c s3SourceInfoClient) Info(ctx context.Context) (SourceInfo, error) {
+	objects, used, err := c.client.ListObjects(ctx)
+	if err != nil {
+		return SourceInfo{}, err
+	}
+	respFiles := make([]SourceInfoFile, 0, len(objects))
+	for _, obj := range objects {
+		respFiles = append(respFiles, SourceInfoFile{ID: obj.Key, Name: obj.Key, Size: obj.Size})
+	}
+	return SourceInfo{
+		Files:       respFiles,
+		StorageUsed: used,
+	}, nil
+}
+
+type emptySourceInfoClient struct{}
+
+func (emptySourceInfoClient) Info(context.Context) (SourceInfo, error) {
+	return SourceInfo{Files: []SourceInfoFile{}}, nil
+}
+
+type directSourceClient struct {
+	client sourceClient
+}
+
+func (c directSourceClient) Download(ctx context.Context, name string) (io.ReadCloser, error) {
+	if streamClient, ok := c.client.(interface {
+		DownloadStream(context.Context, string) (io.ReadCloser, error)
+	}); ok {
+		return streamClient.DownloadStream(ctx, name)
+	}
+	return c.client.Download(ctx, name)
+}

--- a/api-go/internal/manager/source_client_test.go
+++ b/api-go/internal/manager/source_client_test.go
@@ -1,0 +1,281 @@
+package manager
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/example/sfree/api-go/internal/gdrive"
+	"github.com/example/sfree/api-go/internal/repository"
+	"github.com/example/sfree/api-go/internal/s3compat"
+	"github.com/example/sfree/api-go/internal/telegram"
+)
+
+type fakeFullGDriveClient struct {
+	files        []gdrive.File
+	total        int64
+	used         int64
+	free         int64
+	downloadBody string
+}
+
+func (c *fakeFullGDriveClient) Upload(context.Context, string, io.Reader) (string, error) {
+	return "", nil
+}
+
+func (c *fakeFullGDriveClient) Download(context.Context, string) (io.ReadCloser, error) {
+	return io.NopCloser(strings.NewReader(c.downloadBody)), nil
+}
+
+func (c *fakeFullGDriveClient) Delete(context.Context, string) error {
+	return nil
+}
+
+func (c *fakeFullGDriveClient) ListFiles(context.Context) ([]gdrive.File, error) {
+	return c.files, nil
+}
+
+func (c *fakeFullGDriveClient) StorageInfo(context.Context) (int64, int64, int64, error) {
+	return c.total, c.used, c.free, nil
+}
+
+type fakeFullS3Client struct {
+	objects      []s3compat.ObjectInfo
+	used         int64
+	downloadBody string
+}
+
+func (c *fakeFullS3Client) Upload(context.Context, string, io.Reader) (string, error) {
+	return "", nil
+}
+
+func (c *fakeFullS3Client) Download(context.Context, string) (io.ReadCloser, error) {
+	return io.NopCloser(strings.NewReader(c.downloadBody)), nil
+}
+
+func (c *fakeFullS3Client) Delete(context.Context, string) error {
+	return nil
+}
+
+func (c *fakeFullS3Client) ListObjects(context.Context) ([]s3compat.ObjectInfo, int64, error) {
+	return c.objects, c.used, nil
+}
+
+func TestSourceClientBuilderInfoClients(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	gdriveClient := &fakeFullGDriveClient{
+		files: []gdrive.File{{ID: "file-1", Name: "doc.txt", Size: 12}},
+		total: 100,
+		used:  30,
+		free:  70,
+	}
+	s3Client := &fakeFullS3Client{
+		objects: []s3compat.ObjectInfo{{Key: "object.txt", Size: 9}},
+		used:    9,
+	}
+
+	var gotGDriveKey string
+	var gotS3Config s3compat.Config
+	builder := sourceClientBuilder{
+		newGDriveClient: func(_ context.Context, credsJSON []byte) (fullGDriveSourceClient, error) {
+			gotGDriveKey = string(credsJSON)
+			return gdriveClient, nil
+		},
+		newTelegramClient: func(telegram.Config) (sourceClient, error) {
+			t.Fatal("telegram client should not be built for source info")
+			return nil, nil
+		},
+		newS3Client: func(_ context.Context, cfg s3compat.Config) (fullS3SourceClient, error) {
+			gotS3Config = cfg
+			return s3Client, nil
+		},
+	}
+
+	infoClient, err := builder.NewSourceInfoClient(ctx, &repository.Source{Type: repository.SourceTypeGDrive, Key: "gdrive-creds"})
+	if err != nil {
+		t.Fatalf("gdrive info client: %v", err)
+	}
+	info, err := infoClient.Info(ctx)
+	if err != nil {
+		t.Fatalf("gdrive info: %v", err)
+	}
+	if gotGDriveKey != "gdrive-creds" || len(info.Files) != 1 || info.Files[0].ID != "file-1" || info.StorageTotal != 100 || info.StorageUsed != 30 || info.StorageFree != 70 {
+		t.Fatalf("unexpected gdrive info: key=%q info=%+v", gotGDriveKey, info)
+	}
+
+	s3Key, err := s3compat.EncodeConfig(s3compat.Config{
+		Endpoint:     "http://s3.test",
+		Bucket:       "bucket",
+		AccessKeyID:  "access",
+		SecretAccess: "secret",
+	})
+	if err != nil {
+		t.Fatalf("encode s3 config: %v", err)
+	}
+	infoClient, err = builder.NewSourceInfoClient(ctx, &repository.Source{Type: repository.SourceTypeS3, Key: s3Key})
+	if err != nil {
+		t.Fatalf("s3 info client: %v", err)
+	}
+	info, err = infoClient.Info(ctx)
+	if err != nil {
+		t.Fatalf("s3 info: %v", err)
+	}
+	if gotS3Config.Region != "us-east-1" || len(info.Files) != 1 || info.Files[0].ID != "object.txt" || info.StorageUsed != 9 {
+		t.Fatalf("unexpected s3 info: cfg=%+v info=%+v", gotS3Config, info)
+	}
+
+	infoClient, err = builder.NewSourceInfoClient(ctx, &repository.Source{Type: repository.SourceTypeTelegram, Key: "{}"})
+	if err != nil {
+		t.Fatalf("telegram info client: %v", err)
+	}
+	info, err = infoClient.Info(ctx)
+	if err != nil {
+		t.Fatalf("telegram info: %v", err)
+	}
+	if len(info.Files) != 0 || info.StorageTotal != 0 || info.StorageUsed != 0 || info.StorageFree != 0 {
+		t.Fatalf("unexpected telegram info: %+v", info)
+	}
+}
+
+func TestSourceClientBuilderDirectDownloadClients(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	gdriveClient := &fakeFullGDriveClient{downloadBody: "gdrive-body"}
+	s3Client := &fakeFullS3Client{downloadBody: "s3-body"}
+	builder := sourceClientBuilder{
+		newGDriveClient: func(context.Context, []byte) (fullGDriveSourceClient, error) {
+			return gdriveClient, nil
+		},
+		newTelegramClient: func(telegram.Config) (sourceClient, error) {
+			t.Fatal("telegram client should not be built for direct source downloads")
+			return nil, nil
+		},
+		newS3Client: func(context.Context, s3compat.Config) (fullS3SourceClient, error) {
+			return s3Client, nil
+		},
+	}
+
+	downloadClient, err := builder.NewDirectSourceClient(ctx, &repository.Source{Type: repository.SourceTypeGDrive, Key: "{}"})
+	if err != nil {
+		t.Fatalf("gdrive download client: %v", err)
+	}
+	body, err := downloadClient.Download(ctx, "file-id")
+	if err != nil {
+		t.Fatalf("gdrive download: %v", err)
+	}
+	data, err := io.ReadAll(body)
+	if err != nil {
+		t.Fatalf("read gdrive body: %v", err)
+	}
+	_ = body.Close()
+	if string(data) != "gdrive-body" {
+		t.Fatalf("unexpected gdrive body: %q", string(data))
+	}
+
+	s3Key, err := s3compat.EncodeConfig(s3compat.Config{
+		Endpoint:     "http://s3.test",
+		Bucket:       "bucket",
+		AccessKeyID:  "access",
+		SecretAccess: "secret",
+	})
+	if err != nil {
+		t.Fatalf("encode s3 config: %v", err)
+	}
+	downloadClient, err = builder.NewDirectSourceClient(ctx, &repository.Source{Type: repository.SourceTypeS3, Key: s3Key})
+	if err != nil {
+		t.Fatalf("s3 download client: %v", err)
+	}
+	body, err = downloadClient.Download(ctx, "object.txt")
+	if err != nil {
+		t.Fatalf("s3 download: %v", err)
+	}
+	data, err = io.ReadAll(body)
+	if err != nil {
+		t.Fatalf("read s3 body: %v", err)
+	}
+	_ = body.Close()
+	if string(data) != "s3-body" {
+		t.Fatalf("unexpected s3 body: %q", string(data))
+	}
+
+	_, err = builder.NewDirectSourceClient(ctx, &repository.Source{Type: repository.SourceTypeTelegram, Key: "{}"})
+	if !errors.Is(err, ErrSourceDownloadUnsupported) {
+		t.Fatalf("expected ErrSourceDownloadUnsupported, got %v", err)
+	}
+}
+
+func TestSourceClientBuilderDirectDownloadKeepsStreamContextOpen(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	builder := sourceClientBuilder{
+		newGDriveClient: func(context.Context, []byte) (fullGDriveSourceClient, error) {
+			return &contextAwareFullSourceClient{payload: "streamed-body"}, nil
+		},
+	}
+
+	downloadClient, err := builder.NewDirectSourceClient(ctx, &repository.Source{Type: repository.SourceTypeGDrive, Key: "{}"})
+	if err != nil {
+		t.Fatalf("gdrive download client: %v", err)
+	}
+	body, err := downloadClient.Download(ctx, "file-id")
+	if err != nil {
+		t.Fatalf("gdrive download: %v", err)
+	}
+	data, readErr := io.ReadAll(body)
+	closeErr := body.Close()
+	if readErr != nil {
+		t.Fatalf("read gdrive body: %v", readErr)
+	}
+	if closeErr != nil {
+		t.Fatalf("close gdrive body: %v", closeErr)
+	}
+	if string(data) != "streamed-body" {
+		t.Fatalf("unexpected gdrive body: %q", string(data))
+	}
+}
+
+type contextAwareFullSourceClient struct {
+	payload string
+}
+
+func (c *contextAwareFullSourceClient) Upload(context.Context, string, io.Reader) (string, error) {
+	return "", nil
+}
+
+func (c *contextAwareFullSourceClient) Download(ctx context.Context, string) (io.ReadCloser, error) {
+	return &contextAwareSourceBody{ctx: ctx, reader: strings.NewReader(c.payload)}, nil
+}
+
+func (c *contextAwareFullSourceClient) Delete(context.Context, string) error {
+	return nil
+}
+
+func (c *contextAwareFullSourceClient) ListFiles(context.Context) ([]gdrive.File, error) {
+	return nil, nil
+}
+
+func (c *contextAwareFullSourceClient) StorageInfo(context.Context) (int64, int64, int64, error) {
+	return 0, 0, 0, nil
+}
+
+type contextAwareSourceBody struct {
+	ctx    context.Context
+	reader *strings.Reader
+}
+
+func (b *contextAwareSourceBody) Read(p []byte) (int, error) {
+	if err := b.ctx.Err(); err != nil {
+		return 0, err
+	}
+	return b.reader.Read(p)
+}
+
+func (b *contextAwareSourceBody) Close() error {
+	return nil
+}


### PR DESCRIPTION
## Summary
- Move source info and direct source download client selection into manager-level source client helpers.
- Reuse the manager-side storage client builder for direct GDrive/S3 downloads while preserving Telegram direct-download rejection.
- Add focused manager unit tests with fake source clients for GDrive/S3/Telegram selection behavior.

## Validation
- `gofmt` ran on touched Go files.
- `git diff --check` passed.
- Local `go test ./...` and `golangci-lint run` were not run because this environment is resource-constrained; Woodpecker should run backend validation.