### PR TITLE
THE-481: Refresh QA coverage audit

### DIFF
--- a/docs/qa-coverage-audit-2026-04-21.md
+++ b/docs/qa-coverage-audit-2026-04-21.md
@@ -2,25 +2,22 @@
 
 Date: 2026-04-21
 
-Scope: `api-go` automated tests, Woodpecker backend validation, recent `origin/main` changes, and open backend PRs as of 2026-04-21 15:20 UTC.
+Scope: `api-go` automated tests, Woodpecker backend validation, recent `origin/main` changes, and open backend PRs as of 2026-04-21 16:25 UTC.
 
 ## Recent Inputs
 
-- `origin/main` now includes focused S3 range GET, ListObjectsV2 pagination, checksum verification, multipart checksum preservation, one-file-per-bucket-object enforcement, S3 GET stream-failure semantics, DeleteObjects support, CopyObject support, SDK CopyObject compatibility coverage, bucket grant route scoping, and Woodpecker image-pinning changes.
+- `origin/main` now includes focused S3 range GET, ListObjectsV2 pagination, checksum verification, multipart checksum preservation, one-file-per-bucket-object enforcement, S3 GET stream-failure semantics, DeleteObjects support, CopyObject support, SDK CopyObject compatibility coverage, bucket grant route scoping, Woodpecker image-pinning, and the unit-only `api-go` Makefile `test` target.
 - Merged commit `5c4f0a2` (`THE-467`) scopes bucket grant update/delete mutations to the route bucket and adds integration coverage for cross-bucket grant IDs returning 404 without mutating the grant in its real bucket.
 - Merged commit `a5ac19e` (`THE-445`) preserves multipart chunk checksums and adds `TestCompletedMultipartChunksPreservesChecksums`.
 - Merged commit `9895536` (`THE-447`) enforces one file document per bucket object name and adds repository integration coverage for unique bucket/name replacement plus legacy index migration.
+- Merged PR [#196](https://github.com/siberianbearofficial/sfree/pull/196) makes the `api-go` Makefile test target unit-only and documents that integration/E2E suites belong in Woodpecker.
 - Merged PR [#180](https://github.com/siberianbearofficial/sfree/pull/180) adds S3 CopyObject support plus Go E2E coverage for same-bucket copy, cross-bucket copy, response XML fields, unsupported metadata replacement, and copied-object survival after deleting the source object.
 - Merged PR [#178](https://github.com/siberianbearofficial/sfree/pull/178) adds S3 GET stream-failure semantics and handler regression tests for corrupt chunks before success headers/body are emitted.
 - Merged PR [#176](https://github.com/siberianbearofficial/sfree/pull/176) adds S3 DeleteObjects support plus E2E coverage for normal delete, missing-key idempotency, quiet mode, list-after-delete, and oversized XML rejection.
+- Open PR [#202](https://github.com/siberianbearofficial/sfree/pull/202) centralizes source-client construction and adds unit coverage for source-client parsing, wrapping, inspection, download, and stream lifetime behavior.
 - Open PR [#197](https://github.com/siberianbearofficial/sfree/pull/197) redacts SigV4 mismatch diagnostics and adds header-auth plus presigned-url tests that assert submitted signatures, expected signatures, canonical headers, and credentials do not leak in errors.
-- Open PR [#196](https://github.com/siberianbearofficial/sfree/pull/196) makes the `api-go` Makefile test target unit-only and documents that integration/E2E suites belong in Woodpecker.
 - Open PR [#195](https://github.com/siberianbearofficial/sfree/pull/195) fixes cleanup of chunks uploaded before later upload/read failures and adds manager regressions for both paths.
-- Open PR [#194](https://github.com/siberianbearofficial/sfree/pull/194) routes source inspection/download through the source-client factory and adds tests for factory use plus streamed download lifetime.
-- Open PR [#193](https://github.com/siberianbearofficial/sfree/pull/193) fixes non-resilience lint findings in `api-go`; no new product behavior coverage is expected.
-- Open PR [#192](https://github.com/siberianbearofficial/sfree/pull/192) splits the large Go S3 compatibility E2E file into operation-focused files without changing coverage intent.
 - Open PR [#191](https://github.com/siberianbearofficial/sfree/pull/191) moves S3 object mutation logic into a manager service and adds unit coverage for PUT, CopyObject, DeleteObject, CompleteMultipartUpload cleanup, and metadata-save failure cleanup.
-- Open PR [#189](https://github.com/siberianbearofficial/sfree/pull/189) replays source upload bodies on retry and adds resilience wrapper coverage.
 - Open PR [#187](https://github.com/siberianbearofficial/sfree/pull/187) adds `api-go` lint enforcement to Woodpecker and updates CI docs.
 
 ## Coverage Map
@@ -33,10 +30,10 @@ Scope: `api-go` automated tests, Woodpecker backend validation, recent `origin/m
 | Placement logic | Round-robin, weighted selection, and upload failover have unit coverage. | Covered for manager logic. |
 | Reconstruction/retrieval | Manager tests cover checksum-verified streaming, range streaming across chunks, legacy chunks, oversized chunks, truncated chunks, and corruption. S3 E2E covers full-object and ranged download. Handler tests cover S3 full and ranged GET failures before success headers/body are emitted. | Covered for manager logic and pre-commit S3 HTTP error behavior. |
 | Corruption detection | SHA-256 mismatch paths are unit-tested, including short and oversized chunk reads. | Covered at unit level. |
-| Source/backend failure cases | Manager failover and resilience wrappers have tests. S3 GET stream-failure handler coverage is merged on `origin/main`. | Covered for upload/retry logic and pre-commit S3 GET failure behavior. |
+| Source/backend failure cases | Manager failover and resilience wrappers have tests. S3 GET stream-failure handler coverage is merged on `origin/main`; open PR #202 adds source-client construction and stream lifetime coverage. | Covered for upload/retry logic and pre-commit S3 GET failure behavior. |
 | Critical S3-compatible API behavior | Go E2E covers source/bucket creation, object lifecycle, auth failure, presigned GET/PUT, HEAD, expired presign, range GET, ListObjectsV2 prefix/delimiter/pagination, DeleteObjects, CopyObject, and multipart lifecycle. Python SDK E2E covers ListObjectsV2, range GET, DeleteObjects, CopyObject, and multipart. | Covered for currently implemented core operations; weak for metadata and unsupported/malformed request error shapes. |
 | Recent bug regressions | Recent checksum, ListObjectsV2, range GET, multipart checksum propagation, DeleteObjects, CopyObject, S3 GET stream-failure, file-manager cache, upload retry body replay, upload failure cleanup, source-client factory, one-file-per-object enforcement, and bucket grant route scoping work have focused tests or open test branches. Web UI lockfile fix belongs to web UI CI. | Covered for latest backend regressions once open PRs merge. |
-| Recently changed code paths | Backend CI runs Go unit tests plus Python and Go E2E through Woodpecker for `api-go/**`; open PR #196 makes local `make test` unit-only and keeps CPU-heavy integration/E2E work in CI. | Covered by CI routing. |
+| Recently changed code paths | Backend CI runs Go unit tests plus Python and Go E2E through Woodpecker for `api-go/**`; `make test` is unit-only on `origin/main`, keeping CPU-heavy integration/E2E work in CI. Open PR #187 adds lint enforcement to the same backend Woodpecker path. | Covered by CI routing. |
 
 ## Prioritized Missing Tests
 
@@ -72,6 +69,8 @@ Scope: `api-go` automated tests, Woodpecker backend validation, recent `origin/m
 - Confirmed open PR #195 adds manager coverage for uploaded chunk cleanup after both later upload failure and later read failure.
 - Confirmed open PR #197 adds redaction coverage for both header-auth and presigned-url SigV4 mismatch paths.
 - Confirmed open PR #191 adds object-service unit coverage for overwrite cleanup and metadata-save failure cleanup around S3 object mutations.
+- Confirmed open PR #202 adds focused source-client construction coverage and keeps streamed source downloads open for callers.
+- Confirmed `origin/main` now has `make test` scoped to unit tests, matching the QA instruction to leave CPU-heavy suites to Woodpecker.
 - Reviewed `.woodpecker/api-go.yml`; backend PRs and pushes to main run Go unit tests plus S3-backed Python and Go E2E suites in Woodpecker.
 
 ## Verification


### PR DESCRIPTION
## Summary

- refreshes the QA coverage audit with current origin/main and open backend PR status
- records that make test is now unit-only on main
- adds current source-client construction coverage assessment

## Verification

- git diff --check
- heavy backend suites not run locally; Woodpecker should validate the branch