### PR TITLE
THE-485: Centralize webui API request helpers

### DIFF
--- a/webui/src/pages/landing/ui/landing-page.tsx
+++ b/webui/src/pages/landing/ui/landing-page.tsx
@@ -1,5 +1,6 @@
 import {Button, Card, CardBody, Snippet, useDisclosure} from "@heroui/react";
 import {LoginDialog, RegisterDialog} from "../../../features/auth";
+import {apiUrl} from "../../../shared/api/client";
 import {GoogleDriveIcon, TelegramIcon, S3Icon, GitHubIcon} from "../../../shared/icons";
 
 const GITHUB_URL = "https://github.com/siberianbearofficial/sfree";
@@ -60,7 +61,7 @@ export function LandingPage() {
             color="primary"
             size="lg"
             as="a"
-            href={(import.meta.env.VITE_API_BASE || "/api/v1") + "/auth/github"}
+            href={apiUrl("/auth/github")}
             startContent={<GitHubIcon className="w-5 h-5 fill-current" />}
           >
             Sign in with GitHub
@@ -147,7 +148,7 @@ export function LandingPage() {
             color="primary"
             size="lg"
             as="a"
-            href={(import.meta.env.VITE_API_BASE || "/api/v1") + "/auth/github"}
+            href={apiUrl("/auth/github")}
             startContent={<GitHubIcon className="w-5 h-5 fill-current" />}
           >
             Sign in with GitHub

--- a/webui/src/shared/api/buckets.ts
+++ b/webui/src/shared/api/buckets.ts
@@ -1,6 +1,4 @@
-import {throwIfNotOk} from "./error";
-
-const API_BASE = import.meta.env.VITE_API_BASE || "/api/v1";
+import {apiDownload, apiFetch, apiJson} from "./client";
 
 export type Bucket = {
   id: string;
@@ -18,51 +16,32 @@ export type FileInfo = {
   size: number;
 };
 
-import { getAuthHeader, getCredentialsOption } from "../lib/auth";
-
-function authHeader(): Record<string, string> {
-  return getAuthHeader();
-}
-
-function credentials(): RequestCredentials | undefined {
-  return getCredentialsOption();
-}
-
-export async function listBuckets(): Promise<Bucket[]> {
-  const res = await fetch(`${API_BASE}/buckets`, {
-    headers: authHeader(),
-    credentials: credentials(),
-  });
-  await throwIfNotOk(res, "Failed to list buckets");
-  return res.json();
-}
-
-export async function createBucket(key: string, sourceIds: string[]): Promise<{
+type CreateBucketResponse = {
   key: string;
   access_key: string;
   access_secret: string;
   created_at: string;
-}> {
-  const res = await fetch(`${API_BASE}/buckets`, {
+};
+
+export async function listBuckets(): Promise<Bucket[]> {
+  return apiJson<Bucket[]>("/buckets", "Failed to list buckets");
+}
+
+export async function createBucket(
+  key: string,
+  sourceIds: string[],
+): Promise<CreateBucketResponse> {
+  return apiJson<CreateBucketResponse>("/buckets", "Failed to create bucket", {
     method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      ...authHeader(),
-    },
-    credentials: credentials(),
-    body: JSON.stringify({key, source_ids: sourceIds}),
+    json: {key, source_ids: sourceIds},
   });
-  await throwIfNotOk(res, "Failed to create bucket");
-  return res.json();
 }
 
 export async function listFiles(bucketId: string): Promise<FileInfo[]> {
-  const res = await fetch(`${API_BASE}/buckets/${bucketId}/files`, {
-    headers: authHeader(),
-    credentials: credentials(),
-  });
-  await throwIfNotOk(res, "Failed to list files");
-  return res.json();
+  return apiJson<FileInfo[]>(
+    `/buckets/${bucketId}/files`,
+    "Failed to list files",
+  );
 }
 
 export async function uploadFile(
@@ -71,58 +50,41 @@ export async function uploadFile(
 ): Promise<FileInfo> {
   const form = new FormData();
   form.append("file", file);
-  const res = await fetch(`${API_BASE}/buckets/${bucketId}/upload`, {
-    method: "POST",
-    headers: authHeader(),
-    credentials: credentials(),
-    body: form,
-  });
-  await throwIfNotOk(res, "Failed to upload file");
-  return res.json();
+  return apiJson<FileInfo>(
+    `/buckets/${bucketId}/upload`,
+    "Failed to upload file",
+    {
+      method: "POST",
+      body: form,
+    },
+  );
 }
 
 export async function deleteBucket(id: string): Promise<void> {
-  const res = await fetch(`${API_BASE}/buckets/${id}`, {
+  await apiFetch(`/buckets/${id}`, "Failed to delete bucket", {
     method: "DELETE",
-    headers: authHeader(),
-    credentials: credentials(),
   });
-  await throwIfNotOk(res, "Failed to delete bucket");
 }
 
 export async function downloadFile(
   bucketId: string,
   file: FileInfo,
 ): Promise<void> {
-  const res = await fetch(
-    `${API_BASE}/buckets/${bucketId}/files/${file.id}/download`,
-    {
-      headers: authHeader(),
-      credentials: credentials(),
-    },
+  await apiDownload(
+    `/buckets/${bucketId}/files/${file.id}/download`,
+    file.name,
+    "Failed to download file",
   );
-  await throwIfNotOk(res, "Failed to download file");
-  const blob = await res.blob();
-  const url = window.URL.createObjectURL(blob);
-  const a = document.createElement("a");
-  a.href = url;
-  a.download = file.name;
-  a.click();
-  window.URL.revokeObjectURL(url);
 }
 
 export async function fetchFileBlob(
   bucketId: string,
   fileId: string,
 ): Promise<Blob> {
-  const res = await fetch(
-    `${API_BASE}/buckets/${bucketId}/files/${fileId}/download`,
-    {
-      headers: authHeader(),
-      credentials: credentials(),
-    },
+  const res = await apiFetch(
+    `/buckets/${bucketId}/files/${fileId}/download`,
+    "Failed to fetch file",
   );
-  if (!res.ok) throw new Error("failed to fetch file");
   return res.blob();
 }
 
@@ -130,10 +92,11 @@ export async function deleteFile(
   bucketId: string,
   fileId: string,
 ): Promise<void> {
-  const res = await fetch(`${API_BASE}/buckets/${bucketId}/files/${fileId}`, {
-    method: "DELETE",
-    headers: authHeader(),
-    credentials: credentials(),
-  });
-  await throwIfNotOk(res, "Failed to delete file");
+  await apiFetch(
+    `/buckets/${bucketId}/files/${fileId}`,
+    "Failed to delete file",
+    {
+      method: "DELETE",
+    },
+  );
 }

--- a/webui/src/shared/api/client.ts
+++ b/webui/src/shared/api/client.ts
@@ -1,0 +1,68 @@
+import {getAuthHeader, getCredentialsOption} from "../lib/auth";
+import {throwIfNotOk} from "./error";
+
+const API_BASE = import.meta.env.VITE_API_BASE || "/api/v1";
+
+type ApiFetchOptions = Omit<RequestInit, "body" | "headers"> & {
+  auth?: boolean;
+  body?: BodyInit | null;
+  json?: unknown;
+  headers?: HeadersInit;
+};
+
+export function apiUrl(path: string): string {
+  return `${API_BASE}${path}`;
+}
+
+export async function apiFetch(
+  path: string,
+  fallback: string,
+  options: ApiFetchOptions = {},
+): Promise<Response> {
+  const {auth = true, json, headers, ...init} = options;
+  const requestHeaders = new Headers(headers);
+
+  if (json !== undefined && !requestHeaders.has("Content-Type")) {
+    requestHeaders.set("Content-Type", "application/json");
+  }
+
+  if (auth) {
+    for (const [key, value] of Object.entries(getAuthHeader())) {
+      requestHeaders.set(key, value);
+    }
+  }
+
+  const res = await fetch(apiUrl(path), {
+    ...init,
+    headers: requestHeaders,
+    credentials: auth ? getCredentialsOption() : init.credentials,
+    body: json !== undefined ? JSON.stringify(json) : init.body,
+  });
+
+  await throwIfNotOk(res, fallback);
+  return res;
+}
+
+export async function apiJson<T>(
+  path: string,
+  fallback: string,
+  options?: ApiFetchOptions,
+): Promise<T> {
+  const res = await apiFetch(path, fallback, options);
+  return res.json() as Promise<T>;
+}
+
+export async function apiDownload(
+  path: string,
+  filename: string,
+  fallback: string,
+): Promise<void> {
+  const res = await apiFetch(path, fallback);
+  const blob = await res.blob();
+  const url = window.URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  a.click();
+  window.URL.revokeObjectURL(url);
+}

--- a/webui/src/shared/api/grants.ts
+++ b/webui/src/shared/api/grants.ts
@@ -1,11 +1,4 @@
-const API_BASE = import.meta.env.VITE_API_BASE || "/api/v1";
-
-import { getAuthHeader } from "../lib/auth";
-import { throwIfNotOk } from "./error";
-
-function authHeader(): Record<string, string> {
-  return getAuthHeader();
-}
+import {apiFetch, apiJson} from "./client";
 
 export type BucketGrant = {
   id: string;
@@ -22,24 +15,21 @@ export async function createGrant(
   username: string,
   role: "owner" | "editor" | "viewer",
 ): Promise<BucketGrant> {
-  const res = await fetch(`${API_BASE}/buckets/${bucketId}/grants`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      ...authHeader(),
+  return apiJson<BucketGrant>(
+    `/buckets/${bucketId}/grants`,
+    "Failed to grant access",
+    {
+      method: "POST",
+      json: {username, role},
     },
-    body: JSON.stringify({ username, role }),
-  });
-  await throwIfNotOk(res, "Failed to grant access");
-  return res.json();
+  );
 }
 
 export async function listGrants(bucketId: string): Promise<BucketGrant[]> {
-  const res = await fetch(`${API_BASE}/buckets/${bucketId}/grants`, {
-    headers: authHeader(),
-  });
-  await throwIfNotOk(res, "Failed to list grants");
-  return res.json();
+  return apiJson<BucketGrant[]>(
+    `/buckets/${bucketId}/grants`,
+    "Failed to list grants",
+  );
 }
 
 export async function updateGrant(
@@ -47,24 +37,23 @@ export async function updateGrant(
   grantId: string,
   role: "owner" | "editor" | "viewer",
 ): Promise<void> {
-  const res = await fetch(`${API_BASE}/buckets/${bucketId}/grants/${grantId}`, {
-    method: "PATCH",
-    headers: {
-      "Content-Type": "application/json",
-      ...authHeader(),
+  await apiFetch(
+    `/buckets/${bucketId}/grants/${grantId}`,
+    "Failed to update grant",
+    {
+      method: "PATCH",
+      json: {role},
     },
-    body: JSON.stringify({ role }),
-  });
-  await throwIfNotOk(res, "Failed to update grant");
+  );
 }
 
 export async function deleteGrant(
   bucketId: string,
   grantId: string,
 ): Promise<void> {
-  const res = await fetch(`${API_BASE}/buckets/${bucketId}/grants/${grantId}`, {
-    method: "DELETE",
-    headers: authHeader(),
-  });
-  await throwIfNotOk(res, "Failed to revoke access");
+  await apiFetch(
+    `/buckets/${bucketId}/grants/${grantId}`,
+    "Failed to revoke access",
+    {method: "DELETE"},
+  );
 }

--- a/webui/src/shared/api/shares.ts
+++ b/webui/src/shared/api/shares.ts
@@ -1,14 +1,4 @@
-const API_BASE = import.meta.env.VITE_API_BASE || "/api/v1";
-
-import { getAuthHeader, getCredentialsOption } from "../lib/auth";
-
-function authHeader(): Record<string, string> {
-  return getAuthHeader();
-}
-
-function credentials(): RequestCredentials | undefined {
-  return getCredentialsOption();
-}
+import {apiFetch, apiJson} from "./client";
 
 export type ShareLinkInfo = {
   id: string;
@@ -25,42 +15,28 @@ export async function createShareLink(
   fileId: string,
   expiresIn?: number,
 ): Promise<ShareLinkInfo> {
-  const res = await fetch(
-    `${API_BASE}/buckets/${bucketId}/files/${fileId}/share`,
+  return apiJson<ShareLinkInfo>(
+    `/buckets/${bucketId}/files/${fileId}/share`,
+    "Failed to create share link",
     {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        ...authHeader(),
-      },
-      credentials: credentials(),
-      body: JSON.stringify(expiresIn ? { expires_in: expiresIn } : {}),
+      json: expiresIn ? {expires_in: expiresIn} : {},
     },
   );
-  if (!res.ok) throw new Error("failed to create share link");
-  return res.json();
 }
 
 export async function listShareLinks(
   bucketId: string,
   fileId: string,
 ): Promise<ShareLinkInfo[]> {
-  const res = await fetch(
-    `${API_BASE}/buckets/${bucketId}/files/${fileId}/shares`,
-    {
-      headers: authHeader(),
-      credentials: credentials(),
-    },
+  return apiJson<ShareLinkInfo[]>(
+    `/buckets/${bucketId}/files/${fileId}/shares`,
+    "Failed to list share links",
   );
-  if (!res.ok) throw new Error("failed to list share links");
-  return res.json();
 }
 
 export async function deleteShareLink(id: string): Promise<void> {
-  const res = await fetch(`${API_BASE}/shares/${id}`, {
+  await apiFetch(`/shares/${id}`, "Failed to delete share link", {
     method: "DELETE",
-    headers: authHeader(),
-    credentials: credentials(),
   });
-  if (!res.ok) throw new Error("failed to delete share link");
 }

--- a/webui/src/shared/api/sources.ts
+++ b/webui/src/shared/api/sources.ts
@@ -1,6 +1,4 @@
-import {throwIfNotOk} from "./error";
-
-const API_BASE = import.meta.env.VITE_API_BASE || "/api/v1";
+import {apiDownload, apiFetch, apiJson} from "./client";
 
 export type Source = {id: string; name: string; type: string; created_at: string};
 
@@ -16,45 +14,29 @@ export type SourceInfo = {
   storage_free: number;
 };
 
-import { getAuthHeader, getCredentialsOption } from "../lib/auth";
-
-function authHeader(): Record<string, string> {
-  return getAuthHeader();
-}
-
-function credentials(): RequestCredentials | undefined {
-  return getCredentialsOption();
-}
-
 export async function listSources(): Promise<Source[]> {
-  const res = await fetch(`${API_BASE}/sources`, {
-    headers: authHeader(),
-    credentials: credentials(),
-  });
-  await throwIfNotOk(res, "Failed to list sources");
-  return res.json() as Promise<Source[]>;
+  return apiJson<Source[]>("/sources", "Failed to list sources");
 }
 
-export async function createGDriveSource(name: string, key: string): Promise<Source> {
-  const res = await fetch(`${API_BASE}/sources/gdrive`, {
+export async function createGDriveSource(
+  name: string,
+  key: string,
+): Promise<Source> {
+  return apiJson<Source>("/sources/gdrive", "Failed to create source", {
     method: "POST",
-    headers: {"Content-Type": "application/json", ...authHeader()},
-    credentials: credentials(),
-    body: JSON.stringify({name, key}),
+    json: {name, key},
   });
-  await throwIfNotOk(res, "Failed to create source");
-  return res.json();
 }
 
-export async function createTelegramSource(name: string, token: string, chatId: string): Promise<Source> {
-  const res = await fetch(`${API_BASE}/sources/telegram`, {
+export async function createTelegramSource(
+  name: string,
+  token: string,
+  chatId: string,
+): Promise<Source> {
+  return apiJson<Source>("/sources/telegram", "Failed to create source", {
     method: "POST",
-    headers: {"Content-Type": "application/json", ...authHeader()},
-    credentials: credentials(),
-    body: JSON.stringify({name, token, chat_id: chatId}),
+    json: {name, token, chat_id: chatId},
   });
-  await throwIfNotOk(res, "Failed to create source");
-  return res.json();
 }
 
 export type CreateS3SourceParams = {
@@ -67,46 +49,35 @@ export type CreateS3SourceParams = {
   path_style?: boolean;
 };
 
-export async function createS3Source(params: CreateS3SourceParams): Promise<Source> {
-  const res = await fetch(`${API_BASE}/sources/s3`, {
+export async function createS3Source(
+  params: CreateS3SourceParams,
+): Promise<Source> {
+  return apiJson<Source>("/sources/s3", "Failed to create source", {
     method: "POST",
-    headers: {"Content-Type": "application/json", ...authHeader()},
-    credentials: credentials(),
-    body: JSON.stringify(params),
+    json: params,
   });
-  await throwIfNotOk(res, "Failed to create source");
-  return res.json();
 }
 
 export async function getSourceInfo(id: string): Promise<SourceInfo> {
-  const res = await fetch(`${API_BASE}/sources/${id}/info`, {
-    headers: authHeader(),
-    credentials: credentials(),
-  });
-  await throwIfNotOk(res, "Failed to get source info");
-  return res.json();
+  return apiJson<SourceInfo>(
+    `/sources/${id}/info`,
+    "Failed to get source info",
+  );
 }
 
 export async function deleteSource(id: string): Promise<void> {
-  const res = await fetch(`${API_BASE}/sources/${id}`, {
+  await apiFetch(`/sources/${id}`, "Failed to delete source", {
     method: "DELETE",
-    headers: authHeader(),
-    credentials: credentials(),
   });
-  await throwIfNotOk(res, "Failed to delete source");
 }
 
-export async function downloadFile(sourceId: string, file: SourceFile): Promise<void> {
-  const res = await fetch(`${API_BASE}/sources/${sourceId}/files/${file.id}/download`, {
-    headers: authHeader(),
-    credentials: credentials(),
-  });
-  await throwIfNotOk(res, "Failed to download file");
-  const blob = await res.blob();
-  const url = window.URL.createObjectURL(blob);
-  const a = document.createElement("a");
-  a.href = url;
-  a.download = file.name;
-  a.click();
-  window.URL.revokeObjectURL(url);
+export async function downloadFile(
+  sourceId: string,
+  file: SourceFile,
+): Promise<void> {
+  await apiDownload(
+    `/sources/${sourceId}/files/${file.id}/download`,
+    file.name,
+    "Failed to download file",
+  );
 }

--- a/webui/src/shared/api/users.ts
+++ b/webui/src/shared/api/users.ts
@@ -1,13 +1,15 @@
-import {throwIfNotOk} from "./error";
+import {apiJson} from "./client";
 
-const API_BASE = import.meta.env.VITE_API_BASE || "/api/v1";
-
-export async function createUser(username: string): Promise<{id: string; created_at: string; password: string}> {
-  const res = await fetch(`${API_BASE}/users`, {
-    method: "POST",
-    headers: {"Content-Type": "application/json"},
-    body: JSON.stringify({username}),
-  });
-  await throwIfNotOk(res, "Failed to create user");
-  return res.json();
+export async function createUser(
+  username: string,
+): Promise<{id: string; created_at: string; password: string}> {
+  return apiJson<{id: string; created_at: string; password: string}>(
+    "/users",
+    "Failed to create user",
+    {
+      auth: false,
+      method: "POST",
+      json: {username},
+    },
+  );
 }


### PR DESCRIPTION
## Summary
- Add `webui/src/shared/api/client.ts` to centralize API base URL resolution, auth header injection, cookie credentials, JSON request bodies, shared `throwIfNotOk` error conversion, and browser downloads.
- Update bucket, source, grant, share-link, and user API modules to use the shared helper instead of assembling `fetch` calls directly.
- Route GitHub auth links through the shared API URL helper so `VITE_API_BASE` resolution stays in one place.

## Behavior
- REST paths and exported response shapes are unchanged.
- Share-link calls now use the same `ApiError`/`throwIfNotOk` path as the other webui API modules.
- Bucket and source downloads still set the anchor `download` filename from the original file name.

## Validation
- Ran `git diff --check` locally.
- Did not run local lint/build/Playwright per task guidance; Woodpecker should run webui validation.