### PR TITLE
THE-490: Add SDK HEAD coverage

### DIFF
--- a/api-go/e2e/sfree_client.py
+++ b/api-go/e2e/sfree_client.py
@@ -304,6 +304,25 @@ class SFreeClient:
             body = await response["Body"].read()
             return {**response, "Body": body}
 
+    async def head_object_s3(
+        self,
+        access_key: str,
+        access_secret: str,
+        bucket_key: str,
+        object_key: str,
+    ) -> dict[str, Any]:
+        session = get_session()
+        async with session.create_client(
+            "s3",
+            **self._s3_client_kwargs(
+                region="us-east-1",
+                endpoint=self.config.s3_url,
+                access_key=access_key,
+                access_secret=access_secret,
+            ),
+        ) as s3_client:
+            return await s3_client.head_object(Bucket=bucket_key, Key=object_key)
+
     async def list_objects_s3(self, access_key: str, access_secret: str, bucket_key: str) -> list[dict[str, Any]]:
         response = await self.list_objects_v2_s3(
             access_key=access_key,

--- a/api-go/e2e/test_api_e2e.py
+++ b/api-go/e2e/test_api_e2e.py
@@ -228,6 +228,30 @@ async def test_s3_sdk_get_object_range_returns_partial_content(client, e2e_conte
     assert response["AcceptRanges"] == "bytes"
 
 
+async def test_s3_sdk_head_object_returns_metadata(client, e2e_context):
+    filename = f"e2e-sdk-head-{uuid4().hex[:8]}.txt"
+    payload = b"sfree sdk head payload"
+
+    await client.upload_file_s3(
+        access_key=e2e_context.access_key,
+        access_secret=e2e_context.access_secret,
+        bucket_key=e2e_context.bucket_key,
+        object_key=filename,
+        content=payload,
+    )
+
+    response = await client.head_object_s3(
+        access_key=e2e_context.access_key,
+        access_secret=e2e_context.access_secret,
+        bucket_key=e2e_context.bucket_key,
+        object_key=filename,
+    )
+    assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
+    assert response["ContentLength"] == len(payload)
+    assert response["ETag"]
+    assert response["LastModified"]
+
+
 async def test_s3_sdk_copy_object_compatibility(client, e2e_context):
     suffix = uuid4().hex[:8]
     source_key = f"e2e-sdk-copy-source-{suffix}.txt"


### PR DESCRIPTION
## Summary
- add aiobotocore `head_object` coverage to the Python S3 compatibility E2E suite
- refresh the branch against current `main` and drop the stale audit-doc changes already covered by #216

## Verification
- `git diff --check`
- Not run locally: CPU-heavy backend/E2E suites are left to Woodpecker per QA policy.