### PR TITLE
THE-493 Make multipart part replacement cleanup atomic

### DIFF
--- a/api-go/internal/handlers/s3_multipart.go
+++ b/api-go/internal/handlers/s3_multipart.go
@@ -288,15 +288,7 @@ func uploadPart(c *gin.Context, bucketRepo *repository.BucketRepository, sourceR
 		return
 	}
 
-	// Delete old part chunks if re-uploading the same part number.
-	for _, p := range mu.Parts {
-		if p.PartNumber == partNum && len(p.Chunks) > 0 {
-			if delErr := manager.DeleteFileChunks(ctx, sourceRepo, p.Chunks); delErr != nil {
-				slog.WarnContext(ctx, "upload part: delete old part chunks", slog.String("error", delErr.Error()))
-			}
-			break
-		}
-	}
+	previousChunks := multipartPartChunks(mu.Parts, partNum)
 
 	selector := manager.SelectorForBucket(bucketDoc, sources)
 	chunks, err := manager.UploadFileChunksWithStrategy(ctx, c.Request.Body, sources, chunkSize, nil, selector)
@@ -327,9 +319,23 @@ func uploadPart(c *gin.Context, bucketRepo *repository.BucketRepository, sourceR
 		writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
 		return
 	}
+	if len(previousChunks) > 0 {
+		if delErr := manager.DeleteFileChunks(ctx, sourceRepo, previousChunks); delErr != nil {
+			slog.WarnContext(ctx, "upload part: delete replaced part chunks", slog.String("error", delErr.Error()))
+		}
+	}
 
 	c.Header("ETag", etag)
 	c.Status(http.StatusOK)
+}
+
+func multipartPartChunks(parts []repository.UploadPart, partNumber int) []repository.FileChunk {
+	for _, part := range parts {
+		if part.PartNumber == partNumber {
+			return part.Chunks
+		}
+	}
+	return nil
 }
 
 func completeMultipartUpload(c *gin.Context, bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository, mpRepo *repository.MultipartUploadRepository) {

--- a/api-go/internal/handlers/s3_multipart_test.go
+++ b/api-go/internal/handlers/s3_multipart_test.go
@@ -210,6 +210,34 @@ func TestCompletedMultipartChunksPreservesChecksums(t *testing.T) {
 	}
 }
 
+func TestMultipartPartChunksReturnsReplacedPartChunks(t *testing.T) {
+	t.Parallel()
+
+	sourceID := primitive.NewObjectID()
+	parts := []repository.UploadPart{
+		{
+			PartNumber: 1,
+			Chunks: []repository.FileChunk{
+				{SourceID: sourceID, Name: "part-1-old", Order: 0, Size: 5},
+			},
+		},
+		{
+			PartNumber: 2,
+			Chunks: []repository.FileChunk{
+				{SourceID: sourceID, Name: "part-2-kept", Order: 1, Size: 7},
+			},
+		},
+	}
+
+	got := multipartPartChunks(parts, 1)
+	if len(got) != 1 || got[0].Name != "part-1-old" {
+		t.Fatalf("expected previous chunks for replaced part, got %+v", got)
+	}
+	if got := multipartPartChunks(parts, 3); got != nil {
+		t.Fatalf("expected nil chunks for new part, got %+v", got)
+	}
+}
+
 func TestListMultipartUploadsResultXML(t *testing.T) {
 	t.Parallel()
 

--- a/api-go/internal/handlers/s3_test.go
+++ b/api-go/internal/handlers/s3_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/example/sfree/api-go/internal/manager"
 	"github.com/example/sfree/api-go/internal/repository"
 	"github.com/gin-gonic/gin"
 	"go.mongodb.org/mongo-driver/bson/primitive"
@@ -187,13 +188,13 @@ func TestFileListBucketEntryAndObjectETag(t *testing.T) {
 	if !strings.HasPrefix(entry.ETag, "\"") || !strings.HasSuffix(entry.ETag, "\"") {
 		t.Fatalf("expected quoted ETag, got %q", entry.ETag)
 	}
-	if entry.ETag != objectETag(file) {
-		t.Fatalf("expected entry ETag to match objectETag")
+	if entry.ETag != manager.ObjectETag(file) {
+		t.Fatalf("expected entry ETag to match ObjectETag")
 	}
 
 	changed := file
 	changed.Chunks[1].Size = 6
-	if objectETag(changed) == entry.ETag {
+	if manager.ObjectETag(changed) == entry.ETag {
 		t.Fatal("expected ETag to change when chunk metadata changes")
 	}
 }

--- a/api-go/internal/repository/multipart.go
+++ b/api-go/internal/repository/multipart.go
@@ -88,20 +88,27 @@ func (r *MultipartUploadRepository) ListByBucket(ctx context.Context, bucketID p
 	return uploads, cursor.Err()
 }
 
-// SetPart atomically replaces or inserts a part for the given upload.
-// It removes any existing part with the same part_number, then pushes the new one.
 func (r *MultipartUploadRepository) SetPart(ctx context.Context, uploadID string, part UploadPart) error {
-	// First pull any existing part with this number, then push the new one.
-	_, err := r.coll.UpdateOne(ctx,
-		bson.M{"upload_id": uploadID},
-		bson.M{"$pull": bson.M{"parts": bson.M{"part_number": part.PartNumber}}},
-	)
-	if err != nil {
-		return err
+	partDoc := bson.D{
+		{Key: "part_number", Value: part.PartNumber},
+		{Key: "etag", Value: part.ETag},
+		{Key: "size", Value: part.Size},
+		{Key: "chunks", Value: part.Chunks},
 	}
+	partArrayValue := bson.D{{Key: "$literal", Value: bson.A{partDoc}}}
+	partsOrEmpty := bson.D{{Key: "$ifNull", Value: bson.A{"$parts", bson.A{}}}}
+	otherParts := bson.D{{Key: "$filter", Value: bson.D{
+		{Key: "input", Value: partsOrEmpty},
+		{Key: "as", Value: "part"},
+		{Key: "cond", Value: bson.D{{Key: "$ne", Value: bson.A{"$$part.part_number", part.PartNumber}}}},
+	}}}
+	partsExpr := bson.D{{Key: "$concatArrays", Value: bson.A{otherParts, partArrayValue}}}
+
 	res, err := r.coll.UpdateOne(ctx,
 		bson.M{"upload_id": uploadID},
-		bson.M{"$push": bson.M{"parts": part}},
+		mongo.Pipeline{
+			bson.D{{Key: "$set", Value: bson.D{{Key: "parts", Value: partsExpr}}}},
+		},
 	)
 	if err != nil {
 		return err

--- a/api-go/internal/repository/multipart_test.go
+++ b/api-go/internal/repository/multipart_test.go
@@ -1,0 +1,141 @@
+//go:build integration
+// +build integration
+
+package repository
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/example/sfree/api-go/internal/config"
+	"github.com/example/sfree/api-go/internal/db"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+func TestMultipartUploadRepositorySetPartReplacesWithoutDroppingParts(t *testing.T) {
+	_, repo := newMultipartRepositoryTestDB(t)
+
+	ctx := context.Background()
+	bucketID := primitive.NewObjectID()
+	sourceID := primitive.NewObjectID()
+	uploadID := "upload-" + primitive.NewObjectID().Hex()
+	created, err := repo.Create(ctx, MultipartUpload{
+		BucketID:  bucketID,
+		ObjectKey: "object.bin",
+		UploadID:  uploadID,
+		Parts: []UploadPart{
+			{
+				PartNumber: 1,
+				ETag:       `"old"`,
+				Size:       5,
+				Chunks:     []FileChunk{{SourceID: sourceID, Name: "old-part-1", Order: 0, Size: 5}},
+			},
+			{
+				PartNumber: 1,
+				ETag:       `"duplicate-old"`,
+				Size:       6,
+				Chunks:     []FileChunk{{SourceID: sourceID, Name: "duplicate-old-part-1", Order: 1, Size: 6}},
+			},
+			{
+				PartNumber: 2,
+				ETag:       `"kept"`,
+				Size:       7,
+				Chunks:     []FileChunk{{SourceID: sourceID, Name: "kept-part-2", Order: 2, Size: 7}},
+			},
+		},
+		CreatedAt: time.Now(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	replacement := UploadPart{
+		PartNumber: 1,
+		ETag:       `"new"`,
+		Size:       9,
+		Chunks:     []FileChunk{{SourceID: sourceID, Name: "new-part-1", Order: 0, Size: 9}},
+	}
+	if err := repo.SetPart(ctx, uploadID, replacement); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := repo.GetByUploadID(ctx, uploadID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ID != created.ID {
+		t.Fatalf("expected upload id %s, got %s", created.ID.Hex(), got.ID.Hex())
+	}
+	if len(got.Parts) != 2 {
+		t.Fatalf("expected exactly 2 parts after replacement, got %+v", got.Parts)
+	}
+	assertMultipartPart(t, got.Parts, 1, `"new"`, "new-part-1")
+	assertMultipartPart(t, got.Parts, 2, `"kept"`, "kept-part-2")
+
+	added := UploadPart{
+		PartNumber: 3,
+		ETag:       `"added"`,
+		Size:       11,
+		Chunks:     []FileChunk{{SourceID: sourceID, Name: "added-part-3", Order: 2, Size: 11}},
+	}
+	if err := repo.SetPart(ctx, uploadID, added); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err = repo.GetByUploadID(ctx, uploadID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Parts) != 3 {
+		t.Fatalf("expected 3 parts after insert, got %+v", got.Parts)
+	}
+	assertMultipartPart(t, got.Parts, 1, `"new"`, "new-part-1")
+	assertMultipartPart(t, got.Parts, 2, `"kept"`, "kept-part-2")
+	assertMultipartPart(t, got.Parts, 3, `"added"`, "added-part-3")
+
+	err = repo.SetPart(ctx, "missing-upload", added)
+	if err != mongo.ErrNoDocuments {
+		t.Fatalf("expected ErrNoDocuments for missing upload, got %v", err)
+	}
+}
+
+func assertMultipartPart(t *testing.T, parts []UploadPart, partNumber int, etag string, chunkName string) {
+	t.Helper()
+	for _, part := range parts {
+		if part.PartNumber != partNumber {
+			continue
+		}
+		if part.ETag != etag {
+			t.Fatalf("part %d etag: got %q, want %q", partNumber, part.ETag, etag)
+		}
+		if len(part.Chunks) != 1 || part.Chunks[0].Name != chunkName {
+			t.Fatalf("part %d chunks: got %+v, want %q", partNumber, part.Chunks, chunkName)
+		}
+		return
+	}
+	t.Fatalf("missing part %d in %+v", partNumber, parts)
+}
+
+func newMultipartRepositoryTestDB(t *testing.T) (*mongo.Database, *MultipartUploadRepository) {
+	t.Helper()
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	mongoConn, err := db.Connect(context.Background(), cfg.Mongo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	testDB := mongoConn.Client.Database("sfree_multipart_repository_" + primitive.NewObjectID().Hex())
+	t.Cleanup(func() {
+		_ = testDB.Drop(context.Background())
+		_ = mongoConn.Close(context.Background())
+	})
+	repo, err := NewMultipartUploadRepository(testDB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return testDB, repo
+}


### PR DESCRIPTION
## Summary
- keep previous multipart part chunks until the replacement upload is successfully recorded
- replace multipart parts with a single MongoDB update pipeline that filters out all existing entries for the part number and appends exactly one replacement
- add focused coverage for replacement chunk selection and multipart repository replacement semantics, including duplicate historical part entries
- update the S3 ETag test to call the current `manager.ObjectETag` helper so api-go typecheck can compile the handlers test package

## Validation
- Local Go tests/lint/builds were not run per task/resource policy; Woodpecker should validate backend checks.

Closes THE-493