### PR TITLE
THE-484: Clean bucket contents on delete

### DIFF
--- a/api-go/internal/app/router_routes.go
+++ b/api-go/internal/app/router_routes.go
@@ -53,7 +53,7 @@ func registerBucketRoutes(router *gin.Engine, cfg *config.Config, deps *routerDe
 	}
 	router.POST("/api/v1/buckets", deps.auth, handlers.CreateBucket(deps.bucketRepo, deps.sourceRepo, routerAccessSecret(cfg)))
 	router.GET("/api/v1/buckets", deps.auth, handlers.ListBuckets(deps.bucketRepo, deps.grantRepo))
-	router.DELETE("/api/v1/buckets/:id", deps.auth, handlers.DeleteBucket(deps.bucketRepo, deps.grantRepo))
+	router.DELETE("/api/v1/buckets/:id", deps.auth, handlers.DeleteBucket(deps.bucketRepo, deps.sourceRepo, deps.fileRepo, deps.mpRepo, deps.grantRepo))
 	router.PATCH("/api/v1/buckets/:id/distribution", deps.auth, handlers.UpdateBucketDistribution(deps.bucketRepo, deps.grantRepo))
 
 	registerBucketGrantRoutes(router, deps)

--- a/api-go/internal/handlers/bucket.go
+++ b/api-go/internal/handlers/bucket.go
@@ -245,7 +245,7 @@ func ListBuckets(repo *repository.BucketRepository, grantRepo *repository.Bucket
 // @Failure 500 {string} string ""
 // @Security BasicAuth
 // @Router /api/v1/buckets/{id} [delete]
-func DeleteBucket(repo *repository.BucketRepository, grantRepo *repository.BucketGrantRepository) gin.HandlerFunc {
+func DeleteBucket(repo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository, mpRepo *repository.MultipartUploadRepository, grantRepo *repository.BucketGrantRepository) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		ctx := c.Request.Context()
 		if repo == nil {
@@ -256,6 +256,18 @@ func DeleteBucket(repo *repository.BucketRepository, grantRepo *repository.Bucke
 
 		acc := requireBucketAccess(c, repo, grantRepo, repository.RoleOwner)
 		if acc == nil {
+			return
+		}
+
+		if sourceRepo == nil || fileRepo == nil || mpRepo == nil {
+			slog.ErrorContext(ctx, "delete bucket: cleanup repository is nil")
+			c.Status(http.StatusServiceUnavailable)
+			return
+		}
+		objectSvc := manager.NewObjectService(sourceRepo, fileRepo, mpRepo)
+		if _, err := objectSvc.DeleteBucketContents(ctx, acc.Bucket.ID); err != nil {
+			slog.ErrorContext(ctx, "delete bucket: cleanup contents", slog.String("error", err.Error()))
+			c.Status(http.StatusInternalServerError)
 			return
 		}
 

--- a/api-go/internal/handlers/bucket.go
+++ b/api-go/internal/handlers/bucket.go
@@ -259,7 +259,7 @@ func DeleteBucket(repo *repository.BucketRepository, sourceRepo *repository.Sour
 			return
 		}
 
-		if sourceRepo == nil || fileRepo == nil || mpRepo == nil {
+		if sourceRepo == nil || fileRepo == nil {
 			slog.ErrorContext(ctx, "delete bucket: cleanup repository is nil")
 			c.Status(http.StatusServiceUnavailable)
 			return

--- a/api-go/internal/handlers/unit_test.go
+++ b/api-go/internal/handlers/unit_test.go
@@ -320,7 +320,7 @@ func TestListBucketsNoUserID(t *testing.T) {
 func TestDeleteBucketNilRepo(t *testing.T) {
 	t.Parallel()
 	r := gin.New()
-	r.DELETE("/buckets/:id", DeleteBucket(nil, nil))
+	r.DELETE("/buckets/:id", DeleteBucket(nil, nil, nil, nil, nil))
 
 	req, _ := http.NewRequest(http.MethodDelete, "/buckets/"+primitive.NewObjectID().Hex(), nil)
 	w := httptest.NewRecorder()
@@ -336,7 +336,7 @@ func TestDeleteBucketInvalidIDParam(t *testing.T) {
 	r := gin.New()
 	r.DELETE("/buckets/:id",
 		setUserID(validUserID()),
-		DeleteBucket(&repository.BucketRepository{}, nil),
+		DeleteBucket(&repository.BucketRepository{}, nil, nil, nil, nil),
 	)
 
 	req, _ := http.NewRequest(http.MethodDelete, "/buckets/not-a-valid-oid", nil)

--- a/api-go/internal/manager/s3_object.go
+++ b/api-go/internal/manager/s3_object.go
@@ -80,8 +80,13 @@ type ChunkReferenceCounter interface {
 	CountByChunk(ctx context.Context, sourceID primitive.ObjectID, name string) (int64, error)
 }
 
-type objectFileStore interface {
+type BucketScopedChunkReferenceCounter interface {
 	ChunkReferenceCounter
+	CountByChunkExcludingBucket(ctx context.Context, bucketID, sourceID primitive.ObjectID, name string) (int64, error)
+}
+
+type objectFileStore interface {
+	BucketScopedChunkReferenceCounter
 	GetByName(ctx context.Context, bucketID primitive.ObjectID, name string) (*repository.File, error)
 	ListByBucket(ctx context.Context, bucketID primitive.ObjectID) ([]repository.File, error)
 	ReplaceByName(ctx context.Context, f repository.File) (*repository.File, *repository.File, error)
@@ -93,6 +98,7 @@ type objectMultipartStore interface {
 	GetByUploadID(ctx context.Context, uploadID string) (*repository.MultipartUpload, error)
 	ListByBucket(ctx context.Context, bucketID primitive.ObjectID) ([]repository.MultipartUpload, error)
 	CountByPartChunk(ctx context.Context, sourceID primitive.ObjectID, name string) (int64, error)
+	CountByPartChunkExcludingBucket(ctx context.Context, bucketID, sourceID primitive.ObjectID, name string) (int64, error)
 	Delete(ctx context.Context, uploadID string) error
 	DeleteByBucket(ctx context.Context, bucketID primitive.ObjectID) error
 }
@@ -217,6 +223,9 @@ func (s *ObjectService) DeleteBucketContents(ctx context.Context, bucketID primi
 	}
 
 	chunks := bucketCleanupChunks(files, uploads)
+	if err := s.deleteBucketChunksIfUnreferenced(ctx, bucketID, chunks); err != nil {
+		return DeleteBucketContentsResult{}, err
+	}
 	if err := s.files.DeleteByBucket(ctx, bucketID); err != nil {
 		return DeleteBucketContentsResult{}, err
 	}
@@ -224,9 +233,6 @@ func (s *ObjectService) DeleteBucketContents(ctx context.Context, bucketID primi
 		if err := s.multipart.DeleteByBucket(ctx, bucketID); err != nil {
 			return DeleteBucketContentsResult{}, err
 		}
-	}
-	if err := s.deleteBucketChunksIfUnreferenced(ctx, chunks); err != nil {
-		return DeleteBucketContentsResult{}, err
 	}
 	return DeleteBucketContentsResult{
 		FilesDeleted:            len(files),
@@ -333,8 +339,8 @@ func (s *ObjectService) deleteFileChunksIfUnreferenced(ctx context.Context, chun
 	return deleteFileChunksIfUnreferenced(ctx, s.files, s.deleteChunks, chunks)
 }
 
-func (s *ObjectService) deleteBucketChunksIfUnreferenced(ctx context.Context, chunks []repository.FileChunk) error {
-	return deleteBucketChunksIfUnreferenced(ctx, s.files, s.multipart, s.deleteChunks, chunks)
+func (s *ObjectService) deleteBucketChunksIfUnreferenced(ctx context.Context, bucketID primitive.ObjectID, chunks []repository.FileChunk) error {
+	return deleteBucketChunksIfUnreferenced(ctx, bucketID, s.files, s.multipart, s.deleteChunks, chunks)
 }
 
 func DeleteFileChunksIfUnreferenced(ctx context.Context, sourceRepo *repository.SourceRepository, fileStore ChunkReferenceCounter, chunks []repository.FileChunk) error {
@@ -365,7 +371,7 @@ func deleteFileChunksIfUnreferenced(ctx context.Context, files ChunkReferenceCou
 	return nil
 }
 
-func deleteBucketChunksIfUnreferenced(ctx context.Context, files ChunkReferenceCounter, multipart objectMultipartStore, deleteChunks objectChunkDeleter, chunks []repository.FileChunk) error {
+func deleteBucketChunksIfUnreferenced(ctx context.Context, bucketID primitive.ObjectID, files BucketScopedChunkReferenceCounter, multipart objectMultipartStore, deleteChunks objectChunkDeleter, chunks []repository.FileChunk) error {
 	seen := make(map[string]struct{}, len(chunks))
 	for _, chunk := range chunks {
 		ref := chunk.SourceID.Hex() + "/" + chunk.Name
@@ -373,7 +379,7 @@ func deleteBucketChunksIfUnreferenced(ctx context.Context, files ChunkReferenceC
 			continue
 		}
 		seen[ref] = struct{}{}
-		count, err := files.CountByChunk(ctx, chunk.SourceID, chunk.Name)
+		count, err := files.CountByChunkExcludingBucket(ctx, bucketID, chunk.SourceID, chunk.Name)
 		if err != nil {
 			return err
 		}
@@ -381,7 +387,7 @@ func deleteBucketChunksIfUnreferenced(ctx context.Context, files ChunkReferenceC
 			continue
 		}
 		if multipart != nil {
-			count, err = multipart.CountByPartChunk(ctx, chunk.SourceID, chunk.Name)
+			count, err = multipart.CountByPartChunkExcludingBucket(ctx, bucketID, chunk.SourceID, chunk.Name)
 			if err != nil {
 				return err
 			}

--- a/api-go/internal/manager/s3_object.go
+++ b/api-go/internal/manager/s3_object.go
@@ -67,6 +67,11 @@ type CompleteMultipartUploadResult struct {
 	CleanupErrs []error
 }
 
+type DeleteBucketContentsResult struct {
+	FilesDeleted            int
+	MultipartUploadsDeleted int
+}
+
 type objectSourceStore interface {
 	ListByIDs(ctx context.Context, ids []primitive.ObjectID) ([]repository.Source, error)
 }
@@ -78,13 +83,18 @@ type ChunkReferenceCounter interface {
 type objectFileStore interface {
 	ChunkReferenceCounter
 	GetByName(ctx context.Context, bucketID primitive.ObjectID, name string) (*repository.File, error)
+	ListByBucket(ctx context.Context, bucketID primitive.ObjectID) ([]repository.File, error)
 	ReplaceByName(ctx context.Context, f repository.File) (*repository.File, *repository.File, error)
 	Delete(ctx context.Context, id primitive.ObjectID) error
+	DeleteByBucket(ctx context.Context, bucketID primitive.ObjectID) error
 }
 
 type objectMultipartStore interface {
 	GetByUploadID(ctx context.Context, uploadID string) (*repository.MultipartUpload, error)
+	ListByBucket(ctx context.Context, bucketID primitive.ObjectID) ([]repository.MultipartUpload, error)
+	CountByPartChunk(ctx context.Context, sourceID primitive.ObjectID, name string) (int64, error)
 	Delete(ctx context.Context, uploadID string) error
+	DeleteByBucket(ctx context.Context, bucketID primitive.ObjectID) error
 }
 
 type objectChunkUploader func(ctx context.Context, r io.Reader, sources []repository.Source, chunkSize int, selector SourceSelector) ([]repository.FileChunk, error)
@@ -101,15 +111,17 @@ type ObjectService struct {
 
 func NewObjectService(sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository, mpRepo *repository.MultipartUploadRepository) *ObjectService {
 	svc := &ObjectService{
-		sources:   sourceRepo,
-		files:     fileRepo,
-		multipart: mpRepo,
+		sources: sourceRepo,
+		files:   fileRepo,
 		uploadChunks: func(ctx context.Context, r io.Reader, sources []repository.Source, chunkSize int, selector SourceSelector) ([]repository.FileChunk, error) {
 			return UploadFileChunksWithStrategy(ctx, r, sources, chunkSize, nil, selector)
 		},
 		now: func() time.Time {
 			return time.Now().UTC()
 		},
+	}
+	if mpRepo != nil {
+		svc.multipart = mpRepo
 	}
 	svc.deleteChunks = func(ctx context.Context, chunks []repository.FileChunk) error {
 		return DeleteFileChunks(ctx, sourceRepo, chunks)
@@ -187,6 +199,38 @@ func (s *ObjectService) DeleteObject(ctx context.Context, bucketID primitive.Obj
 	return DeleteObjectResult{
 		Deleted:    true,
 		CleanupErr: s.deleteFileChunksIfUnreferenced(ctx, fileDoc.Chunks),
+	}, nil
+}
+
+func (s *ObjectService) DeleteBucketContents(ctx context.Context, bucketID primitive.ObjectID) (DeleteBucketContentsResult, error) {
+	files, err := s.files.ListByBucket(ctx, bucketID)
+	if err != nil {
+		return DeleteBucketContentsResult{}, err
+	}
+
+	var uploads []repository.MultipartUpload
+	if s.multipart != nil {
+		uploads, err = s.multipart.ListByBucket(ctx, bucketID)
+		if err != nil {
+			return DeleteBucketContentsResult{}, err
+		}
+	}
+
+	chunks := bucketCleanupChunks(files, uploads)
+	if err := s.files.DeleteByBucket(ctx, bucketID); err != nil {
+		return DeleteBucketContentsResult{}, err
+	}
+	if s.multipart != nil {
+		if err := s.multipart.DeleteByBucket(ctx, bucketID); err != nil {
+			return DeleteBucketContentsResult{}, err
+		}
+	}
+	if err := s.deleteBucketChunksIfUnreferenced(ctx, chunks); err != nil {
+		return DeleteBucketContentsResult{}, err
+	}
+	return DeleteBucketContentsResult{
+		FilesDeleted:            len(files),
+		MultipartUploadsDeleted: len(uploads),
 	}, nil
 }
 
@@ -289,6 +333,10 @@ func (s *ObjectService) deleteFileChunksIfUnreferenced(ctx context.Context, chun
 	return deleteFileChunksIfUnreferenced(ctx, s.files, s.deleteChunks, chunks)
 }
 
+func (s *ObjectService) deleteBucketChunksIfUnreferenced(ctx context.Context, chunks []repository.FileChunk) error {
+	return deleteBucketChunksIfUnreferenced(ctx, s.files, s.multipart, s.deleteChunks, chunks)
+}
+
 func DeleteFileChunksIfUnreferenced(ctx context.Context, sourceRepo *repository.SourceRepository, fileStore ChunkReferenceCounter, chunks []repository.FileChunk) error {
 	return deleteFileChunksIfUnreferenced(ctx, fileStore, func(ctx context.Context, chunks []repository.FileChunk) error {
 		return DeleteFileChunks(ctx, sourceRepo, chunks)
@@ -315,6 +363,50 @@ func deleteFileChunksIfUnreferenced(ctx context.Context, files ChunkReferenceCou
 		}
 	}
 	return nil
+}
+
+func deleteBucketChunksIfUnreferenced(ctx context.Context, files ChunkReferenceCounter, multipart objectMultipartStore, deleteChunks objectChunkDeleter, chunks []repository.FileChunk) error {
+	seen := make(map[string]struct{}, len(chunks))
+	for _, chunk := range chunks {
+		ref := chunk.SourceID.Hex() + "/" + chunk.Name
+		if _, ok := seen[ref]; ok {
+			continue
+		}
+		seen[ref] = struct{}{}
+		count, err := files.CountByChunk(ctx, chunk.SourceID, chunk.Name)
+		if err != nil {
+			return err
+		}
+		if count > 0 {
+			continue
+		}
+		if multipart != nil {
+			count, err = multipart.CountByPartChunk(ctx, chunk.SourceID, chunk.Name)
+			if err != nil {
+				return err
+			}
+			if count > 0 {
+				continue
+			}
+		}
+		if err := deleteChunks(ctx, []repository.FileChunk{chunk}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func bucketCleanupChunks(files []repository.File, uploads []repository.MultipartUpload) []repository.FileChunk {
+	var chunks []repository.FileChunk
+	for _, file := range files {
+		chunks = append(chunks, file.Chunks...)
+	}
+	for _, upload := range uploads {
+		for _, part := range upload.Parts {
+			chunks = append(chunks, part.Chunks...)
+		}
+	}
+	return chunks
 }
 
 func ObjectETag(file repository.File) string {

--- a/api-go/internal/manager/s3_object_test.go
+++ b/api-go/internal/manager/s3_object_test.go
@@ -125,6 +125,25 @@ func (f *fakeObjectFiles) CountByChunk(_ context.Context, sourceID primitive.Obj
 	return count, nil
 }
 
+func (f *fakeObjectFiles) CountByChunkExcludingBucket(_ context.Context, bucketID, sourceID primitive.ObjectID, name string) (int64, error) {
+	if f.countErr != nil {
+		return 0, f.countErr
+	}
+	var count int64
+	for _, file := range f.byName {
+		if file.BucketID == bucketID {
+			continue
+		}
+		for _, chunk := range file.Chunks {
+			if chunk.SourceID == sourceID && chunk.Name == name {
+				count++
+				break
+			}
+		}
+	}
+	return count, nil
+}
+
 type fakeMultipartUploads struct {
 	uploads map[string]repository.MultipartUpload
 	delErr  error
@@ -166,6 +185,24 @@ func (f *fakeMultipartUploads) ListByBucket(_ context.Context, bucketID primitiv
 func (f *fakeMultipartUploads) CountByPartChunk(_ context.Context, sourceID primitive.ObjectID, name string) (int64, error) {
 	var count int64
 	for _, upload := range f.uploads {
+		for _, part := range upload.Parts {
+			for _, chunk := range part.Chunks {
+				if chunk.SourceID == sourceID && chunk.Name == name {
+					count++
+					break
+				}
+			}
+		}
+	}
+	return count, nil
+}
+
+func (f *fakeMultipartUploads) CountByPartChunkExcludingBucket(_ context.Context, bucketID, sourceID primitive.ObjectID, name string) (int64, error) {
+	var count int64
+	for _, upload := range f.uploads {
+		if upload.BucketID == bucketID {
+			continue
+		}
 		for _, part := range upload.Parts {
 			for _, chunk := range part.Chunks {
 				if chunk.SourceID == sourceID && chunk.Name == name {
@@ -433,6 +470,9 @@ func TestObjectServiceDeleteBucketContentsReturnsChunkCleanupError(t *testing.T)
 	_, err := svc.DeleteBucketContents(context.Background(), bucketID)
 	if !errors.Is(err, cleanupErr) {
 		t.Fatalf("expected cleanup error, got %v", err)
+	}
+	if _, err := files.GetByName(context.Background(), bucketID, "object.txt"); err != nil {
+		t.Fatalf("expected file metadata to remain after cleanup failure, got %v", err)
 	}
 }
 

--- a/api-go/internal/manager/s3_object_test.go
+++ b/api-go/internal/manager/s3_object_test.go
@@ -31,6 +31,7 @@ type fakeObjectFiles struct {
 	countErr   error
 	replaceErr error
 	deleteErr  error
+	listErr    error
 }
 
 func newFakeObjectFiles(files ...repository.File) *fakeObjectFiles {
@@ -83,6 +84,31 @@ func (f *fakeObjectFiles) Delete(_ context.Context, id primitive.ObjectID) error
 	return mongo.ErrNoDocuments
 }
 
+func (f *fakeObjectFiles) ListByBucket(_ context.Context, bucketID primitive.ObjectID) ([]repository.File, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	var files []repository.File
+	for _, file := range f.byName {
+		if file.BucketID == bucketID {
+			files = append(files, file)
+		}
+	}
+	return files, nil
+}
+
+func (f *fakeObjectFiles) DeleteByBucket(_ context.Context, bucketID primitive.ObjectID) error {
+	if f.deleteErr != nil {
+		return f.deleteErr
+	}
+	for key, file := range f.byName {
+		if file.BucketID == bucketID {
+			delete(f.byName, key)
+		}
+	}
+	return nil
+}
+
 func (f *fakeObjectFiles) CountByChunk(_ context.Context, sourceID primitive.ObjectID, name string) (int64, error) {
 	if f.countErr != nil {
 		return 0, f.countErr
@@ -102,6 +128,7 @@ func (f *fakeObjectFiles) CountByChunk(_ context.Context, sourceID primitive.Obj
 type fakeMultipartUploads struct {
 	uploads map[string]repository.MultipartUpload
 	delErr  error
+	listErr error
 }
 
 func (f *fakeMultipartUploads) GetByUploadID(_ context.Context, uploadID string) (*repository.MultipartUpload, error) {
@@ -120,6 +147,46 @@ func (f *fakeMultipartUploads) Delete(_ context.Context, uploadID string) error 
 		return mongo.ErrNoDocuments
 	}
 	delete(f.uploads, uploadID)
+	return nil
+}
+
+func (f *fakeMultipartUploads) ListByBucket(_ context.Context, bucketID primitive.ObjectID) ([]repository.MultipartUpload, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	var uploads []repository.MultipartUpload
+	for _, upload := range f.uploads {
+		if upload.BucketID == bucketID {
+			uploads = append(uploads, upload)
+		}
+	}
+	return uploads, nil
+}
+
+func (f *fakeMultipartUploads) CountByPartChunk(_ context.Context, sourceID primitive.ObjectID, name string) (int64, error) {
+	var count int64
+	for _, upload := range f.uploads {
+		for _, part := range upload.Parts {
+			for _, chunk := range part.Chunks {
+				if chunk.SourceID == sourceID && chunk.Name == name {
+					count++
+					break
+				}
+			}
+		}
+	}
+	return count, nil
+}
+
+func (f *fakeMultipartUploads) DeleteByBucket(_ context.Context, bucketID primitive.ObjectID) error {
+	if f.delErr != nil {
+		return f.delErr
+	}
+	for uploadID, upload := range f.uploads {
+		if upload.BucketID == bucketID {
+			delete(f.uploads, uploadID)
+		}
+	}
 	return nil
 }
 
@@ -280,6 +347,92 @@ func TestObjectServiceDeleteObjectRemovesMetadataAndUnreferencedChunks(t *testin
 	}
 	if _, err := files.GetByName(context.Background(), bucketID, "object.txt"); !errors.Is(err, mongo.ErrNoDocuments) {
 		t.Fatalf("expected metadata delete, got %v", err)
+	}
+}
+
+func TestObjectServiceDeleteBucketContentsRemovesMetadataAndUnreferencedChunks(t *testing.T) {
+	bucketID := primitive.NewObjectID()
+	otherBucketID := primitive.NewObjectID()
+	sourceID := primitive.NewObjectID()
+	fileOnlyChunk := repository.FileChunk{SourceID: sourceID, Name: "file-only", Size: 3}
+	fileSharedChunk := repository.FileChunk{SourceID: sourceID, Name: "file-shared", Size: 5}
+	partOnlyChunk := repository.FileChunk{SourceID: sourceID, Name: "part-only", Size: 7}
+	partSharedChunk := repository.FileChunk{SourceID: sourceID, Name: "part-shared", Size: 11}
+	files := newFakeObjectFiles(
+		repository.File{ID: primitive.NewObjectID(), BucketID: bucketID, Name: "object.txt", Chunks: []repository.FileChunk{fileOnlyChunk, fileSharedChunk}},
+		repository.File{ID: primitive.NewObjectID(), BucketID: otherBucketID, Name: "survivor.txt", Chunks: []repository.FileChunk{fileSharedChunk}},
+	)
+	uploads := &fakeMultipartUploads{uploads: map[string]repository.MultipartUpload{
+		"delete-upload": {
+			BucketID:  bucketID,
+			ObjectKey: "pending.txt",
+			UploadID:  "delete-upload",
+			Parts: []repository.UploadPart{
+				{PartNumber: 1, Chunks: []repository.FileChunk{partOnlyChunk, partSharedChunk}},
+			},
+		},
+		"survivor-upload": {
+			BucketID:  otherBucketID,
+			ObjectKey: "other-pending.txt",
+			UploadID:  "survivor-upload",
+			Parts: []repository.UploadPart{
+				{PartNumber: 1, Chunks: []repository.FileChunk{partSharedChunk}},
+			},
+		},
+	}}
+	var deleted []repository.FileChunk
+	svc := testObjectService(files, &deleted)
+	svc.multipart = uploads
+
+	result, err := svc.DeleteBucketContents(context.Background(), bucketID)
+	if err != nil {
+		t.Fatalf("DeleteBucketContents returned error: %v", err)
+	}
+	if result.FilesDeleted != 1 || result.MultipartUploadsDeleted != 1 {
+		t.Fatalf("unexpected delete counts: %+v", result)
+	}
+	if _, err := files.GetByName(context.Background(), bucketID, "object.txt"); !errors.Is(err, mongo.ErrNoDocuments) {
+		t.Fatalf("expected deleted bucket file metadata to be removed, got %v", err)
+	}
+	if _, err := files.GetByName(context.Background(), otherBucketID, "survivor.txt"); err != nil {
+		t.Fatalf("expected other bucket file metadata to remain, got %v", err)
+	}
+	if _, err := uploads.GetByUploadID(context.Background(), "delete-upload"); !errors.Is(err, mongo.ErrNoDocuments) {
+		t.Fatalf("expected deleted bucket multipart metadata to be removed, got %v", err)
+	}
+	if _, err := uploads.GetByUploadID(context.Background(), "survivor-upload"); err != nil {
+		t.Fatalf("expected other bucket multipart metadata to remain, got %v", err)
+	}
+	deletedNames := make(map[string]bool, len(deleted))
+	for _, chunk := range deleted {
+		deletedNames[chunk.Name] = true
+	}
+	if !deletedNames[fileOnlyChunk.Name] || !deletedNames[partOnlyChunk.Name] {
+		t.Fatalf("expected unreferenced chunks to be deleted, got %#v", deleted)
+	}
+	if deletedNames[fileSharedChunk.Name] || deletedNames[partSharedChunk.Name] {
+		t.Fatalf("expected shared chunks to remain, got %#v", deleted)
+	}
+}
+
+func TestObjectServiceDeleteBucketContentsReturnsChunkCleanupError(t *testing.T) {
+	bucketID := primitive.NewObjectID()
+	cleanupErr := errors.New("delete chunks failed")
+	files := newFakeObjectFiles(repository.File{
+		ID:       primitive.NewObjectID(),
+		BucketID: bucketID,
+		Name:     "object.txt",
+		Chunks:   []repository.FileChunk{{SourceID: primitive.NewObjectID(), Name: "delete-me", Size: 3}},
+	})
+	var deleted []repository.FileChunk
+	svc := testObjectService(files, &deleted)
+	svc.deleteChunks = func(context.Context, []repository.FileChunk) error {
+		return cleanupErr
+	}
+
+	_, err := svc.DeleteBucketContents(context.Background(), bucketID)
+	if !errors.Is(err, cleanupErr) {
+		t.Fatalf("expected cleanup error, got %v", err)
 	}
 }
 

--- a/api-go/internal/manager/s3_object_test.go
+++ b/api-go/internal/manager/s3_object_test.go
@@ -476,6 +476,66 @@ func TestObjectServiceDeleteBucketContentsReturnsChunkCleanupError(t *testing.T)
 	}
 }
 
+func TestObjectServiceDeleteBucketContentsReturnsFileMetadataDeleteError(t *testing.T) {
+	bucketID := primitive.NewObjectID()
+	deleteErr := errors.New("delete metadata failed")
+	files := newFakeObjectFiles(repository.File{
+		ID:       primitive.NewObjectID(),
+		BucketID: bucketID,
+		Name:     "object.txt",
+		Chunks:   []repository.FileChunk{{SourceID: primitive.NewObjectID(), Name: "delete-me", Size: 3}},
+	})
+	files.deleteErr = deleteErr
+	var deleted []repository.FileChunk
+	svc := testObjectService(files, &deleted)
+
+	_, err := svc.DeleteBucketContents(context.Background(), bucketID)
+	if !errors.Is(err, deleteErr) {
+		t.Fatalf("expected file metadata delete error, got %v", err)
+	}
+	if len(deleted) != 1 || deleted[0].Name != "delete-me" {
+		t.Fatalf("expected chunk cleanup before metadata delete failure, got %#v", deleted)
+	}
+	if _, err := files.GetByName(context.Background(), bucketID, "object.txt"); err != nil {
+		t.Fatalf("expected file metadata to remain after delete failure, got %v", err)
+	}
+}
+
+func TestObjectServiceDeleteBucketContentsReturnsMultipartMetadataDeleteError(t *testing.T) {
+	bucketID := primitive.NewObjectID()
+	deleteErr := errors.New("delete multipart metadata failed")
+	files := newFakeObjectFiles(repository.File{
+		ID:       primitive.NewObjectID(),
+		BucketID: bucketID,
+		Name:     "object.txt",
+		Chunks:   []repository.FileChunk{{SourceID: primitive.NewObjectID(), Name: "delete-me", Size: 3}},
+	})
+	uploads := &fakeMultipartUploads{
+		uploads: map[string]repository.MultipartUpload{
+			"delete-upload": {
+				BucketID:  bucketID,
+				ObjectKey: "pending.txt",
+				UploadID:  "delete-upload",
+			},
+		},
+		delErr: deleteErr,
+	}
+	var deleted []repository.FileChunk
+	svc := testObjectService(files, &deleted)
+	svc.multipart = uploads
+
+	_, err := svc.DeleteBucketContents(context.Background(), bucketID)
+	if !errors.Is(err, deleteErr) {
+		t.Fatalf("expected multipart metadata delete error, got %v", err)
+	}
+	if _, err := files.GetByName(context.Background(), bucketID, "object.txt"); !errors.Is(err, mongo.ErrNoDocuments) {
+		t.Fatalf("expected file metadata deleted before multipart delete failure, got %v", err)
+	}
+	if _, err := uploads.GetByUploadID(context.Background(), "delete-upload"); err != nil {
+		t.Fatalf("expected multipart metadata to remain after delete failure, got %v", err)
+	}
+}
+
 func TestObjectServiceCompleteMultipartUploadBuildsFinalFileAndCleansUnusedChunks(t *testing.T) {
 	bucketID := primitive.NewObjectID()
 	oldChunk := repository.FileChunk{SourceID: primitive.NewObjectID(), Name: "old-file-chunk", Size: 2}

--- a/api-go/internal/repository/file.go
+++ b/api-go/internal/repository/file.go
@@ -241,6 +241,11 @@ func (r *FileRepository) Delete(ctx context.Context, id primitive.ObjectID) erro
 	return nil
 }
 
+func (r *FileRepository) DeleteByBucket(ctx context.Context, bucketID primitive.ObjectID) error {
+	_, err := r.coll.DeleteMany(ctx, bson.M{"bucket_id": bucketID})
+	return err
+}
+
 func (r *FileRepository) UpdateByID(ctx context.Context, f File) (*File, error) {
 	f.CreatedAt = f.CreatedAt.UTC()
 	res, err := r.coll.UpdateOne(ctx, bson.M{"_id": f.ID}, bson.M{"$set": bson.M{

--- a/api-go/internal/repository/file.go
+++ b/api-go/internal/repository/file.go
@@ -160,6 +160,16 @@ func (r *FileRepository) CountByChunk(ctx context.Context, sourceID primitive.Ob
 	})
 }
 
+func (r *FileRepository) CountByChunkExcludingBucket(ctx context.Context, bucketID, sourceID primitive.ObjectID, name string) (int64, error) {
+	return r.coll.CountDocuments(ctx, bson.M{
+		"bucket_id": bson.M{"$ne": bucketID},
+		"chunks": bson.M{"$elemMatch": bson.M{
+			"source_id": sourceID,
+			"name":      name,
+		}},
+	})
+}
+
 func (r *FileRepository) ListByBucket(ctx context.Context, bucketID primitive.ObjectID) ([]File, error) {
 	return r.ListByBucketWithPrefix(ctx, bucketID, "")
 }

--- a/api-go/internal/repository/multipart.go
+++ b/api-go/internal/repository/multipart.go
@@ -88,6 +88,17 @@ func (r *MultipartUploadRepository) ListByBucket(ctx context.Context, bucketID p
 	return uploads, cursor.Err()
 }
 
+func (r *MultipartUploadRepository) CountByPartChunk(ctx context.Context, sourceID primitive.ObjectID, name string) (int64, error) {
+	return r.coll.CountDocuments(ctx, bson.M{
+		"parts": bson.M{"$elemMatch": bson.M{
+			"chunks": bson.M{"$elemMatch": bson.M{
+				"source_id": sourceID,
+				"name":      name,
+			}},
+		}},
+	})
+}
+
 func (r *MultipartUploadRepository) SetPart(ctx context.Context, uploadID string, part UploadPart) error {
 	partDoc := bson.D{
 		{Key: "part_number", Value: part.PartNumber},
@@ -117,6 +128,11 @@ func (r *MultipartUploadRepository) SetPart(ctx context.Context, uploadID string
 		return mongo.ErrNoDocuments
 	}
 	return nil
+}
+
+func (r *MultipartUploadRepository) DeleteByBucket(ctx context.Context, bucketID primitive.ObjectID) error {
+	_, err := r.coll.DeleteMany(ctx, bson.M{"bucket_id": bucketID})
+	return err
 }
 
 func (r *MultipartUploadRepository) Delete(ctx context.Context, uploadID string) error {

--- a/api-go/internal/repository/multipart.go
+++ b/api-go/internal/repository/multipart.go
@@ -99,6 +99,18 @@ func (r *MultipartUploadRepository) CountByPartChunk(ctx context.Context, source
 	})
 }
 
+func (r *MultipartUploadRepository) CountByPartChunkExcludingBucket(ctx context.Context, bucketID, sourceID primitive.ObjectID, name string) (int64, error) {
+	return r.coll.CountDocuments(ctx, bson.M{
+		"bucket_id": bson.M{"$ne": bucketID},
+		"parts": bson.M{"$elemMatch": bson.M{
+			"chunks": bson.M{"$elemMatch": bson.M{
+				"source_id": sourceID,
+				"name":      name,
+			}},
+		}},
+	})
+}
+
 func (r *MultipartUploadRepository) SetPart(ctx context.Context, uploadID string, part UploadPart) error {
 	partDoc := bson.D{
 		{Key: "part_number", Value: part.PartNumber},


### PR DESCRIPTION
## Summary
- clean bucket-owned file metadata and multipart upload metadata before deleting a bucket
- delete bucket-owned chunks through the existing object cleanup path when no remaining file or multipart references exist
- add focused manager unit coverage for bucket-content cleanup and cleanup error propagation
- refresh the branch onto current `main`, preserving the merged atomic multipart `SetPart` behavior alongside bucket cleanup reference-count helpers

## Validation
- Not run locally per resource policy; Woodpecker should run the relevant backend checks.