### PR TITLE
THE-500: Speed up Woodpecker CI

### DIFF
--- a/.woodpecker/api-go.yml
+++ b/.woodpecker/api-go.yml
@@ -49,7 +49,7 @@ steps:
       DOCKER_HOST: tcp://docker:2375
       DOCKER_TLS_CERTDIR: ""
       GO_IMAGE: public.ecr.aws/docker/library/golang:1.24
-      MONGO_IMAGE: public.ecr.aws/docker/library/mongo:7
+      MONGO_IMAGE: public.ecr.aws/docker/library/mongo:7.0.32-rc2-jammy
       MINIO_IMAGE: quay.io/minio/minio:RELEASE.2025-01-20T14-49-07Z
     commands:
       - echo "Waiting for Docker daemon..."

--- a/.woodpecker/webui.yml
+++ b/.woodpecker/webui.yml
@@ -13,19 +13,12 @@ when:
         - webui/**
 
 steps:
-  - name: validate
+  - name: validate and e2e
     image: node:20
     commands:
       - cd webui
       - npm ci --include=dev
       - npm run lint
-      - npm run build
-
-  - name: e2e tests
-    image: node:20
-    commands:
-      - cd webui
-      - npm ci --include=dev
       - npm run build
       - npx playwright install --with-deps chromium
       - npm run test:e2e

--- a/api-go/docker-compose.go-e2e.yml
+++ b/api-go/docker-compose.go-e2e.yml
@@ -1,6 +1,6 @@
 services:
   mongo:
-    image: ${MONGO_IMAGE:-mongo:7}
+    image: ${MONGO_IMAGE:-mongo:7.0.32-rc2-jammy}
     environment:
       - MONGO_INITDB_ROOT_USERNAME=root
       - MONGO_INITDB_ROOT_PASSWORD=example


### PR DESCRIPTION
## Summary
- Combine web UI lint/build/e2e into one Woodpecker step to avoid a second `npm ci` and duplicate build.
- Align the API Go E2E Mongo image tag with the existing API/Smoke E2E tag so the Docker daemon can reuse the same pulled image.

## Verification
- `git diff --check`
- Did not run Docker, Playwright, builds, or other CPU-bound checks locally per QA agent policy; validation should run in Woodpecker.