### PR TITLE
THE-503 Fix short-read upload chunking

### DIFF
--- a/api-go/internal/manager/file.go
+++ b/api-go/internal/manager/file.go
@@ -456,8 +456,8 @@ func UploadFileChunksWithStrategy(ctx context.Context, r io.Reader, sources []re
 	idx := 0
 	failoverCount := 0
 	for {
-		n, readErr := r.Read(buf)
-		if readErr != nil && readErr != io.EOF {
+		n, readErr := io.ReadFull(r, buf)
+		if readErr != nil && readErr != io.EOF && readErr != io.ErrUnexpectedEOF {
 			span.RecordError(readErr)
 			span.SetStatus(codes.Error, "read failed")
 			cleanupUploadedChunks(ctx, chunks, clientCache)
@@ -546,7 +546,7 @@ func UploadFileChunksWithStrategy(ctx context.Context, r io.Reader, sources []re
 			Checksum: hex.EncodeToString(sum[:]),
 		})
 		idx++
-		if readErr == io.EOF {
+		if readErr == io.EOF || readErr == io.ErrUnexpectedEOF {
 			break
 		}
 	}

--- a/api-go/internal/manager/file_test.go
+++ b/api-go/internal/manager/file_test.go
@@ -143,6 +143,57 @@ func TestUploadFileChunksWithRoundRobinStrategy(t *testing.T) {
 	}
 }
 
+type shortReadReader struct {
+	data    []byte
+	maxRead int
+}
+
+func (r *shortReadReader) Read(p []byte) (int, error) {
+	if len(r.data) == 0 {
+		return 0, io.EOF
+	}
+	if len(p) > r.maxRead {
+		p = p[:r.maxRead]
+	}
+	if len(p) > len(r.data) {
+		p = p[:len(r.data)]
+	}
+	n := copy(p, r.data[:len(p)])
+	r.data = r.data[n:]
+	return n, nil
+}
+
+func TestUploadFileChunksFillsChunksAcrossShortReads(t *testing.T) {
+	t.Parallel()
+	src := repository.Source{ID: primitive.NewObjectID(), Type: repository.SourceTypeTelegram}
+	stub := &stubSourceClient{}
+	factory := func(_ context.Context, _ *repository.Source) (sourceClient, error) {
+		return stub, nil
+	}
+
+	payload := []byte("abcdefghij")
+	chunks, err := UploadFileChunksWithStrategy(context.Background(), &shortReadReader{data: payload, maxRead: 1}, []repository.Source{src}, 4, factory, &RoundRobinSelector{})
+	if err != nil {
+		t.Fatalf("upload chunks: %v", err)
+	}
+	if len(chunks) != 3 {
+		t.Fatalf("expected 3 chunks, got %d", len(chunks))
+	}
+	if len(stub.uploaded) != 3 {
+		t.Fatalf("expected 3 uploaded payloads, got %d", len(stub.uploaded))
+	}
+
+	wantUploads := [][]byte{payload[:4], payload[4:8], payload[8:]}
+	for i, want := range wantUploads {
+		if !bytes.Equal(stub.uploaded[i], want) {
+			t.Fatalf("upload %d: got %q, want %q", i, stub.uploaded[i], want)
+		}
+		if chunks[i].Size != int64(len(want)) {
+			t.Fatalf("chunk %d size: got %d, want %d", i, chunks[i].Size, len(want))
+		}
+	}
+}
+
 func TestRoundRobinSelectorNoSources(t *testing.T) {
 	t.Parallel()
 	sel := &RoundRobinSelector{}


### PR DESCRIPTION
## Summary
- Fill upload buffers with `io.ReadFull` so short reads do not create undersized intermediate chunks.
- Preserve final partial chunk handling on EOF.
- Add a focused short-read reader regression test in `api-go/internal/manager/file_test.go`.

## Validation
- `gofmt -w api-go/internal/manager/file.go api-go/internal/manager/file_test.go`
- `git diff --check`
- Local Go tests not run per agent instruction to avoid CPU-bound validation; Woodpecker should run CI.