### PR TITLE
docs: align webui contributor setup

### DIFF
--- a/webui/README.md
+++ b/webui/README.md
@@ -10,17 +10,30 @@
 
 ## Development
 
-Install dependencies and run the dev server:
+Install dependencies from the lockfile and run the dev server:
 
 ```bash
-npm install
+cd webui
+npm ci
 npm run dev
 ```
 
-Validation commands:
+For standalone development against a local Go API:
+
+```bash
+VITE_API_BASE=http://localhost:8080/api/v1 npm run dev
+```
+
+Normal local validation:
 
 - `npm run lint`
 - `npm run build`
+
+Playwright/browser E2E is validated in Woodpecker for webui changes. Do not run
+it locally by default unless a maintainer asks for local reproduction.
+
+See [../CONTRIBUTING.md](../CONTRIBUTING.md) and [../docs/ci.md](../docs/ci.md)
+for full repository validation expectations.
 
 ## Backend Configuration
 


### PR DESCRIPTION
## Summary

- Update `webui/README.md` to use locked dependency setup with `npm ci`.
- Document normal local frontend checks as `npm run lint` and `npm run build`.
- Clarify that Playwright/browser E2E belongs in Woodpecker unless a maintainer asks for local reproduction.
- Add the standalone local API example with `VITE_API_BASE=http://localhost:8080/api/v1 npm run dev` and link to the full contributor/CI docs.

Links [THE-514](/THE/issues/THE-514).
Related: [THE-510](/THE/issues/THE-510).

## Validation

- `git diff --check`

No code validation was required beyond whitespace checks for this docs-only change.