### PR TITLE
THE-513: Fail router setup on dependency init errors

### DIFF
--- a/api-go/cmd/server/main.go
+++ b/api-go/cmd/server/main.go
@@ -71,7 +71,11 @@ func main() {
 		slog.Error("failed to connect mongo", slog.String("error", err.Error()))
 		os.Exit(1)
 	}
-	router := app.SetupRouter(mongoConn, cfg)
+	router, err := app.SetupRouter(mongoConn, cfg)
+	if err != nil {
+		slog.Error("failed to initialize router", slog.String("error", err.Error()))
+		os.Exit(1)
+	}
 	slog.Info("starting server")
 	if err := router.Run(); err != nil {
 		slog.Error("failed to run server", slog.String("error", err.Error()))

--- a/api-go/internal/app/router.go
+++ b/api-go/internal/app/router.go
@@ -10,19 +10,22 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin"
 )
 
-func SetupRouter(m *db.Mongo, cfg *config.Config) *gin.Engine {
+func SetupRouter(m *db.Mongo, cfg *config.Config) (*gin.Engine, error) {
 	router := gin.New()
 
 	registerMiddleware(router, cfg)
 	registerProbeRoutes(router, m)
 
-	deps := newRouterDependencies(m, cfg)
+	deps, err := newRouterDependencies(m, cfg)
+	if err != nil {
+		return nil, err
+	}
 	registerRESTRoutes(router, cfg, deps)
 	registerPublicShareRoutes(router, deps)
 	registerDocsMetricsRoutes(router)
 	registerS3Routes(router, cfg, deps)
 
-	return router
+	return router, nil
 }
 
 func registerMiddleware(router *gin.Engine, cfg *config.Config) {

--- a/api-go/internal/app/router_dependencies.go
+++ b/api-go/internal/app/router_dependencies.go
@@ -1,11 +1,23 @@
 package app
 
 import (
+	"fmt"
+
 	"github.com/example/sfree/api-go/internal/config"
 	"github.com/example/sfree/api-go/internal/db"
 	"github.com/example/sfree/api-go/internal/handlers"
 	"github.com/example/sfree/api-go/internal/repository"
 	"github.com/gin-gonic/gin"
+)
+
+var (
+	newUserRepository            = repository.NewUserRepository
+	newBucketRepository          = repository.NewBucketRepository
+	newSourceRepository          = repository.NewSourceRepository
+	newFileRepository            = repository.NewFileRepository
+	newShareLinkRepository       = repository.NewShareLinkRepository
+	newMultipartUploadRepository = repository.NewMultipartUploadRepository
+	newBucketGrantRepository     = repository.NewBucketGrantRepository
 )
 
 type routerDependencies struct {
@@ -19,25 +31,45 @@ type routerDependencies struct {
 	grantRepo     *repository.BucketGrantRepository
 }
 
-func newRouterDependencies(m *db.Mongo, cfg *config.Config) *routerDependencies {
+func newRouterDependencies(m *db.Mongo, cfg *config.Config) (*routerDependencies, error) {
 	deps := &routerDependencies{}
 	if m == nil {
-		return deps
+		return deps, nil
 	}
 
 	var err error
-	deps.userRepo, err = repository.NewUserRepository(m.DB)
-	if err == nil {
-		deps.auth = handlers.Auth(deps.userRepo, routerJWTSecret(cfg))
+	deps.userRepo, err = newUserRepository(m.DB)
+	if err != nil {
+		return nil, fmt.Errorf("initialize user repository: %w", err)
 	}
-	deps.bucketRepo, _ = repository.NewBucketRepository(m.DB)
-	deps.sourceRepo, _ = repository.NewSourceRepository(m.DB, routerAccessSecret(cfg))
-	deps.fileRepo, _ = repository.NewFileRepository(m.DB)
-	deps.mpRepo, _ = repository.NewMultipartUploadRepository(m.DB)
-	deps.shareLinkRepo, _ = repository.NewShareLinkRepository(m.DB)
-	deps.grantRepo, _ = repository.NewBucketGrantRepository(m.DB)
+	deps.auth = handlers.Auth(deps.userRepo, routerJWTSecret(cfg))
 
-	return deps
+	deps.bucketRepo, err = newBucketRepository(m.DB)
+	if err != nil {
+		return nil, fmt.Errorf("initialize bucket repository: %w", err)
+	}
+	deps.sourceRepo, err = newSourceRepository(m.DB, routerAccessSecret(cfg))
+	if err != nil {
+		return nil, fmt.Errorf("initialize source repository: %w", err)
+	}
+	deps.fileRepo, err = newFileRepository(m.DB)
+	if err != nil {
+		return nil, fmt.Errorf("initialize file repository: %w", err)
+	}
+	deps.mpRepo, err = newMultipartUploadRepository(m.DB)
+	if err != nil {
+		return nil, fmt.Errorf("initialize multipart upload repository: %w", err)
+	}
+	deps.shareLinkRepo, err = newShareLinkRepository(m.DB)
+	if err != nil {
+		return nil, fmt.Errorf("initialize share link repository: %w", err)
+	}
+	deps.grantRepo, err = newBucketGrantRepository(m.DB)
+	if err != nil {
+		return nil, fmt.Errorf("initialize bucket grant repository: %w", err)
+	}
+
+	return deps, nil
 }
 
 func routerJWTSecret(cfg *config.Config) string {

--- a/api-go/internal/app/router_integration_test.go
+++ b/api-go/internal/app/router_integration_test.go
@@ -22,7 +22,10 @@ func TestRouterWithDB(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	r := SetupRouter(mongoConn, cfg)
+	r, err := SetupRouter(mongoConn, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
 	req, _ := http.NewRequest(http.MethodGet, "/dbz", nil)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)

--- a/api-go/internal/app/router_test.go
+++ b/api-go/internal/app/router_test.go
@@ -1,15 +1,23 @@
 package app
 
 import (
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
+	"github.com/example/sfree/api-go/internal/db"
+	"github.com/example/sfree/api-go/internal/repository"
 	"github.com/gin-gonic/gin"
+	"go.mongodb.org/mongo-driver/mongo"
 )
 
 func TestSetupRouter(t *testing.T) {
-	r := SetupRouter(nil, nil)
+	r, err := SetupRouter(nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 	endpoints := []string{"/readyz", "/healthz", "/publication/ready"}
 	for _, e := range endpoints {
 		req, _ := http.NewRequest(http.MethodGet, e, nil)
@@ -22,7 +30,10 @@ func TestSetupRouter(t *testing.T) {
 }
 
 func TestSetupRouterNilMongoRouteSet(t *testing.T) {
-	r := SetupRouter(nil, nil)
+	r, err := SetupRouter(nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	expectedRoutes := []struct {
 		method string
@@ -56,6 +67,92 @@ func TestSetupRouterNilMongoRouteSet(t *testing.T) {
 	}
 }
 
+func TestNewRouterDependenciesReturnsRepositoryErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		fail func(error)
+	}{
+		{
+			name: "user repository",
+			fail: func(failure error) {
+				newUserRepository = func(*mongo.Database) (*repository.UserRepository, error) {
+					return nil, failure
+				}
+			},
+		},
+		{
+			name: "bucket repository",
+			fail: func(failure error) {
+				newBucketRepository = func(*mongo.Database) (*repository.BucketRepository, error) {
+					return nil, failure
+				}
+			},
+		},
+		{
+			name: "source repository",
+			fail: func(failure error) {
+				newSourceRepository = func(*mongo.Database, ...string) (*repository.SourceRepository, error) {
+					return nil, failure
+				}
+			},
+		},
+		{
+			name: "file repository",
+			fail: func(failure error) {
+				newFileRepository = func(*mongo.Database) (*repository.FileRepository, error) {
+					return nil, failure
+				}
+			},
+		},
+		{
+			name: "multipart upload repository",
+			fail: func(failure error) {
+				newMultipartUploadRepository = func(*mongo.Database) (*repository.MultipartUploadRepository, error) {
+					return nil, failure
+				}
+			},
+		},
+		{
+			name: "share link repository",
+			fail: func(failure error) {
+				newShareLinkRepository = func(*mongo.Database) (*repository.ShareLinkRepository, error) {
+					return nil, failure
+				}
+			},
+		},
+		{
+			name: "bucket grant repository",
+			fail: func(failure error) {
+				newBucketGrantRepository = func(*mongo.Database) (*repository.BucketGrantRepository, error) {
+					return nil, failure
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stubRouterRepositoryConstructors(t)
+			failure := errors.New("create index")
+			tt.fail(failure)
+
+			deps, err := newRouterDependencies(&db.Mongo{}, nil)
+			if err == nil {
+				t.Fatal("expected repository initialization error")
+			}
+			if deps != nil {
+				t.Fatal("expected nil dependencies on initialization error")
+			}
+			if !errors.Is(err, failure) {
+				t.Fatalf("expected error to wrap failure, got %v", err)
+			}
+			if !strings.Contains(err.Error(), "initialize "+tt.name) {
+				t.Fatalf("expected repository name in error, got %v", err)
+			}
+		})
+	}
+}
+
 func hasRoute(r *gin.Engine, method, path string) bool {
 	for _, route := range r.Routes() {
 		if route.Method == method && route.Path == path {
@@ -63,4 +160,46 @@ func hasRoute(r *gin.Engine, method, path string) bool {
 		}
 	}
 	return false
+}
+
+func stubRouterRepositoryConstructors(t *testing.T) {
+	originalUser := newUserRepository
+	originalBucket := newBucketRepository
+	originalSource := newSourceRepository
+	originalFile := newFileRepository
+	originalShareLink := newShareLinkRepository
+	originalMultipartUpload := newMultipartUploadRepository
+	originalBucketGrant := newBucketGrantRepository
+
+	t.Cleanup(func() {
+		newUserRepository = originalUser
+		newBucketRepository = originalBucket
+		newSourceRepository = originalSource
+		newFileRepository = originalFile
+		newShareLinkRepository = originalShareLink
+		newMultipartUploadRepository = originalMultipartUpload
+		newBucketGrantRepository = originalBucketGrant
+	})
+
+	newUserRepository = func(*mongo.Database) (*repository.UserRepository, error) {
+		return &repository.UserRepository{}, nil
+	}
+	newBucketRepository = func(*mongo.Database) (*repository.BucketRepository, error) {
+		return &repository.BucketRepository{}, nil
+	}
+	newSourceRepository = func(*mongo.Database, ...string) (*repository.SourceRepository, error) {
+		return &repository.SourceRepository{}, nil
+	}
+	newFileRepository = func(*mongo.Database) (*repository.FileRepository, error) {
+		return &repository.FileRepository{}, nil
+	}
+	newMultipartUploadRepository = func(*mongo.Database) (*repository.MultipartUploadRepository, error) {
+		return &repository.MultipartUploadRepository{}, nil
+	}
+	newShareLinkRepository = func(*mongo.Database) (*repository.ShareLinkRepository, error) {
+		return &repository.ShareLinkRepository{}, nil
+	}
+	newBucketGrantRepository = func(*mongo.Database) (*repository.BucketGrantRepository, error) {
+		return &repository.BucketGrantRepository{}, nil
+	}
 }

--- a/api-go/internal/e2e/s3_compat_helpers_test.go
+++ b/api-go/internal/e2e/s3_compat_helpers_test.go
@@ -157,7 +157,10 @@ func newTestServer(t *testing.T) (*httptest.Server, *appconfig.Config) {
 	if err != nil {
 		t.Fatalf("connect mongo: %v", err)
 	}
-	router := app.SetupRouter(mongoConn, cfg)
+	router, err := app.SetupRouter(mongoConn, cfg)
+	if err != nil {
+		t.Fatalf("setup router: %v", err)
+	}
 	ts := httptest.NewServer(router)
 	t.Cleanup(ts.Close)
 	return ts, cfg

--- a/api-go/internal/e2e/server_test.go
+++ b/api-go/internal/e2e/server_test.go
@@ -23,7 +23,10 @@ func TestServerStartup(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	router := app.SetupRouter(mongoConn, cfg)
+	router, err := app.SetupRouter(mongoConn, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
 	ts := httptest.NewServer(router)
 	defer ts.Close()
 


### PR DESCRIPTION
## Summary

- Return router setup errors when required repository initialization fails.
- Log router initialization failure in server startup before binding the HTTP server.
- Add lightweight unit coverage that stubs repository constructors and checks each dependency error path.

## Related

- [THE-510](/THE/issues/THE-510)
- [THE-513](/THE/issues/THE-513)

## Validation

- `gofmt`
- `git diff --check`
- Go tests deferred to Woodpecker per local CPU-bound task policy.