### PR TITLE
THE-521: Refresh QA coverage audit

### DIFF
--- a/api-go/internal/e2e/s3_compat_delete_test.go
+++ b/api-go/internal/e2e/s3_compat_delete_test.go
@@ -115,4 +115,11 @@ func TestS3CompatDeleteObjects(t *testing.T) {
 	if status != http.StatusBadRequest {
 		t.Fatalf("DeleteObjects too many keys: expected 400, got %d: %s", status, body)
 	}
+	assertS3Error(t, body, "InvalidRequest")
+
+	status, body = s3Do(t, http.MethodPost, deleteURL, bucket.AccessKey, bucket.AccessSecret, env.Region, []byte("<Delete><Object><Key>broken"))
+	if status != http.StatusBadRequest {
+		t.Fatalf("DeleteObjects malformed XML: expected 400, got %d: %s", status, body)
+	}
+	assertS3Error(t, body, "MalformedXML")
 }

--- a/docs/qa-coverage-audit-2026-04-21.md
+++ b/docs/qa-coverage-audit-2026-04-21.md
@@ -2,11 +2,15 @@
 
 Date: 2026-04-21
 
-Scope: `api-go` automated tests, Woodpecker backend validation, recent `origin/main` changes, and open backend PRs as of 2026-04-21 19:25 UTC.
+Scope: `api-go` automated tests, Woodpecker backend validation, recent `origin/main` changes, and open backend PRs as of 2026-04-21 20:25 UTC.
 
 ## Recent Inputs
 
-- `origin/main` now includes focused S3 range GET, ListObjectsV2 pagination, checksum verification, multipart checksum preservation, one-file-per-bucket-object enforcement, S3 GET stream-failure semantics, DeleteObjects support, CopyObject support, SDK CopyObject compatibility coverage, bucket grant route scoping, S3 helper coverage, SigV4 redaction coverage, manager-level S3 object mutation coverage, Woodpecker image-pinning, lint enforcement, and the unit-only `api-go` Makefile `test` target.
+- `origin/main` now includes focused S3 range GET, ListObjectsV2 pagination, checksum verification, multipart checksum preservation, one-file-per-bucket-object enforcement, S3 GET stream-failure semantics, DeleteObjects support, CopyObject support, SDK CopyObject compatibility coverage, bucket grant route scoping, S3 helper coverage, multipart malformed error-shape coverage, SigV4 redaction coverage, upload-failure cleanup coverage, manager-level S3 object mutation coverage, Woodpecker image-pinning, lint enforcement, Woodpecker E2E image-pull speedups, and the unit-only `api-go` Makefile `test` target.
+- Merged commit `49cc4d5` (`THE-500`) speeds Woodpecker validation by using pre-pulled/pinned E2E images and removing web UI dependency installs where unnecessary.
+- Merged commit `6589a19` (`THE-458`) cleans uploaded chunks after later upload/read failures and adds manager regressions for both paths.
+- Merged commit `7ad432d` (`THE-513`) makes router setup fail on repository dependency initialization errors and adds unit/integration coverage for nil-Mongo route registration and dependency errors.
+- Merged commit `045a8b6` (`THE-486`) adds Go E2E coverage for malformed and unsupported multipart request error shapes.
 - Merged PR [#208](https://github.com/siberianbearofficial/sfree/pull/208) adds S3 helper unit coverage for query parsing, bucket-name validation, metadata extraction, error XML, request signing context, and object key trimming.
 - Merged PR [#187](https://github.com/siberianbearofficial/sfree/pull/187) adds `api-go` lint enforcement to Woodpecker and updates CI docs.
 - Merged commit `ea8c5df` (`THE-448`) moves S3 object mutation logic into a manager service and adds unit coverage for PUT, CopyObject, DeleteObject, CompleteMultipartUpload cleanup, and metadata-save failure cleanup.
@@ -21,13 +25,11 @@ Scope: `api-go` automated tests, Woodpecker backend validation, recent `origin/m
 - Merged PR [#176](https://github.com/siberianbearofficial/sfree/pull/176) adds S3 DeleteObjects support plus E2E coverage for normal delete, missing-key idempotency, quiet mode, list-after-delete, and oversized XML rejection.
 - Open PR [#215](https://github.com/siberianbearofficial/sfree/pull/215) extracts S3 listing handlers; existing handler and Go E2E tests still cover delimiter common prefixes, prefix filtering, continuation-token pagination, and V1 delimiter behavior.
 - Open PR [#214](https://github.com/siberianbearofficial/sfree/pull/214) fixes short-read upload chunking and adds `TestUploadFileChunksFillsChunksAcrossShortReads`.
-- Open PR [#213](https://github.com/siberianbearofficial/sfree/pull/213) speeds Woodpecker backend/web UI validation by adjusting CI images and compose wiring.
 - Open PR [#212](https://github.com/siberianbearofficial/sfree/pull/212) adds an OpenAPI docs route with router coverage for the generated spec endpoint.
 - Open PR [#210](https://github.com/siberianbearofficial/sfree/pull/210) cleans bucket contents on delete and adds manager regressions for object chunk cleanup, multipart part cleanup, and repository delete helpers.
 - Open PR [#209](https://github.com/siberianbearofficial/sfree/pull/209) makes multipart part replacement cleanup atomic and adds repository and handler coverage for replacement behavior.
 - Open PR [#207](https://github.com/siberianbearofficial/sfree/pull/207) adds Python SDK `head_object` coverage and refreshes this audit artifact.
 - Open PR [#202](https://github.com/siberianbearofficial/sfree/pull/202) centralizes source-client construction and adds unit coverage for source-client parsing, wrapping, inspection, download, and stream lifetime behavior.
-- Open PR [#195](https://github.com/siberianbearofficial/sfree/pull/195) fixes cleanup of chunks uploaded before later upload/read failures and adds manager regressions for both paths.
 
 ## Coverage Map
 
@@ -39,18 +41,18 @@ Scope: `api-go` automated tests, Woodpecker backend validation, recent `origin/m
 | Placement logic | Round-robin, weighted selection, and upload failover have unit coverage. | Covered for manager logic. |
 | Reconstruction/retrieval | Manager tests cover checksum-verified streaming, range streaming across chunks, legacy chunks, oversized chunks, truncated chunks, and corruption. S3 E2E covers full-object and ranged download. Handler tests cover S3 full and ranged GET failures before success headers/body are emitted. | Covered for manager logic and pre-commit S3 HTTP error behavior. |
 | Corruption detection | SHA-256 mismatch paths are unit-tested, including short and oversized chunk reads. | Covered at unit level. |
-| Source/backend failure cases | Manager failover and resilience wrappers have tests. S3 GET stream-failure handler coverage is merged on `origin/main`; open PRs #195 and #202 cover upload cleanup failures and source-client construction/stream lifetime behavior. | Covered for upload/retry logic and pre-commit S3 GET failure behavior once open cleanup/source-client branches merge. |
-| Critical S3-compatible API behavior | Go E2E covers source/bucket creation, object lifecycle, auth failure, presigned GET/PUT, HEAD, expired presign, range GET, ListObjectsV2 prefix/delimiter/pagination, DeleteObjects, CopyObject, and multipart lifecycle. Python SDK E2E covers ListObjectsV2, range GET, DeleteObjects, CopyObject, and multipart; open PR #207 adds SDK HEAD coverage. | Covered for currently implemented core operations; weak for metadata and unsupported/malformed request error shapes. |
-| Recent bug regressions | Recent checksum, ListObjectsV2, range GET, multipart checksum propagation, DeleteObjects, CopyObject, S3 GET stream-failure, file-manager cache, upload retry body replay, upload failure cleanup, source-client factory, one-file-per-object enforcement, bucket grant route scoping, short-read chunking, bucket delete cleanup, and multipart replacement atomicity work have focused tests or open test branches. | Covered for latest backend regressions once open PRs merge. |
-| Recently changed code paths | Backend CI runs lint, Go unit tests, Python E2E, and Go E2E through Woodpecker for `api-go/**`; `make test` is unit-only on `origin/main`, keeping CPU-heavy integration/E2E work in CI. Open PR #213 changes CI performance characteristics and should be validated by Woodpecker, not local runs. | Covered by CI routing. |
+| Source/backend failure cases | Manager failover, resilience wrappers, upload retry body replay, uploaded-chunk cleanup after later failures, and S3 GET stream-failure handler behavior have tests. Open PR #202 covers source-client construction/stream lifetime behavior. | Covered for upload/retry/cleanup logic and pre-commit S3 GET failure behavior; source-client branch remains open. |
+| Critical S3-compatible API behavior | Go E2E covers source/bucket creation, object lifecycle, auth failure, presigned GET/PUT, HEAD, expired presign, range GET, ListObjectsV2 prefix/delimiter/pagination, DeleteObjects, CopyObject, multipart lifecycle, malformed multipart errors, and DeleteObjects malformed/oversized error codes. Python SDK E2E covers ListObjectsV2, range GET, DeleteObjects, CopyObject, and multipart; open PR #207 adds SDK HEAD coverage. | Covered for currently implemented core operations; weak for metadata and broader unsupported/malformed request combinations. |
+| Recent bug regressions | Recent checksum, ListObjectsV2, range GET, multipart checksum propagation, DeleteObjects, CopyObject, S3 GET stream-failure, file-manager cache, upload retry body replay, upload failure cleanup, source-client factory, one-file-per-object enforcement, bucket grant route scoping, short-read chunking, bucket delete cleanup, and multipart replacement atomicity work have focused tests or open test branches. | Covered for latest backend regressions once source-client, short-read, bucket-cleanup, multipart-replacement, and SDK HEAD branches merge. |
+| Recently changed code paths | Backend CI runs lint, Go unit tests, Python E2E, and Go E2E through Woodpecker for `api-go/**`; `make test` is unit-only on `origin/main`, keeping CPU-heavy integration/E2E work in CI. THE-500’s CI speedups are merged and should be validated by Woodpecker, not local runs. | Covered by CI routing. |
 
 ## Prioritized Missing Tests
 
 1. Add S3 object metadata/header behavior coverage when metadata support is implemented.
    Acceptance: PUT with `Content-Type` and `x-amz-meta-*` either preserves those values through HEAD/GET or returns an intentional S3-compatible unsupported-feature response.
 
-2. Add S3 malformed/unsupported request error-shape coverage at SDK and raw HTTP levels.
-   Acceptance: unsupported operations and malformed query combinations return XML S3 errors with stable status codes instead of generic JSON or empty responses.
+2. Add broader S3 unsupported request error-shape coverage at SDK and raw HTTP levels.
+   Acceptance: unsupported operations and malformed query combinations beyond multipart/DeleteObjects return XML S3 errors with stable status codes instead of generic JSON or empty responses.
 
 3. Add SDK-level presigned URL coverage if the Python SDK compatibility suite is expected to be the long-term compatibility matrix rather than a focused SDK smoke branch.
    Acceptance: aiobotocore-generated presigned GET/PUT URLs work without client-specific signing hacks and return stable S3-compatible responses.
@@ -78,9 +80,10 @@ Scope: `api-go` automated tests, Woodpecker backend validation, recent `origin/m
 - Confirmed `TestCompletedMultipartChunksPreservesChecksums` covers checksum preservation when completed multipart parts are flattened into final file chunks.
 - Confirmed `TestFileRepositoryUniqueBucketNameAndReplace` and `TestFileRepositoryMigratesLegacyBucketNameIndex` cover one authoritative file document per bucket/object name and legacy index migration.
 - Confirmed `TestUpdateGrantRejectsCrossBucketGrantID` and `TestDeleteGrantRejectsCrossBucketGrantID` cover the latest bucket grant route-scoping regression.
-- Confirmed open PR #195 adds manager coverage for uploaded chunk cleanup after both later upload failure and later read failure.
+- Confirmed merged THE-458 coverage handles uploaded chunk cleanup after both later upload failure and later read failure.
 - Confirmed merged SigV4 redaction coverage covers both header-auth and presigned-url mismatch paths.
 - Confirmed merged object-service unit coverage covers overwrite cleanup and metadata-save failure cleanup around S3 object mutations.
+- Added Go S3 E2E assertions that DeleteObjects oversized and malformed XML requests return stable S3 XML error codes (`InvalidRequest` and `MalformedXML`).
 - Confirmed open PR #214 adds short-read upload chunking coverage for readers that return less than the requested chunk size without EOF.
 - Confirmed open PR #210 adds manager/repository cleanup coverage for deleting buckets with objects and multipart state.
 - Confirmed open PR #209 adds repository and handler coverage for atomic multipart part replacement cleanup.
@@ -92,4 +95,4 @@ Scope: `api-go` automated tests, Woodpecker backend validation, recent `origin/m
 
 ## Verification
 
-Local CPU-heavy validation was intentionally not run. The backend suite should be executed by Woodpecker for this branch.
+Local CPU-heavy validation was intentionally not run. `gofmt` was applied to the changed Go E2E test, and the backend suite should be executed by Woodpecker for this branch.


### PR DESCRIPTION
## Summary
- add Go S3 E2E assertions for DeleteObjects oversized and malformed XML error codes
- refresh the QA coverage audit with current main/open PR state and remaining prioritized gaps

## Verification
- gofmt api-go/internal/e2e/s3_compat_delete_test.go
- git diff --check

Local Go/Docker/E2E suites intentionally not run; Woodpecker should execute CPU-heavy validation.