### PR TITLE
THE-535 Preflight REST and share downloads

### DIFF
--- a/api-go/internal/handlers/bucket.go
+++ b/api-go/internal/handlers/bucket.go
@@ -1,10 +1,8 @@
 package handlers
 
 import (
-	"fmt"
 	"log/slog"
 	"net/http"
-	"strconv"
 	"strings"
 	"time"
 
@@ -545,8 +543,20 @@ func DownloadFile(bucketRepo *repository.BucketRepository, sourceRepo *repositor
 			c.Status(http.StatusServiceUnavailable)
 			return
 		}
+		downloadFile(bucketRepo, sourceRepo, fileRepo, grantRepo)(c)
+	}
+}
 
-		acc := requireBucketAccess(c, bucketRepo, grantRepo, repository.RoleViewer)
+func downloadFile(bucketRepo bucketAccessBucketReader, sourceRepo *repository.SourceRepository, fileRepo fileByIDReader, grantRepo bucketAccessGrantReader) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		ctx := c.Request.Context()
+		if bucketRepo == nil || sourceRepo == nil || fileRepo == nil {
+			slog.ErrorContext(ctx, "download file: repository is nil")
+			c.Status(http.StatusServiceUnavailable)
+			return
+		}
+
+		acc := requireBucketAccessFor(c, bucketRepo, grantRepo, repository.RoleViewer)
 		if acc == nil {
 			return
 		}
@@ -570,16 +580,16 @@ func DownloadFile(bucketRepo *repository.BucketRepository, sourceRepo *repositor
 			c.Status(http.StatusNotFound)
 			return
 		}
-		var total int64
-		for _, ch := range fileDoc.Chunks {
-			total += ch.Size
-		}
-		c.Header("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s\"", sanitizeFilename(fileDoc.Name)))
-		c.Header("Content-Type", "application/octet-stream")
-		c.Header("Content-Length", strconv.FormatInt(total, 10))
-		c.Status(http.StatusOK)
-		if err := manager.StreamFile(c.Request.Context(), sourceRepo, fileDoc, c.Writer); err != nil {
+		total := fileContentLength(fileDoc)
+		if err := preflightFile(ctx, sourceRepo, fileDoc, total, streamDownloadFileRange); err != nil {
 			slog.ErrorContext(ctx, "download file: stream failed", slog.String("error", err.Error()))
+			c.Status(http.StatusInternalServerError)
+			return
+		}
+		setAttachmentDownloadHeaders(c, fileDoc.Name, total)
+		c.Status(http.StatusOK)
+		if err := streamDownloadFile(c.Request.Context(), sourceRepo, fileDoc, c.Writer); err != nil {
+			slog.ErrorContext(ctx, "download file: stream failed after response commit", slog.String("error", err.Error()))
 		}
 	}
 }

--- a/api-go/internal/handlers/bucket.go
+++ b/api-go/internal/handlers/bucket.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"fmt"
 	"log/slog"
 	"net/http"
 	"strings"
@@ -543,7 +544,11 @@ func DownloadFile(bucketRepo *repository.BucketRepository, sourceRepo *repositor
 			c.Status(http.StatusServiceUnavailable)
 			return
 		}
-		downloadFile(bucketRepo, sourceRepo, fileRepo, grantRepo)(c)
+		var grantReader bucketAccessGrantReader
+		if grantRepo != nil {
+			grantReader = grantRepo
+		}
+		downloadFile(bucketRepo, sourceRepo, fileRepo, grantReader)(c)
 	}
 }
 

--- a/api-go/internal/handlers/download_stream.go
+++ b/api-go/internal/handlers/download_stream.go
@@ -1,0 +1,60 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strconv"
+
+	"github.com/example/sfree/api-go/internal/manager"
+	"github.com/example/sfree/api-go/internal/repository"
+	"github.com/gin-gonic/gin"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+const downloadPreflightBytes = int64(1)
+
+type fileStreamFunc func(context.Context, *repository.SourceRepository, *repository.File, io.Writer) error
+type fileRangeStreamFunc func(context.Context, *repository.SourceRepository, *repository.File, io.Writer, int64, int64) error
+
+type fileByIDReader interface {
+	GetByID(ctx context.Context, id primitive.ObjectID) (*repository.File, error)
+}
+
+type shareLinkByTokenReader interface {
+	GetByToken(ctx context.Context, token string) (*repository.ShareLink, error)
+}
+
+var (
+	streamDownloadFile      fileStreamFunc      = manager.StreamFile
+	streamDownloadFileRange fileRangeStreamFunc = manager.StreamFileRange
+)
+
+func fileContentLength(fileDoc *repository.File) int64 {
+	var total int64
+	for _, ch := range fileDoc.Chunks {
+		total += ch.Size
+	}
+	return total
+}
+
+func preflightFileRange(ctx context.Context, sourceRepo *repository.SourceRepository, fileDoc *repository.File, start, end int64, streamRange fileRangeStreamFunc) error {
+	if end < start {
+		return nil
+	}
+	preflightEnd := start + downloadPreflightBytes - 1
+	if preflightEnd > end {
+		preflightEnd = end
+	}
+	return streamRange(ctx, sourceRepo, fileDoc, io.Discard, start, preflightEnd)
+}
+
+func preflightFile(ctx context.Context, sourceRepo *repository.SourceRepository, fileDoc *repository.File, total int64, streamRange fileRangeStreamFunc) error {
+	return preflightFileRange(ctx, sourceRepo, fileDoc, 0, total-1, streamRange)
+}
+
+func setAttachmentDownloadHeaders(c *gin.Context, filename string, total int64) {
+	c.Header("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s\"", sanitizeFilename(filename)))
+	c.Header("Content-Type", "application/octet-stream")
+	c.Header("Content-Length", strconv.FormatInt(total, 10))
+}

--- a/api-go/internal/handlers/download_stream_test.go
+++ b/api-go/internal/handlers/download_stream_test.go
@@ -1,0 +1,206 @@
+package handlers
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/example/sfree/api-go/internal/manager"
+	"github.com/example/sfree/api-go/internal/repository"
+	"github.com/gin-gonic/gin"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+type fakeBucketByIDReader struct {
+	bucket *repository.Bucket
+	err    error
+}
+
+func (r fakeBucketByIDReader) GetByID(_ context.Context, _ primitive.ObjectID) (*repository.Bucket, error) {
+	return r.bucket, r.err
+}
+
+type fakeFileByIDReader struct {
+	file *repository.File
+	err  error
+}
+
+func (r fakeFileByIDReader) GetByID(_ context.Context, _ primitive.ObjectID) (*repository.File, error) {
+	return r.file, r.err
+}
+
+type fakeShareLinkByTokenReader struct {
+	link *repository.ShareLink
+	err  error
+}
+
+func (r fakeShareLinkByTokenReader) GetByToken(_ context.Context, _ string) (*repository.ShareLink, error) {
+	return r.link, r.err
+}
+
+func testDownloadFile() (*repository.Bucket, *repository.File, primitive.ObjectID) {
+	userID := primitive.NewObjectID()
+	bucketID := primitive.NewObjectID()
+	sourceID := primitive.NewObjectID()
+	bucket := &repository.Bucket{
+		ID:     bucketID,
+		UserID: userID,
+		Key:    "bucket",
+	}
+	file := &repository.File{
+		ID:        primitive.NewObjectID(),
+		BucketID:  bucketID,
+		Name:      "object.txt",
+		CreatedAt: time.Unix(1700000000, 0).UTC(),
+		Chunks: []repository.FileChunk{
+			{SourceID: sourceID, Name: "chunk-1", Order: 0, Size: 7, Checksum: "bad"},
+		},
+	}
+	return bucket, file, userID
+}
+
+func TestDownloadFileStreamFailureReturnsErrorBeforeSuccessHeaders(t *testing.T) {
+	origStream := streamDownloadFile
+	origStreamRange := streamDownloadFileRange
+	t.Cleanup(func() {
+		streamDownloadFile = origStream
+		streamDownloadFileRange = origStreamRange
+	})
+
+	var gotStart, gotEnd int64
+	streamDownloadFileRange = func(_ context.Context, _ *repository.SourceRepository, _ *repository.File, w io.Writer, start, end int64) error {
+		gotStart, gotEnd = start, end
+		_, _ = io.WriteString(w, "partial")
+		return manager.ErrChecksumMismatch
+	}
+	streamDownloadFile = func(_ context.Context, _ *repository.SourceRepository, _ *repository.File, w io.Writer) error {
+		_, err := io.WriteString(w, "complete")
+		return err
+	}
+
+	bucket, file, userID := testDownloadFile()
+	r := gin.New()
+	r.GET(
+		"/buckets/:id/files/:file_id/download",
+		setUserID(userID.Hex()),
+		downloadFile(fakeBucketByIDReader{bucket: bucket}, &repository.SourceRepository{}, fakeFileByIDReader{file: file}, nil),
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/buckets/"+bucket.ID.Hex()+"/files/"+file.ID.Hex()+"/download", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", w.Code)
+	}
+	if gotStart != 0 || gotEnd != 0 {
+		t.Fatalf("expected bounded preflight range 0-0, got %d-%d", gotStart, gotEnd)
+	}
+	if body := w.Body.String(); strings.Contains(body, "partial") || strings.Contains(body, "complete") {
+		t.Fatalf("unexpected body: %s", body)
+	}
+	if got := w.Header().Get("Content-Disposition"); got != "" {
+		t.Fatalf("expected no success Content-Disposition header, got %q", got)
+	}
+	if got := w.Header().Get("Content-Length"); got != "" {
+		t.Fatalf("expected no success Content-Length header, got %q", got)
+	}
+}
+
+func TestGetSharedFileStreamFailureReturnsErrorBeforeSuccessHeaders(t *testing.T) {
+	origStream := streamDownloadFile
+	origStreamRange := streamDownloadFileRange
+	t.Cleanup(func() {
+		streamDownloadFile = origStream
+		streamDownloadFileRange = origStreamRange
+	})
+
+	streamDownloadFileRange = func(_ context.Context, _ *repository.SourceRepository, _ *repository.File, w io.Writer, start, end int64) error {
+		if start != 0 || end != 0 {
+			t.Fatalf("expected bounded preflight range 0-0, got %d-%d", start, end)
+		}
+		_, _ = io.WriteString(w, "partial")
+		return manager.ErrChecksumMismatch
+	}
+	streamDownloadFile = func(_ context.Context, _ *repository.SourceRepository, _ *repository.File, w io.Writer) error {
+		_, err := io.WriteString(w, "complete")
+		return err
+	}
+
+	bucket, file, userID := testDownloadFile()
+	link := &repository.ShareLink{
+		ID:        primitive.NewObjectID(),
+		FileID:    file.ID,
+		BucketID:  bucket.ID,
+		UserID:    userID,
+		Token:     "token",
+		CreatedAt: time.Now().UTC(),
+	}
+	r := gin.New()
+	r.GET("/share/:token", getSharedFile(fakeShareLinkByTokenReader{link: link}, &repository.SourceRepository{}, fakeFileByIDReader{file: file}))
+
+	req := httptest.NewRequest(http.MethodGet, "/share/token", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", w.Code)
+	}
+	if body := w.Body.String(); strings.Contains(body, "partial") || strings.Contains(body, "complete") {
+		t.Fatalf("unexpected body: %s", body)
+	}
+	if got := w.Header().Get("Content-Disposition"); got != "" {
+		t.Fatalf("expected no success Content-Disposition header, got %q", got)
+	}
+	if got := w.Header().Get("Content-Length"); got != "" {
+		t.Fatalf("expected no success Content-Length header, got %q", got)
+	}
+}
+
+func TestDownloadFileStreamsBodyAfterBoundedPreflight(t *testing.T) {
+	origStream := streamDownloadFile
+	origStreamRange := streamDownloadFileRange
+	t.Cleanup(func() {
+		streamDownloadFile = origStream
+		streamDownloadFileRange = origStreamRange
+	})
+
+	var gotStart, gotEnd int64
+	streamDownloadFileRange = func(_ context.Context, _ *repository.SourceRepository, _ *repository.File, _ io.Writer, start, end int64) error {
+		gotStart, gotEnd = start, end
+		return nil
+	}
+	streamDownloadFile = func(_ context.Context, _ *repository.SourceRepository, _ *repository.File, w io.Writer) error {
+		_, err := io.WriteString(w, "complete")
+		return err
+	}
+
+	bucket, file, userID := testDownloadFile()
+	r := gin.New()
+	r.GET(
+		"/buckets/:id/files/:file_id/download",
+		setUserID(userID.Hex()),
+		downloadFile(fakeBucketByIDReader{bucket: bucket}, &repository.SourceRepository{}, fakeFileByIDReader{file: file}, nil),
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/buckets/"+bucket.ID.Hex()+"/files/"+file.ID.Hex()+"/download", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if gotStart != 0 || gotEnd != 0 {
+		t.Fatalf("expected bounded preflight range 0-0, got %d-%d", gotStart, gotEnd)
+	}
+	if body := w.Body.String(); body != "complete" {
+		t.Fatalf("unexpected body: %s", body)
+	}
+	if got := w.Header().Get("Content-Length"); got != "7" {
+		t.Fatalf("expected Content-Length 7, got %q", got)
+	}
+}

--- a/api-go/internal/handlers/permission.go
+++ b/api-go/internal/handlers/permission.go
@@ -34,7 +34,11 @@ func requireBucketAccess(
 	grantRepo *repository.BucketGrantRepository,
 	requiredRole repository.BucketRole,
 ) *bucketAccess {
-	return requireBucketAccessFor(c, bucketRepo, grantRepo, requiredRole)
+	var grantReader bucketAccessGrantReader
+	if grantRepo != nil {
+		grantReader = grantRepo
+	}
+	return requireBucketAccessFor(c, bucketRepo, grantReader, requiredRole)
 }
 
 func requireBucketAccessFor(

--- a/api-go/internal/handlers/permission.go
+++ b/api-go/internal/handlers/permission.go
@@ -1,12 +1,22 @@
 package handlers
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/example/sfree/api-go/internal/repository"
 	"github.com/gin-gonic/gin"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 )
+
+type bucketAccessBucketReader interface {
+	GetByID(ctx context.Context, id primitive.ObjectID) (*repository.Bucket, error)
+}
+
+type bucketAccessGrantReader interface {
+	GetByBucketAndUser(ctx context.Context, bucketID, userID primitive.ObjectID) (*repository.BucketGrant, error)
+}
 
 // bucketAccess holds the result of a permission check.
 type bucketAccess struct {
@@ -22,6 +32,15 @@ func requireBucketAccess(
 	c *gin.Context,
 	bucketRepo *repository.BucketRepository,
 	grantRepo *repository.BucketGrantRepository,
+	requiredRole repository.BucketRole,
+) *bucketAccess {
+	return requireBucketAccessFor(c, bucketRepo, grantRepo, requiredRole)
+}
+
+func requireBucketAccessFor(
+	c *gin.Context,
+	bucketRepo bucketAccessBucketReader,
+	grantRepo bucketAccessGrantReader,
 	requiredRole repository.BucketRole,
 ) *bucketAccess {
 	bucketID, ok := routeObjectID(c, "id")

--- a/api-go/internal/handlers/s3.go
+++ b/api-go/internal/handlers/s3.go
@@ -172,10 +172,6 @@ type objectRange struct {
 	end   int64
 }
 
-const (
-	s3GetPreflightBytes = int64(1)
-)
-
 var (
 	streamS3Object      = manager.StreamFile
 	streamS3ObjectRange = manager.StreamFileRange
@@ -309,14 +305,7 @@ func setObjectHeaders(c *gin.Context, fileDoc *repository.File, total int64) {
 // incomplete body under the declared Content-Length, which preserves large
 // object streaming without staging the full response in memory or on disk.
 func preflightObjectRange(ctx context.Context, sourceRepo *repository.SourceRepository, fileDoc *repository.File, start, end int64) error {
-	if end < start {
-		return nil
-	}
-	preflightEnd := start + s3GetPreflightBytes - 1
-	if preflightEnd > end {
-		preflightEnd = end
-	}
-	return streamS3ObjectRange(ctx, sourceRepo, fileDoc, io.Discard, start, preflightEnd)
+	return preflightFileRange(ctx, sourceRepo, fileDoc, start, end, streamS3ObjectRange)
 }
 
 // HeadObject godoc

--- a/api-go/internal/handlers/sharelink.go
+++ b/api-go/internal/handlers/sharelink.go
@@ -4,11 +4,9 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	"strconv"
 	"time"
 
 	"github.com/example/sfree/api-go/internal/cryptoutil"
-	"github.com/example/sfree/api-go/internal/manager"
 	"github.com/example/sfree/api-go/internal/repository"
 	"github.com/gin-gonic/gin"
 	"go.mongodb.org/mongo-driver/mongo"
@@ -146,6 +144,18 @@ func GetSharedFile(shareLinkRepo *repository.ShareLinkRepository, bucketRepo *re
 			c.Status(http.StatusServiceUnavailable)
 			return
 		}
+		getSharedFile(shareLinkRepo, sourceRepo, fileRepo)(c)
+	}
+}
+
+func getSharedFile(shareLinkRepo shareLinkByTokenReader, sourceRepo *repository.SourceRepository, fileRepo fileByIDReader) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		ctx := c.Request.Context()
+		if shareLinkRepo == nil || sourceRepo == nil || fileRepo == nil {
+			slog.ErrorContext(ctx, "get shared file: repository is nil")
+			c.Status(http.StatusServiceUnavailable)
+			return
+		}
 		token := c.Param("token")
 		if token == "" {
 			c.Status(http.StatusNotFound)
@@ -180,16 +190,16 @@ func GetSharedFile(shareLinkRepo *repository.ShareLinkRepository, bucketRepo *re
 			return
 		}
 
-		var total int64
-		for _, ch := range fileDoc.Chunks {
-			total += ch.Size
-		}
-		c.Header("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s\"", sanitizeFilename(fileDoc.Name)))
-		c.Header("Content-Type", "application/octet-stream")
-		c.Header("Content-Length", strconv.FormatInt(total, 10))
-		c.Status(http.StatusOK)
-		if err := manager.StreamFile(ctx, sourceRepo, fileDoc, c.Writer); err != nil {
+		total := fileContentLength(fileDoc)
+		if err := preflightFile(ctx, sourceRepo, fileDoc, total, streamDownloadFileRange); err != nil {
 			slog.ErrorContext(ctx, "get shared file: stream", slog.String("error", err.Error()))
+			c.Status(http.StatusInternalServerError)
+			return
+		}
+		setAttachmentDownloadHeaders(c, fileDoc.Name, total)
+		c.Status(http.StatusOK)
+		if err := streamDownloadFile(ctx, sourceRepo, fileDoc, c.Writer); err != nil {
+			slog.ErrorContext(ctx, "get shared file: stream failed after response commit", slog.String("error", err.Error()))
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Add a shared one-byte preflight helper before REST/share download success headers are committed
- Keep S3 GetObject preflight behavior equivalent by routing it through the shared helper
- Add focused handler tests for REST bucket and public share preflight failures plus successful REST streaming

## Validation
- go test ./internal/handlers -run 'Test(DownloadFile|GetSharedFile|GetObject)'\n\nFull backend validation should run in Woodpecker per task constraints.