### PR TITLE
THE-545: Share S3 bucket lookup helper

### DIFF
--- a/api-go/internal/handlers/s3.go
+++ b/api-go/internal/handlers/s3.go
@@ -193,6 +193,26 @@ func writeS3Error(c *gin.Context, status int, code, message string) {
 	c.XML(status, s3Error{Code: code, Message: message})
 }
 
+func lookupBucket(c *gin.Context, bucketRepo objectBucketReader) (*repository.Bucket, bool) {
+	ctx := c.Request.Context()
+	bucketDoc, err := bucketRepo.GetByKey(ctx, c.Param("bucket"))
+	if err != nil {
+		if err == mongo.ErrNoDocuments {
+			writeS3Error(c, http.StatusNotFound, "NoSuchBucket", "")
+			return nil, false
+		}
+		slog.ErrorContext(ctx, "lookup bucket", slog.String("error", err.Error()))
+		writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
+		return nil, false
+	}
+	accessKey := c.GetString("accessKey")
+	if accessKey == "" || bucketDoc.AccessKey != accessKey {
+		writeS3Error(c, http.StatusNotFound, "NoSuchBucket", "")
+		return nil, false
+	}
+	return bucketDoc, true
+}
+
 func parseCopySource(raw string) (string, string, bool) {
 	raw = strings.TrimSpace(raw)
 	raw = strings.TrimPrefix(raw, "/")
@@ -254,21 +274,9 @@ func parseObjectRange(raw string, total int64) (objectRange, bool) {
 
 func lookupObject(c *gin.Context, bucketRepo objectBucketReader, fileRepo objectFileReader) (*repository.File, int64, bool) {
 	ctx := c.Request.Context()
-	bucketKey := c.Param("bucket")
 	name := strings.TrimPrefix(c.Param("object"), "/")
-	bucketDoc, err := bucketRepo.GetByKey(ctx, bucketKey)
-	if err != nil {
-		if err == mongo.ErrNoDocuments {
-			writeS3Error(c, http.StatusNotFound, "NoSuchBucket", "")
-			return nil, 0, false
-		}
-		slog.ErrorContext(ctx, "lookup object: get bucket", slog.String("error", err.Error()))
-		writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
-		return nil, 0, false
-	}
-	accessKey := c.GetString("accessKey")
-	if accessKey == "" || bucketDoc.AccessKey != accessKey {
-		writeS3Error(c, http.StatusNotFound, "NoSuchBucket", "")
+	bucketDoc, ok := lookupBucket(c, bucketRepo)
+	if !ok {
 		return nil, 0, false
 	}
 	fileDoc, err := fileRepo.GetByName(ctx, bucketDoc.ID, name)
@@ -538,20 +546,8 @@ func DeleteObject(bucketRepo *repository.BucketRepository, sourceRepo *repositor
 			c.Status(http.StatusServiceUnavailable)
 			return
 		}
-		bucketKey := c.Param("bucket")
-		bucketDoc, err := bucketRepo.GetByKey(ctx, bucketKey)
-		if err != nil {
-			if err == mongo.ErrNoDocuments {
-				writeS3Error(c, http.StatusNotFound, "NoSuchBucket", "")
-				return
-			}
-			slog.ErrorContext(ctx, "delete object: get bucket", slog.String("error", err.Error()))
-			writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
-			return
-		}
-		accessKey := c.GetString("accessKey")
-		if accessKey == "" || bucketDoc.AccessKey != accessKey {
-			writeS3Error(c, http.StatusNotFound, "NoSuchBucket", "")
+		bucketDoc, ok := lookupBucket(c, bucketRepo)
+		if !ok {
 			return
 		}
 		name := strings.TrimPrefix(c.Param("object"), "/")

--- a/api-go/internal/handlers/s3_get_test.go
+++ b/api-go/internal/handlers/s3_get_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/example/sfree/api-go/internal/repository"
 	"github.com/gin-gonic/gin"
 	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
 )
 
 type fakeObjectBucketReader struct {
@@ -31,6 +32,82 @@ type fakeObjectFileReader struct {
 
 func (r fakeObjectFileReader) GetByName(_ context.Context, _ primitive.ObjectID, _ string) (*repository.File, error) {
 	return r.file, r.err
+}
+
+func newLookupObjectTestContext(accessKey string) (*gin.Context, *httptest.ResponseRecorder) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/s3/bucket/object.txt", nil)
+	c.Params = gin.Params{
+		{Key: "bucket", Value: "bucket"},
+		{Key: "object", Value: "/object.txt"},
+	}
+	if accessKey != "" {
+		c.Set("accessKey", accessKey)
+	}
+	return c, w
+}
+
+func TestLookupObjectMissingBucketReturnsNoSuchBucket(t *testing.T) {
+	c, w := newLookupObjectTestContext("access-key")
+
+	fileDoc, total, ok := lookupObject(c, fakeObjectBucketReader{err: mongo.ErrNoDocuments}, fakeObjectFileReader{})
+
+	if ok || fileDoc != nil || total != 0 {
+		t.Fatalf("expected lookup failure, got ok=%v file=%v total=%d", ok, fileDoc, total)
+	}
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+	if body := w.Body.String(); !strings.Contains(body, "<Code>NoSuchBucket</Code>") {
+		t.Fatalf("unexpected body: %s", body)
+	}
+}
+
+func TestLookupObjectWrongAccessKeyReturnsNoSuchBucket(t *testing.T) {
+	c, w := newLookupObjectTestContext("wrong-key")
+	bucketID := primitive.NewObjectID()
+
+	fileDoc, total, ok := lookupObject(c, fakeObjectBucketReader{
+		bucket: &repository.Bucket{
+			ID:        bucketID,
+			Key:       "bucket",
+			AccessKey: "access-key",
+		},
+	}, fakeObjectFileReader{})
+
+	if ok || fileDoc != nil || total != 0 {
+		t.Fatalf("expected lookup failure, got ok=%v file=%v total=%d", ok, fileDoc, total)
+	}
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+	if body := w.Body.String(); !strings.Contains(body, "<Code>NoSuchBucket</Code>") {
+		t.Fatalf("unexpected body: %s", body)
+	}
+}
+
+func TestLookupObjectMissingObjectReturnsNoSuchKey(t *testing.T) {
+	c, w := newLookupObjectTestContext("access-key")
+	bucketID := primitive.NewObjectID()
+
+	fileDoc, total, ok := lookupObject(c, fakeObjectBucketReader{
+		bucket: &repository.Bucket{
+			ID:        bucketID,
+			Key:       "bucket",
+			AccessKey: "access-key",
+		},
+	}, fakeObjectFileReader{err: mongo.ErrNoDocuments})
+
+	if ok || fileDoc != nil || total != 0 {
+		t.Fatalf("expected lookup failure, got ok=%v file=%v total=%d", ok, fileDoc, total)
+	}
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+	if body := w.Body.String(); !strings.Contains(body, "<Code>NoSuchKey</Code>") {
+		t.Fatalf("unexpected body: %s", body)
+	}
 }
 
 func getObjectFailureTestHandler(t *testing.T) gin.HandlerFunc {

--- a/api-go/internal/handlers/s3_multipart.go
+++ b/api-go/internal/handlers/s3_multipart.go
@@ -80,28 +80,6 @@ type partXML struct {
 	LastModified string `xml:"LastModified"`
 }
 
-// lookupBucket resolves the bucket from the request and validates access.
-func lookupBucket(c *gin.Context, bucketRepo *repository.BucketRepository) (*repository.Bucket, bool) {
-	ctx := c.Request.Context()
-	bucketKey := c.Param("bucket")
-	bucketDoc, err := bucketRepo.GetByKey(ctx, bucketKey)
-	if err != nil {
-		if err == mongo.ErrNoDocuments {
-			writeS3Error(c, http.StatusNotFound, "NoSuchBucket", "")
-			return nil, false
-		}
-		slog.ErrorContext(ctx, "lookup bucket", slog.String("error", err.Error()))
-		writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
-		return nil, false
-	}
-	accessKey := c.GetString("accessKey")
-	if accessKey == "" || bucketDoc.AccessKey != accessKey {
-		writeS3Error(c, http.StatusNotFound, "NoSuchBucket", "")
-		return nil, false
-	}
-	return bucketDoc, true
-}
-
 // PostObject dispatches POST requests on S3 object paths.
 // ?uploads → CreateMultipartUpload
 // ?uploadId=X → CompleteMultipartUpload


### PR DESCRIPTION
## Summary
- Extract shared S3 bucket lookup and access-key validation into one helper boundary.
- Route object lookup and delete-object bucket validation through the shared helper.
- Add focused lookup-object tests for missing bucket, wrong access key, and missing object behavior.

## Tests
- `go test ./internal/handlers -run 'Test(LookupObject|GetObject|PostObject|PutObjectOrPart|DeleteObjectOrAbort|ListObjectsOrUploads|CompleteMultipart|InitiateMultipart|CompletedMultipart|ListMultipart|ListParts|DecodeDeleteObjects|ParseCopySource|ParseObjectRange|ParseListMaxKeys|FileListBucketEntryAndObjectETag|BuildListBucketPage)'`

Full backend validation should run in Woodpecker per task instructions.