### PR TITLE
THE-542: Bound SigV4 payload hashing

### DIFF
--- a/api-go/internal/s3sigv4/validator.go
+++ b/api-go/internal/s3sigv4/validator.go
@@ -1,7 +1,6 @@
 package s3sigv4
 
 import (
-	"bytes"
 	"context"
 	"crypto/hmac"
 	"crypto/sha256"
@@ -9,7 +8,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -30,6 +28,7 @@ var (
 	ErrSignatureMismatch    = errors.New("sigv4: signature mismatch")
 	ErrExpired              = errors.New("sigv4: request expired")
 	ErrClockSkew            = errors.New("sigv4: request time outside allowed skew")
+	ErrMissingPayloadHash   = errors.New("sigv4: missing X-Amz-Content-Sha256 for request body")
 )
 
 type Validator struct {
@@ -197,11 +196,10 @@ func (v *Validator) validateHeaderAuth(ctx context.Context, r *http.Request, acc
 		return nil, fmt.Errorf("%w: SignedHeaders must include host", ErrInvalidSignedHeaders)
 	}
 
-	payloadHash, bodyBytes, err := payloadHashForHeaderAuth(r)
+	payloadHash, err := payloadHashForHeaderAuth(r)
 	if err != nil {
 		return nil, err
 	}
-	restoreBody(r, bodyBytes)
 
 	canonReq, _, err := buildCanonicalRequest(r, signedHeaders, payloadHash, false)
 	if err != nil {
@@ -335,21 +333,17 @@ func (v *Validator) validatePresign(ctx context.Context, r *http.Request, access
 	}
 
 	payloadHash := q.Get("X-Amz-Content-Sha256")
-	var bodyBytes []byte
 	if payloadHash == "" {
 		if h := strings.TrimSpace(r.Header.Get("X-Amz-Content-Sha256")); h != "" {
 			payloadHash = h
 		} else if strings.EqualFold(service, "s3") {
 			payloadHash = "UNSIGNED-PAYLOAD"
 		} else {
-			payloadHash, bodyBytes, err = payloadHashForHeaderAuth(r)
+			payloadHash, err = payloadHashForHeaderAuth(r)
 			if err != nil {
 				return nil, err
 			}
 		}
-	}
-	if bodyBytes != nil {
-		restoreBody(r, bodyBytes)
 	}
 
 	canonReq, _, err := buildCanonicalRequest(r, signedHeaders, payloadHash, true)
@@ -683,29 +677,16 @@ func normalizeAndValidateSignedHeaders(s string) ([]string, error) {
 	return out, nil
 }
 
-func payloadHashForHeaderAuth(r *http.Request) (payloadHash string, bodyBytes []byte, err error) {
+func payloadHashForHeaderAuth(r *http.Request) (string, error) {
 	if h := strings.TrimSpace(r.Header.Get("X-Amz-Content-Sha256")); h != "" {
-		return h, nil, nil
+		return h, nil
 	}
 
-	if r.Body == nil {
+	if r.Body == nil || r.Body == http.NoBody || r.ContentLength == 0 {
 		empty := sha256.Sum256(nil)
-		return hex.EncodeToString(empty[:]), nil, nil
+		return hex.EncodeToString(empty[:]), nil
 	}
-	b, err := io.ReadAll(r.Body)
-	if err != nil {
-		return "", nil, fmt.Errorf("sigv4: read body: %w", err)
-	}
-	sum := sha256.Sum256(b)
-	return hex.EncodeToString(sum[:]), b, nil
-}
-
-func restoreBody(r *http.Request, body []byte) {
-	if body == nil {
-		return
-	}
-	r.Body = io.NopCloser(bytes.NewReader(body))
-	r.ContentLength = int64(len(body))
+	return "", ErrMissingPayloadHash
 }
 
 func buildStringToSign(algorithm string, amzDate time.Time, scope string, canonicalRequest string) string {

--- a/api-go/internal/s3sigv4/validator.go
+++ b/api-go/internal/s3sigv4/validator.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -685,6 +686,17 @@ func payloadHashForHeaderAuth(r *http.Request) (string, error) {
 	if r.Body == nil || r.Body == http.NoBody || r.ContentLength == 0 {
 		empty := sha256.Sum256(nil)
 		return hex.EncodeToString(empty[:]), nil
+	}
+	if r.ContentLength < 0 {
+		var b [1]byte
+		n, err := r.Body.Read(b[:])
+		if n == 0 && err == io.EOF {
+			empty := sha256.Sum256(nil)
+			return hex.EncodeToString(empty[:]), nil
+		}
+		if err != nil && err != io.EOF {
+			return "", fmt.Errorf("sigv4: read body prefix: %w", err)
+		}
 	}
 	return "", ErrMissingPayloadHash
 }

--- a/api-go/internal/s3sigv4/validator_test.go
+++ b/api-go/internal/s3sigv4/validator_test.go
@@ -2,7 +2,10 @@ package s3sigv4
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -192,6 +195,72 @@ func TestValidatorPresignS3PutObject(t *testing.T) {
 	}
 }
 
+func TestValidatorHeaderAuthUsesExplicitPayloadHashWithoutReadingBody(t *testing.T) {
+	accessKey := "mybucketkey"
+	secretKey := "mysecretkey123"
+	now := time.Date(2026, 4, 13, 10, 0, 0, 0, time.UTC)
+	payload := "streamed object payload"
+	sum := sha256.Sum256([]byte(payload))
+	payloadHash := hex.EncodeToString(sum[:])
+
+	req, err := http.NewRequest("PUT", "https://sfree.example.com/api/s3/mybucket/uploads/doc.pdf", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	body := &readTrackingBody{reader: strings.NewReader(payload)}
+	req.Body = body
+	req.ContentLength = int64(len(payload))
+
+	signedHeaders := []string{"host", "x-amz-content-sha256", "x-amz-date"}
+	signHeaderAuthRequest(t, req, accessKey, secretKey, "us-east-1", "s3", signedHeaders, now, payloadHash)
+
+	v := Validator{Now: func() time.Time { return now }}
+	res, err := v.Validate(context.Background(), req, accessKey, secretKey)
+	if err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	if res.PayloadHash != payloadHash {
+		t.Fatalf("payload hash: expected %s got %s", payloadHash, res.PayloadHash)
+	}
+	if body.reads != 0 {
+		t.Fatalf("expected validator not to read body, read count was %d", body.reads)
+	}
+
+	remaining, err := io.ReadAll(req.Body)
+	if err != nil {
+		t.Fatalf("read remaining body: %v", err)
+	}
+	if string(remaining) != payload {
+		t.Fatalf("body after validate: expected %q got %q", payload, string(remaining))
+	}
+}
+
+func TestValidatorHeaderAuthRejectsBodyWithoutPayloadHash(t *testing.T) {
+	accessKey := "mybucketkey"
+	secretKey := "mysecretkey123"
+	now := time.Date(2026, 4, 13, 10, 0, 0, 0, time.UTC)
+	payload := "streamed object payload"
+
+	req, err := http.NewRequest("PUT", "https://sfree.example.com/api/s3/mybucket/uploads/doc.pdf", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	body := &readTrackingBody{reader: strings.NewReader(payload)}
+	req.Body = body
+	req.ContentLength = int64(len(payload))
+	req.Header.Set("X-Amz-Date", now.Format("20060102T150405Z"))
+	req.Header.Set("Authorization", "AWS4-HMAC-SHA256 Credential="+accessKey+"/"+now.Format("20060102")+"/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-date, Signature="+strings.Repeat("a", 64))
+
+	v := Validator{Now: func() time.Time { return now }}
+	_, err = v.Validate(context.Background(), req, accessKey, secretKey)
+	if !errors.Is(err, ErrMissingPayloadHash) {
+		t.Fatalf("expected missing payload hash error, got %v", err)
+	}
+	if body.reads != 0 {
+		t.Fatalf("expected validator not to read unsupported body, read count was %d", body.reads)
+	}
+}
+
 func TestValidatorPresignExpired(t *testing.T) {
 	accessKey := "mybucketkey"
 	secretKey := "mysecretkey123"
@@ -370,4 +439,35 @@ e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855`
 	if res.Signature != expectedSig {
 		t.Fatalf("signature mismatch: expected %s got %s", expectedSig, res.Signature)
 	}
+}
+
+type readTrackingBody struct {
+	reader *strings.Reader
+	reads  int
+}
+
+func (b *readTrackingBody) Read(p []byte) (int, error) {
+	b.reads++
+	return b.reader.Read(p)
+}
+
+func (b *readTrackingBody) Close() error {
+	return nil
+}
+
+func signHeaderAuthRequest(t *testing.T, req *http.Request, accessKey, secretKey, region, service string, signedHeaders []string, now time.Time, payloadHash string) {
+	t.Helper()
+
+	req.Header.Set("X-Amz-Date", now.Format("20060102T150405Z"))
+	req.Header.Set("X-Amz-Content-Sha256", payloadHash)
+
+	dateStr := now.Format("20060102")
+	scope := dateStr + "/" + region + "/" + service + "/aws4_request"
+	canonReq, _, err := buildCanonicalRequest(req, signedHeaders, payloadHash, false)
+	if err != nil {
+		t.Fatalf("build canonical request: %v", err)
+	}
+	stringToSign := buildStringToSign("AWS4-HMAC-SHA256", now, scope, canonReq)
+	sig := computeSignature(secretKey, dateStr, region, service, stringToSign)
+	req.Header.Set("Authorization", "AWS4-HMAC-SHA256 Credential="+accessKey+"/"+scope+", SignedHeaders="+strings.Join(signedHeaders, ";")+", Signature="+sig)
 }

--- a/api-go/internal/s3sigv4/validator_test.go
+++ b/api-go/internal/s3sigv4/validator_test.go
@@ -261,6 +261,62 @@ func TestValidatorHeaderAuthRejectsBodyWithoutPayloadHash(t *testing.T) {
 	}
 }
 
+func TestValidatorHeaderAuthAllowsUnknownLengthEmptyBodyWithoutPayloadHash(t *testing.T) {
+	accessKey := "mybucketkey"
+	secretKey := "mysecretkey123"
+	now := time.Date(2026, 4, 13, 10, 0, 0, 0, time.UTC)
+	payloadHash := emptyPayloadHash()
+
+	req, err := http.NewRequest("PUT", "https://sfree.example.com/api/s3/mybucket/uploads/empty.txt", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	body := &readTrackingBody{reader: strings.NewReader("")}
+	req.Body = body
+	req.ContentLength = -1
+
+	signedHeaders := []string{"host", "x-amz-date"}
+	signHeaderAuthRequest(t, req, accessKey, secretKey, "us-east-1", "s3", signedHeaders, now, payloadHash)
+
+	v := Validator{Now: func() time.Time { return now }}
+	res, err := v.Validate(context.Background(), req, accessKey, secretKey)
+	if err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	if res.PayloadHash != payloadHash {
+		t.Fatalf("payload hash: expected %s got %s", payloadHash, res.PayloadHash)
+	}
+	if body.reads != 1 {
+		t.Fatalf("expected one-byte empty-body probe, read count was %d", body.reads)
+	}
+}
+
+func TestValidatorHeaderAuthRejectsUnknownLengthBodyWithoutPayloadHashAfterBoundedProbe(t *testing.T) {
+	accessKey := "mybucketkey"
+	secretKey := "mysecretkey123"
+	now := time.Date(2026, 4, 13, 10, 0, 0, 0, time.UTC)
+	payload := "streamed object payload"
+
+	req, err := http.NewRequest("PUT", "https://sfree.example.com/api/s3/mybucket/uploads/doc.pdf", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	body := &readTrackingBody{reader: strings.NewReader(payload)}
+	req.Body = body
+	req.ContentLength = -1
+	req.Header.Set("X-Amz-Date", now.Format("20060102T150405Z"))
+	req.Header.Set("Authorization", "AWS4-HMAC-SHA256 Credential="+accessKey+"/"+now.Format("20060102")+"/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-date, Signature="+strings.Repeat("a", 64))
+
+	v := Validator{Now: func() time.Time { return now }}
+	_, err = v.Validate(context.Background(), req, accessKey, secretKey)
+	if !errors.Is(err, ErrMissingPayloadHash) {
+		t.Fatalf("expected missing payload hash error, got %v", err)
+	}
+	if body.reads != 1 {
+		t.Fatalf("expected one-byte bounded probe, read count was %d", body.reads)
+	}
+}
+
 func TestValidatorPresignExpired(t *testing.T) {
 	accessKey := "mybucketkey"
 	secretKey := "mysecretkey123"
@@ -455,11 +511,18 @@ func (b *readTrackingBody) Close() error {
 	return nil
 }
 
+func emptyPayloadHash() string {
+	sum := sha256.Sum256(nil)
+	return hex.EncodeToString(sum[:])
+}
+
 func signHeaderAuthRequest(t *testing.T, req *http.Request, accessKey, secretKey, region, service string, signedHeaders []string, now time.Time, payloadHash string) {
 	t.Helper()
 
 	req.Header.Set("X-Amz-Date", now.Format("20060102T150405Z"))
-	req.Header.Set("X-Amz-Content-Sha256", payloadHash)
+	if contains(signedHeaders, "x-amz-content-sha256") {
+		req.Header.Set("X-Amz-Content-Sha256", payloadHash)
+	}
 
 	dateStr := now.Format("20060102")
 	scope := dateStr + "/" + region + "/" + service + "/aws4_request"

--- a/docs/s3-compatibility.md
+++ b/docs/s3-compatibility.md
@@ -70,7 +70,7 @@ Bucket administration APIs, ACLs, versioning, lifecycle, object lock, tagging, a
 
 | Feature | Status | Notes |
 | --- | --- | --- |
-| AWS Signature V4 header auth | Implemented | Validates `AWS4-HMAC-SHA256` requests against bucket access credentials. |
+| AWS Signature V4 header auth | Implemented | Validates `AWS4-HMAC-SHA256` requests against bucket access credentials. Requests with bodies must send `X-Amz-Content-Sha256`; otherwise validation rejects the request without buffering the body. |
 | AWS Signature V4 presigned URLs | Implemented | Query-string presign validation supports default S3 unsigned payload behavior and a max TTL of seven days. |
 | AWS Signature V2 | Missing | Legacy clients that require V2 are unsupported. |
 | Anonymous access | Missing | S3 API requests require signed bucket credentials. |


### PR DESCRIPTION
## Summary
- Stop SigV4 validation from reading and restoring request bodies when `X-Amz-Content-Sha256` is absent.
- Require explicit `X-Amz-Content-Sha256` for signed requests with bodies; no-body requests still use the empty SHA-256 payload hash and S3 presigned URLs keep `UNSIGNED-PAYLOAD` behavior.
- Add focused validator tests for the no-read/body-preservation path and the unsupported missing-payload-hash path.
- Document the header-auth body signing requirement in the S3 compatibility matrix.

## Validation
- `gofmt -w api-go/internal/s3sigv4/validator.go api-go/internal/s3sigv4/validator_test.go`
- `git diff --check`

Per task policy, I did not run local `go test`, `make test`, Docker, or Playwright. Woodpecker should run the backend validation.