### PR TITLE
Route REST bucket file mutations through object service

### DIFF
--- a/api-go/internal/handlers/bucket.go
+++ b/api-go/internal/handlers/bucket.go
@@ -1,7 +1,10 @@
 package handlers
 
 import (
+	"context"
+	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"strconv"
@@ -388,6 +391,18 @@ type uploadFileResponse struct {
 	CreatedAt time.Time `json:"created_at"`
 }
 
+type bucketObjectMutationService interface {
+	PutObject(ctx context.Context, bucket *repository.Bucket, name string, body io.Reader, chunkSize int) (manager.PutObjectResult, error)
+	DeleteObjectByID(ctx context.Context, bucketID primitive.ObjectID, fileID primitive.ObjectID) (manager.DeleteObjectResult, error)
+}
+
+var (
+	newBucketObjectMutationService = func(sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository) bucketObjectMutationService {
+		return manager.NewObjectService(sourceRepo, fileRepo, nil)
+	}
+	requireBucketFileAccess = requireBucketAccess
+)
+
 // UploadFile godoc
 // @Summary Upload file to bucket
 // @Tags buckets
@@ -403,6 +418,7 @@ type uploadFileResponse struct {
 // @Security BasicAuth
 // @Router /api/v1/buckets/{id}/upload [post]
 func UploadFile(bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository, grantRepo *repository.BucketGrantRepository, chunkSize int) gin.HandlerFunc {
+	objectSvc := newBucketObjectMutationService(sourceRepo, fileRepo)
 	return func(c *gin.Context) {
 		ctx := c.Request.Context()
 		if bucketRepo == nil || sourceRepo == nil || fileRepo == nil {
@@ -411,21 +427,11 @@ func UploadFile(bucketRepo *repository.BucketRepository, sourceRepo *repository.
 			return
 		}
 
-		acc := requireBucketAccess(c, bucketRepo, grantRepo, repository.RoleEditor)
+		acc := requireBucketFileAccess(c, bucketRepo, grantRepo, repository.RoleEditor)
 		if acc == nil {
 			return
 		}
 		bucketDoc := acc.Bucket
-		sources, err := sourceRepo.ListByIDs(c.Request.Context(), bucketDoc.SourceIDs)
-		if err != nil {
-			slog.ErrorContext(ctx, "upload file: list sources", slog.String("error", err.Error()))
-			c.Status(http.StatusInternalServerError)
-			return
-		}
-		if len(sources) == 0 {
-			c.Status(http.StatusBadRequest)
-			return
-		}
 		fh, err := c.FormFile("file")
 		if err != nil {
 			slog.WarnContext(ctx, "upload file: get file", slog.String("error", err.Error()))
@@ -440,36 +446,23 @@ func UploadFile(bucketRepo *repository.BucketRepository, sourceRepo *repository.
 		}
 		defer func() { _ = f.Close() }()
 
-		selector := manager.SelectorForBucket(bucketDoc, sources)
-		chunks, err := manager.UploadFileChunksWithStrategy(ctx, f, sources, chunkSize, nil, selector)
+		result, err := objectSvc.PutObject(ctx, bucketDoc, fh.Filename, f, chunkSize)
 		if err != nil {
-			slog.ErrorContext(ctx, "upload file: upload chunks", slog.String("error", err.Error()))
-			c.Status(http.StatusInternalServerError)
-			return
-		}
-
-		fileDoc := repository.File{
-			BucketID:  bucketDoc.ID,
-			Name:      fh.Filename,
-			CreatedAt: time.Now().UTC(),
-			Chunks:    chunks,
-		}
-		created, previousFile, err := fileRepo.ReplaceByName(ctx, fileDoc)
-		if err != nil {
-			_ = manager.DeleteFileChunks(ctx, sourceRepo, chunks)
-			slog.ErrorContext(ctx, "upload file: save file", slog.String("error", err.Error()))
-			c.Status(http.StatusInternalServerError)
-			return
-		}
-		if previousFile != nil {
-			if err := manager.DeleteFileChunksIfUnreferenced(ctx, sourceRepo, fileRepo, previousFile.Chunks); err != nil {
-				slog.WarnContext(ctx, "upload file: delete old chunks", slog.String("error", err.Error()))
+			if errors.Is(err, manager.ErrNoSources) {
+				c.Status(http.StatusBadRequest)
+				return
 			}
+			slog.ErrorContext(ctx, "upload file: mutate object", slog.String("error", err.Error()))
+			c.Status(http.StatusInternalServerError)
+			return
+		}
+		if result.CleanupErr != nil {
+			slog.WarnContext(ctx, "upload file: delete old chunks", slog.String("error", result.CleanupErr.Error()))
 		}
 		c.JSON(http.StatusOK, uploadFileResponse{
-			ID:        created.ID.Hex(),
-			Name:      created.Name,
-			CreatedAt: created.CreatedAt,
+			ID:        result.File.ID.Hex(),
+			Name:      result.File.Name,
+			CreatedAt: result.File.CreatedAt,
 		})
 	}
 }
@@ -597,6 +590,7 @@ func DownloadFile(bucketRepo *repository.BucketRepository, sourceRepo *repositor
 // @Security BasicAuth
 // @Router /api/v1/buckets/{id}/files/{file_id} [delete]
 func DeleteFile(bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository, grantRepo *repository.BucketGrantRepository) gin.HandlerFunc {
+	objectSvc := newBucketObjectMutationService(sourceRepo, fileRepo)
 	return func(c *gin.Context) {
 		ctx := c.Request.Context()
 		if bucketRepo == nil || sourceRepo == nil || fileRepo == nil {
@@ -605,7 +599,7 @@ func DeleteFile(bucketRepo *repository.BucketRepository, sourceRepo *repository.
 			return
 		}
 
-		acc := requireBucketAccess(c, bucketRepo, grantRepo, repository.RoleEditor)
+		acc := requireBucketFileAccess(c, bucketRepo, grantRepo, repository.RoleEditor)
 		if acc == nil {
 			return
 		}
@@ -615,27 +609,22 @@ func DeleteFile(bucketRepo *repository.BucketRepository, sourceRepo *repository.
 		if !ok {
 			return
 		}
-		fileDoc, err := fileRepo.GetByID(c.Request.Context(), fileID)
+		result, err := objectSvc.DeleteObjectByID(ctx, bucketID, fileID)
 		if err != nil {
-			if err == mongo.ErrNoDocuments {
+			if errors.Is(err, manager.ErrObjectNotFound) {
 				c.Status(http.StatusNotFound)
 				return
 			}
-			slog.ErrorContext(ctx, "delete file: get file", slog.String("error", err.Error()))
+			slog.ErrorContext(ctx, "delete file: delete file", slog.String("error", err.Error()))
 			c.Status(http.StatusInternalServerError)
 			return
 		}
-		if fileDoc.BucketID != bucketID {
+		if !result.Deleted {
 			c.Status(http.StatusNotFound)
 			return
 		}
-		if err := fileRepo.Delete(ctx, fileID); err != nil {
-			slog.ErrorContext(ctx, "delete file: delete metadata", slog.String("error", err.Error()))
-			c.Status(http.StatusInternalServerError)
-			return
-		}
-		if err := manager.DeleteFileChunksIfUnreferenced(ctx, sourceRepo, fileRepo, fileDoc.Chunks); err != nil {
-			slog.ErrorContext(ctx, "delete file: delete chunk", slog.String("error", err.Error()))
+		if result.CleanupErr != nil {
+			slog.ErrorContext(ctx, "delete file: delete chunk", slog.String("error", result.CleanupErr.Error()))
 			c.Status(http.StatusInternalServerError)
 			return
 		}

--- a/api-go/internal/handlers/bucket_object_service_test.go
+++ b/api-go/internal/handlers/bucket_object_service_test.go
@@ -1,0 +1,157 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/example/sfree/api-go/internal/manager"
+	"github.com/example/sfree/api-go/internal/repository"
+	"github.com/gin-gonic/gin"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+type fakeBucketObjectMutationService struct {
+	putObject        func(context.Context, *repository.Bucket, string, io.Reader, int) (manager.PutObjectResult, error)
+	deleteObjectByID func(context.Context, primitive.ObjectID, primitive.ObjectID) (manager.DeleteObjectResult, error)
+}
+
+func (f *fakeBucketObjectMutationService) PutObject(ctx context.Context, bucket *repository.Bucket, name string, body io.Reader, chunkSize int) (manager.PutObjectResult, error) {
+	return f.putObject(ctx, bucket, name, body, chunkSize)
+}
+
+func (f *fakeBucketObjectMutationService) DeleteObjectByID(ctx context.Context, bucketID primitive.ObjectID, fileID primitive.ObjectID) (manager.DeleteObjectResult, error) {
+	return f.deleteObjectByID(ctx, bucketID, fileID)
+}
+
+func stubBucketFileMutation(t *testing.T, bucket *repository.Bucket, svc bucketObjectMutationService) {
+	t.Helper()
+	originalNewObjectService := newBucketObjectMutationService
+	originalRequireAccess := requireBucketFileAccess
+	t.Cleanup(func() {
+		newBucketObjectMutationService = originalNewObjectService
+		requireBucketFileAccess = originalRequireAccess
+	})
+	newBucketObjectMutationService = func(*repository.SourceRepository, *repository.FileRepository) bucketObjectMutationService {
+		return svc
+	}
+	requireBucketFileAccess = func(c *gin.Context, _ *repository.BucketRepository, _ *repository.BucketGrantRepository, role repository.BucketRole) *bucketAccess {
+		if role != repository.RoleEditor {
+			t.Fatalf("expected editor access check, got %s", role)
+		}
+		return &bucketAccess{Bucket: bucket, Role: repository.RoleOwner}
+	}
+}
+
+func multipartFileBody(t *testing.T, fieldName, fileName, content string) (*bytes.Buffer, string) {
+	t.Helper()
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	part, err := writer.CreateFormFile(fieldName, fileName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.WriteString(part, content); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return &body, writer.FormDataContentType()
+}
+
+func TestUploadFileRoutesOverwriteThroughObjectService(t *testing.T) {
+	bucketID := primitive.NewObjectID()
+	fileID := primitive.NewObjectID()
+	createdAt := time.Date(2026, 4, 21, 13, 0, 0, 0, time.UTC)
+	bucket := &repository.Bucket{ID: bucketID}
+	var called bool
+	svc := &fakeBucketObjectMutationService{
+		putObject: func(_ context.Context, gotBucket *repository.Bucket, name string, body io.Reader, chunkSize int) (manager.PutObjectResult, error) {
+			called = true
+			if gotBucket.ID != bucketID {
+				t.Fatalf("expected bucket %s, got %s", bucketID.Hex(), gotBucket.ID.Hex())
+			}
+			if name != "object.txt" {
+				t.Fatalf("expected object.txt, got %q", name)
+			}
+			if chunkSize != 16 {
+				t.Fatalf("expected chunk size 16, got %d", chunkSize)
+			}
+			data, err := io.ReadAll(body)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(data) != "replacement" {
+				t.Fatalf("unexpected body %q", string(data))
+			}
+			return manager.PutObjectResult{
+				File:       repository.File{ID: fileID, BucketID: bucketID, Name: name, CreatedAt: createdAt},
+				CleanupErr: errors.New("old chunk cleanup failed"),
+			}, nil
+		},
+	}
+	stubBucketFileMutation(t, bucket, svc)
+
+	body, contentType := multipartFileBody(t, "file", "object.txt", "replacement")
+	r := gin.New()
+	r.POST("/buckets/:id/upload", UploadFile(&repository.BucketRepository{}, &repository.SourceRepository{}, &repository.FileRepository{}, nil, 16))
+	req := httptest.NewRequest(http.MethodPost, "/buckets/"+bucketID.Hex()+"/upload", body)
+	req.Header.Set("Content-Type", contentType)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if !called {
+		t.Fatal("expected object service PutObject call")
+	}
+	var resp uploadFileResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.ID != fileID.Hex() || resp.Name != "object.txt" || !resp.CreatedAt.Equal(createdAt) {
+		t.Fatalf("unexpected response: %+v", resp)
+	}
+}
+
+func TestDeleteFileRoutesCleanupFailureFromObjectService(t *testing.T) {
+	bucketID := primitive.NewObjectID()
+	fileID := primitive.NewObjectID()
+	bucket := &repository.Bucket{ID: bucketID}
+	var called bool
+	svc := &fakeBucketObjectMutationService{
+		deleteObjectByID: func(_ context.Context, gotBucketID primitive.ObjectID, gotFileID primitive.ObjectID) (manager.DeleteObjectResult, error) {
+			called = true
+			if gotBucketID != bucketID {
+				t.Fatalf("expected bucket %s, got %s", bucketID.Hex(), gotBucketID.Hex())
+			}
+			if gotFileID != fileID {
+				t.Fatalf("expected file %s, got %s", fileID.Hex(), gotFileID.Hex())
+			}
+			return manager.DeleteObjectResult{Deleted: true, CleanupErr: errors.New("chunk cleanup failed")}, nil
+		},
+	}
+	stubBucketFileMutation(t, bucket, svc)
+
+	r := gin.New()
+	r.DELETE("/buckets/:id/files/:file_id", DeleteFile(&repository.BucketRepository{}, &repository.SourceRepository{}, &repository.FileRepository{}, nil))
+	req := httptest.NewRequest(http.MethodDelete, "/buckets/"+bucketID.Hex()+"/files/"+fileID.Hex(), nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", w.Code)
+	}
+	if !called {
+		t.Fatal("expected object service DeleteObjectByID call")
+	}
+}

--- a/api-go/internal/manager/s3_object.go
+++ b/api-go/internal/manager/s3_object.go
@@ -87,6 +87,7 @@ type BucketScopedChunkReferenceCounter interface {
 
 type objectFileStore interface {
 	BucketScopedChunkReferenceCounter
+	GetByID(ctx context.Context, id primitive.ObjectID) (*repository.File, error)
 	GetByName(ctx context.Context, bucketID primitive.ObjectID, name string) (*repository.File, error)
 	ListByBucket(ctx context.Context, bucketID primitive.ObjectID) ([]repository.File, error)
 	ReplaceByName(ctx context.Context, f repository.File) (*repository.File, *repository.File, error)
@@ -196,6 +197,24 @@ func (s *ObjectService) DeleteObject(ctx context.Context, bucketID primitive.Obj
 		}
 		return DeleteObjectResult{}, err
 	}
+	return s.deleteObjectFile(ctx, fileDoc)
+}
+
+func (s *ObjectService) DeleteObjectByID(ctx context.Context, bucketID primitive.ObjectID, fileID primitive.ObjectID) (DeleteObjectResult, error) {
+	fileDoc, err := s.files.GetByID(ctx, fileID)
+	if err != nil {
+		if err == mongo.ErrNoDocuments {
+			return DeleteObjectResult{}, ErrObjectNotFound
+		}
+		return DeleteObjectResult{}, err
+	}
+	if fileDoc.BucketID != bucketID {
+		return DeleteObjectResult{}, ErrObjectNotFound
+	}
+	return s.deleteObjectFile(ctx, fileDoc)
+}
+
+func (s *ObjectService) deleteObjectFile(ctx context.Context, fileDoc *repository.File) (DeleteObjectResult, error) {
 	if err := s.files.Delete(ctx, fileDoc.ID); err != nil {
 		if err == mongo.ErrNoDocuments {
 			return DeleteObjectResult{}, nil

--- a/api-go/internal/manager/s3_object_test.go
+++ b/api-go/internal/manager/s3_object_test.go
@@ -71,6 +71,15 @@ func (f *fakeObjectFiles) GetByName(_ context.Context, bucketID primitive.Object
 	return &file, nil
 }
 
+func (f *fakeObjectFiles) GetByID(_ context.Context, id primitive.ObjectID) (*repository.File, error) {
+	for _, file := range f.byName {
+		if file.ID == id {
+			return &file, nil
+		}
+	}
+	return nil, mongo.ErrNoDocuments
+}
+
 func (f *fakeObjectFiles) Delete(_ context.Context, id primitive.ObjectID) error {
 	if f.deleteErr != nil {
 		return f.deleteErr
@@ -533,6 +542,28 @@ func TestObjectServiceDeleteBucketContentsReturnsMultipartMetadataDeleteError(t 
 	}
 	if _, err := uploads.GetByUploadID(context.Background(), "delete-upload"); err != nil {
 		t.Fatalf("expected multipart metadata to remain after delete failure, got %v", err)
+	}
+}
+
+func TestObjectServiceDeleteObjectByIDRejectsWrongBucket(t *testing.T) {
+	bucketID := primitive.NewObjectID()
+	fileID := primitive.NewObjectID()
+	files := newFakeObjectFiles(repository.File{ID: fileID, BucketID: bucketID, Name: "object.txt"})
+	var deleted []repository.FileChunk
+	svc := testObjectService(files, &deleted)
+
+	result, err := svc.DeleteObjectByID(context.Background(), primitive.NewObjectID(), fileID)
+	if !errors.Is(err, ErrObjectNotFound) {
+		t.Fatalf("expected object not found, got %v", err)
+	}
+	if result.Deleted {
+		t.Fatal("expected no deletion")
+	}
+	if len(deleted) != 0 {
+		t.Fatalf("expected no chunk cleanup, got %#v", deleted)
+	}
+	if _, err := files.GetByID(context.Background(), fileID); err != nil {
+		t.Fatalf("expected file to remain, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- route REST multipart uploads through `manager.ObjectService.PutObject`
- add `ObjectService.DeleteObjectByID` so REST file deletes keep the `file_id` route contract while sharing object deletion cleanup
- preserve current-main bucket-wide cleanup/reference-count semantics while rebasing
- add focused handler/object-service tests for overwrite cleanup and delete cleanup mapping

## Validation
- Local tests, formatting, lint, Docker, Playwright, and diff checks were not run after the latest rebase per resource policy; Woodpecker should run backend validation for the PR.

Closes THE-543