### PR TITLE
THE-552: Validate weighted source weights

### DIFF
--- a/api-go/internal/handlers/bucket.go
+++ b/api-go/internal/handlers/bucket.go
@@ -45,6 +45,40 @@ type fileResponse struct {
 	Size      int64     `json:"size"`
 }
 
+func validateSourceWeights(weights map[string]int, sourceIDs []primitive.ObjectID) error {
+	if len(weights) == 0 {
+		return nil
+	}
+	attached := make(map[primitive.ObjectID]struct{}, len(sourceIDs))
+	for _, sourceID := range sourceIDs {
+		attached[sourceID] = struct{}{}
+	}
+	for sourceIDHex, weight := range weights {
+		sourceID, err := primitive.ObjectIDFromHex(sourceIDHex)
+		if err != nil {
+			return fmt.Errorf("source_weights key %q must be a valid source id", sourceIDHex)
+		}
+		if _, ok := attached[sourceID]; !ok {
+			return fmt.Errorf("source_weights key %q is not attached to this bucket", sourceIDHex)
+		}
+		if weight <= 0 {
+			return fmt.Errorf("source_weights value for %q must be positive", sourceIDHex)
+		}
+		if weight > manager.MaxWeightedSourceWeight {
+			return fmt.Errorf("source_weights value for %q must be <= %d", sourceIDHex, manager.MaxWeightedSourceWeight)
+		}
+	}
+	return nil
+}
+
+func respondBadSourceWeights(c *gin.Context, err error) bool {
+	if err == nil {
+		return false
+	}
+	c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+	return true
+}
+
 // CreateBucket godoc
 // @Summary Create bucket
 // @Tags buckets
@@ -122,6 +156,9 @@ func CreateBucket(repo *repository.BucketRepository, sourceRepo *repository.Sour
 		}
 		if strategy != repository.StrategyRoundRobin && strategy != repository.StrategyWeighted {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid distribution_strategy"})
+			return
+		}
+		if respondBadSourceWeights(c, validateSourceWeights(req.SourceWeights, sourceIDs)) {
 			return
 		}
 		bucket := repository.Bucket{
@@ -313,6 +350,9 @@ func UpdateBucketDistribution(repo *repository.BucketRepository, grantRepo *repo
 
 		acc := requireBucketAccess(c, repo, grantRepo, repository.RoleOwner)
 		if acc == nil {
+			return
+		}
+		if respondBadSourceWeights(c, validateSourceWeights(req.SourceWeights, acc.Bucket.SourceIDs)) {
 			return
 		}
 

--- a/api-go/internal/handlers/bucket_validation_test.go
+++ b/api-go/internal/handlers/bucket_validation_test.go
@@ -1,0 +1,73 @@
+package handlers
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/example/sfree/api-go/internal/manager"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+func TestValidateSourceWeightsRejectsInvalidKey(t *testing.T) {
+	t.Parallel()
+	sourceID := primitive.NewObjectID()
+
+	err := validateSourceWeights(map[string]int{"not-an-object-id": 1}, []primitive.ObjectID{sourceID})
+	if err == nil {
+		t.Fatal("expected invalid source weight key error")
+	}
+	if !strings.Contains(err.Error(), "valid source id") {
+		t.Fatalf("expected useful error, got %q", err.Error())
+	}
+}
+
+func TestValidateSourceWeightsRejectsUnknownSource(t *testing.T) {
+	t.Parallel()
+	attachedSourceID := primitive.NewObjectID()
+	unknownSourceID := primitive.NewObjectID()
+
+	err := validateSourceWeights(map[string]int{unknownSourceID.Hex(): 1}, []primitive.ObjectID{attachedSourceID})
+	if err == nil {
+		t.Fatal("expected unknown source weight key error")
+	}
+	if !strings.Contains(err.Error(), "not attached") {
+		t.Fatalf("expected useful error, got %q", err.Error())
+	}
+}
+
+func TestValidateSourceWeightsRejectsNonPositiveWeight(t *testing.T) {
+	t.Parallel()
+	sourceID := primitive.NewObjectID()
+
+	err := validateSourceWeights(map[string]int{sourceID.Hex(): 0}, []primitive.ObjectID{sourceID})
+	if err == nil {
+		t.Fatal("expected non-positive source weight error")
+	}
+	if !strings.Contains(err.Error(), "positive") {
+		t.Fatalf("expected useful error, got %q", err.Error())
+	}
+}
+
+func TestValidateSourceWeightsRejectsOverLimitWeight(t *testing.T) {
+	t.Parallel()
+	sourceID := primitive.NewObjectID()
+
+	err := validateSourceWeights(map[string]int{sourceID.Hex(): manager.MaxWeightedSourceWeight + 1}, []primitive.ObjectID{sourceID})
+	if err == nil {
+		t.Fatal("expected over-limit source weight error")
+	}
+	if !strings.Contains(err.Error(), "must be <=") {
+		t.Fatalf("expected useful error, got %q", err.Error())
+	}
+}
+
+func TestValidateSourceWeightsAllowsMissingDefaultWeight(t *testing.T) {
+	t.Parallel()
+	firstSourceID := primitive.NewObjectID()
+	secondSourceID := primitive.NewObjectID()
+
+	err := validateSourceWeights(map[string]int{firstSourceID.Hex(): 2}, []primitive.ObjectID{firstSourceID, secondSourceID})
+	if err != nil {
+		t.Fatalf("expected missing weight to default later, got %v", err)
+	}
+}

--- a/api-go/internal/manager/file.go
+++ b/api-go/internal/manager/file.go
@@ -24,6 +24,8 @@ import (
 
 var ErrUnsupportedSourceType = errors.New("unsupported source type")
 
+const MaxWeightedSourceWeight = 1000
+
 // ErrChecksumMismatch is returned when a downloaded chunk's SHA-256 hash does
 // not match the value stored at upload time, indicating possible corruption.
 var ErrChecksumMismatch = errors.New("checksum mismatch")
@@ -85,37 +87,39 @@ func (s *RoundRobinSelector) NextSource(sources []repository.Source) (int, repos
 	return idx, sources[idx], nil
 }
 
-// WeightedSelector distributes chunks across sources proportionally to their
-// configured weights. It builds a repeating sequence where each source appears
-// a number of times equal to its weight, then cycles through that sequence.
 type WeightedSelector struct {
-	sequence []int
-	next     int
+	cumulativeWeights []int
+	totalWeight       int
+	next              int
 }
 
 // NewWeightedSelector creates a selector that distributes chunks according to
 // per-source weights. The weights map uses source ID hex strings as keys.
 // Sources without an entry default to weight 1.
 func NewWeightedSelector(sources []repository.Source, weights map[string]int) *WeightedSelector {
-	seq := make([]int, 0)
+	cumulativeWeights := make([]int, 0, len(sources))
+	totalWeight := 0
 	for i, src := range sources {
 		w := weights[src.ID.Hex()]
 		if w <= 0 {
 			w = 1
 		}
-		for j := 0; j < w; j++ {
-			seq = append(seq, i)
-		}
+		totalWeight += w
+		cumulativeWeights = append(cumulativeWeights, totalWeight)
 	}
-	return &WeightedSelector{sequence: seq}
+	return &WeightedSelector{cumulativeWeights: cumulativeWeights, totalWeight: totalWeight}
 }
 
 func (s *WeightedSelector) NextSource(sources []repository.Source) (int, repository.Source, error) {
-	if len(sources) == 0 || len(s.sequence) == 0 {
+	if len(sources) == 0 || s.totalWeight == 0 || len(s.cumulativeWeights) == 0 {
 		return 0, repository.Source{}, errors.New("no sources")
 	}
-	idx := s.sequence[s.next%len(s.sequence)]
-	s.next = (s.next + 1) % len(s.sequence)
+	offset := s.next % s.totalWeight
+	s.next = (s.next + 1) % s.totalWeight
+	idx := 0
+	for idx < len(s.cumulativeWeights) && offset >= s.cumulativeWeights[idx] {
+		idx++
+	}
 	if idx >= len(sources) {
 		return 0, repository.Source{}, errors.New("source index out of range")
 	}

--- a/api-go/internal/manager/file.go
+++ b/api-go/internal/manager/file.go
@@ -99,7 +99,7 @@ type WeightedSelector struct {
 func NewWeightedSelector(sources []repository.Source, weights map[string]int) *WeightedSelector {
 	cumulativeWeights := make([]int, 0, len(sources))
 	totalWeight := 0
-	for i, src := range sources {
+	for _, src := range sources {
 		w := weights[src.ID.Hex()]
 		if w <= 0 {
 			w = 1

--- a/api-go/internal/manager/file_test.go
+++ b/api-go/internal/manager/file_test.go
@@ -305,6 +305,22 @@ func TestWeightedSelectorDefaultWeight(t *testing.T) {
 	}
 }
 
+func TestWeightedSelectorDoesNotAllocateWeightSizedSequence(t *testing.T) {
+	t.Parallel()
+	s1 := repository.Source{ID: primitive.NewObjectID()}
+	s2 := repository.Source{ID: primitive.NewObjectID()}
+	sources := []repository.Source{s1, s2}
+	weights := map[string]int{s1.ID.Hex(): MaxWeightedSourceWeight, s2.ID.Hex(): 1}
+
+	sel := NewWeightedSelector(sources, weights)
+	if len(sel.cumulativeWeights) != len(sources) {
+		t.Fatalf("expected one cumulative weight per source, got %d", len(sel.cumulativeWeights))
+	}
+	if sel.totalWeight != MaxWeightedSourceWeight+1 {
+		t.Fatalf("expected total weight %d, got %d", MaxWeightedSourceWeight+1, sel.totalWeight)
+	}
+}
+
 func TestWeightedSelectorNoSources(t *testing.T) {
 	t.Parallel()
 	sel := NewWeightedSelector(nil, nil)


### PR DESCRIPTION
## Summary
- validate bucket `source_weights` through a shared helper on create and distribution update
- reject malformed, unattached, non-positive, and over-limit explicit weights with JSON 400 responses
- refactor weighted source selection to use cumulative weights instead of a weight-expanded sequence

## Tests
- Added focused handler validation tests and manager selector coverage
- Local CPU-bound tests were not run per agent instructions; Woodpecker should validate this PR