### PR TITLE
Fix S3 multipart part replacement cleanup order

### DIFF
--- a/api-go/internal/handlers/s3_multipart.go
+++ b/api-go/internal/handlers/s3_multipart.go
@@ -1,8 +1,6 @@
 package handlers
 
 import (
-	"crypto/md5"
-	"encoding/hex"
 	"encoding/xml"
 	"errors"
 	"fmt"
@@ -255,55 +253,25 @@ func uploadPart(c *gin.Context, bucketRepo *repository.BucketRepository, sourceR
 		return
 	}
 
-	sources, err := sourceRepo.ListByIDs(ctx, bucketDoc.SourceIDs)
+	objectSvc := manager.NewObjectService(sourceRepo, nil, mpRepo)
+	result, err := objectSvc.UploadMultipartPartRecord(ctx, bucketDoc, mu, partNum, c.Request.Body, chunkSize)
 	if err != nil {
-		slog.ErrorContext(ctx, "upload part: list sources", slog.String("error", err.Error()))
-		writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
-		return
-	}
-	if len(sources) == 0 {
-		writeS3Error(c, http.StatusBadRequest, "InvalidRequest", "no sources configured")
-		return
-	}
-
-	previousChunks := multipartPartChunks(mu.Parts, partNum)
-
-	selector := manager.SelectorForBucket(bucketDoc, sources)
-	chunks, err := manager.UploadFileChunksWithStrategy(ctx, c.Request.Body, sources, chunkSize, nil, selector)
-	if err != nil {
-		slog.ErrorContext(ctx, "upload part: upload chunks", slog.String("error", err.Error()))
-		writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
-		return
-	}
-
-	var totalSize int64
-	h := md5.New()
-	for _, ch := range chunks {
-		totalSize += ch.Size
-		_, _ = h.Write([]byte(ch.Name))
-	}
-	etag := fmt.Sprintf("\"%s\"", hex.EncodeToString(h.Sum(nil)))
-
-	part := repository.UploadPart{
-		PartNumber: partNum,
-		ETag:       etag,
-		Size:       totalSize,
-		Chunks:     chunks,
-	}
-	if err := mpRepo.SetPart(ctx, uploadID, part); err != nil {
-		slog.ErrorContext(ctx, "upload part: set part", slog.String("error", err.Error()))
-		// Best-effort cleanup of the uploaded chunks.
-		_ = manager.DeleteFileChunks(ctx, sourceRepo, chunks)
-		writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
-		return
-	}
-	if len(previousChunks) > 0 {
-		if delErr := manager.DeleteFileChunks(ctx, sourceRepo, previousChunks); delErr != nil {
-			slog.WarnContext(ctx, "upload part: delete replaced part chunks", slog.String("error", delErr.Error()))
+		switch {
+		case errors.Is(err, manager.ErrMultipartUploadNotFound):
+			writeS3Error(c, http.StatusNotFound, "NoSuchUpload", "")
+		case errors.Is(err, manager.ErrNoSources):
+			writeS3Error(c, http.StatusBadRequest, "InvalidRequest", "no sources configured")
+		default:
+			slog.ErrorContext(ctx, "upload part: store part", slog.String("error", err.Error()))
+			writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
 		}
+		return
+	}
+	if result.CleanupErr != nil {
+		slog.WarnContext(ctx, "upload part: delete old part chunks", slog.String("error", result.CleanupErr.Error()))
 	}
 
-	c.Header("ETag", etag)
+	c.Header("ETag", result.ETag)
 	c.Status(http.StatusOK)
 }
 

--- a/api-go/internal/manager/s3_object.go
+++ b/api-go/internal/manager/s3_object.go
@@ -50,6 +50,12 @@ type PutObjectResult struct {
 	CleanupErr error
 }
 
+type UploadMultipartPartResult struct {
+	Part       repository.UploadPart
+	ETag       string
+	CleanupErr error
+}
+
 type CopyObjectResult struct {
 	File       repository.File
 	CleanupErr error
@@ -99,6 +105,7 @@ type objectMultipartStore interface {
 	ListByBucket(ctx context.Context, bucketID primitive.ObjectID) ([]repository.MultipartUpload, error)
 	CountByPartChunk(ctx context.Context, sourceID primitive.ObjectID, name string) (int64, error)
 	CountByPartChunkExcludingBucket(ctx context.Context, bucketID, sourceID primitive.ObjectID, name string) (int64, error)
+	SetPart(ctx context.Context, uploadID string, part repository.UploadPart) (*repository.UploadPart, error)
 	Delete(ctx context.Context, uploadID string) error
 	DeleteByBucket(ctx context.Context, bucketID primitive.ObjectID) error
 }
@@ -160,6 +167,51 @@ func (s *ObjectService) PutObject(ctx context.Context, bucket *repository.Bucket
 		cleanupErr = s.deleteFileChunksIfUnreferenced(ctx, previousFile.Chunks)
 	}
 	return PutObjectResult{File: *currentFile, CleanupErr: cleanupErr}, nil
+}
+
+func (s *ObjectService) UploadMultipartPartRecord(ctx context.Context, bucket *repository.Bucket, mu *repository.MultipartUpload, partNumber int, body io.Reader, chunkSize int) (UploadMultipartPartResult, error) {
+	if bucket == nil || mu == nil || mu.BucketID != bucket.ID {
+		return UploadMultipartPartResult{}, ErrMultipartUploadNotFound
+	}
+
+	sources, err := s.sources.ListByIDs(ctx, bucket.SourceIDs)
+	if err != nil {
+		return UploadMultipartPartResult{}, err
+	}
+	if len(sources) == 0 {
+		return UploadMultipartPartResult{}, ErrNoSources
+	}
+
+	chunks, err := s.uploadChunks(ctx, body, sources, chunkSize, SelectorForBucket(bucket, sources))
+	if err != nil {
+		return UploadMultipartPartResult{}, err
+	}
+
+	var totalSize int64
+	for _, ch := range chunks {
+		totalSize += ch.Size
+	}
+	part := repository.UploadPart{
+		PartNumber: partNumber,
+		ETag:       multipartPartETag(chunks),
+		Size:       totalSize,
+		Chunks:     chunks,
+	}
+
+	previous, err := s.multipart.SetPart(ctx, mu.UploadID, part)
+	if err != nil {
+		_ = s.deleteChunks(ctx, chunks)
+		if err == mongo.ErrNoDocuments {
+			return UploadMultipartPartResult{}, ErrMultipartUploadNotFound
+		}
+		return UploadMultipartPartResult{}, err
+	}
+
+	var cleanupErr error
+	if previous != nil {
+		cleanupErr = s.deleteChunks(ctx, previous.Chunks)
+	}
+	return UploadMultipartPartResult{Part: part, ETag: part.ETag, CleanupErr: cleanupErr}, nil
 }
 
 func (s *ObjectService) CopyObject(ctx context.Context, sourceBucket, destBucket *repository.Bucket, sourceKey, destKey string) (CopyObjectResult, error) {
@@ -427,6 +479,14 @@ func ObjectETag(file repository.File) string {
 		_, _ = h.Write([]byte(strconv.FormatInt(chunk.Size, 10)))
 	}
 	return "\"" + hex.EncodeToString(h.Sum(nil)) + "\""
+}
+
+func multipartPartETag(chunks []repository.FileChunk) string {
+	h := md5.New()
+	for _, chunk := range chunks {
+		_, _ = h.Write([]byte(chunk.Name))
+	}
+	return fmt.Sprintf("\"%s\"", hex.EncodeToString(h.Sum(nil)))
 }
 
 func multipartETag(requestedParts []CompleteMultipartPart, partMap map[int]repository.UploadPart) string {

--- a/api-go/internal/manager/s3_object_test.go
+++ b/api-go/internal/manager/s3_object_test.go
@@ -146,8 +146,10 @@ func (f *fakeObjectFiles) CountByChunkExcludingBucket(_ context.Context, bucketI
 
 type fakeMultipartUploads struct {
 	uploads map[string]repository.MultipartUpload
+	setErr  error
 	delErr  error
 	listErr error
+	events  *[]string
 }
 
 func (f *fakeMultipartUploads) GetByUploadID(_ context.Context, uploadID string) (*repository.MultipartUpload, error) {
@@ -156,6 +158,33 @@ func (f *fakeMultipartUploads) GetByUploadID(_ context.Context, uploadID string)
 		return nil, mongo.ErrNoDocuments
 	}
 	return &upload, nil
+}
+
+func (f *fakeMultipartUploads) SetPart(_ context.Context, uploadID string, part repository.UploadPart) (*repository.UploadPart, error) {
+	if f.events != nil {
+		*f.events = append(*f.events, "set part")
+	}
+	if f.setErr != nil {
+		return nil, f.setErr
+	}
+	upload, ok := f.uploads[uploadID]
+	if !ok {
+		return nil, mongo.ErrNoDocuments
+	}
+	var previous *repository.UploadPart
+	parts := make([]repository.UploadPart, 0, len(upload.Parts)+1)
+	for _, existing := range upload.Parts {
+		if existing.PartNumber != part.PartNumber {
+			parts = append(parts, existing)
+			continue
+		}
+		partCopy := existing
+		previous = &partCopy
+	}
+	parts = append(parts, part)
+	upload.Parts = parts
+	f.uploads[uploadID] = upload
+	return previous, nil
 }
 
 func (f *fakeMultipartUploads) Delete(_ context.Context, uploadID string) error {
@@ -225,6 +254,124 @@ func (f *fakeMultipartUploads) DeleteByBucket(_ context.Context, bucketID primit
 		}
 	}
 	return nil
+}
+
+func TestObjectServiceUploadMultipartPartReplacesPartThenDeletesPreviousChunks(t *testing.T) {
+	bucketID := primitive.NewObjectID()
+	sourceID := primitive.NewObjectID()
+	oldChunk := repository.FileChunk{SourceID: sourceID, Name: "old-part-chunk", Size: 5}
+	var deleted []repository.FileChunk
+	var events []string
+	svc := testObjectService(newFakeObjectFiles(), &deleted)
+	svc.sources = &fakeObjectSources{sources: []repository.Source{{ID: sourceID}}}
+	svc.multipart = &fakeMultipartUploads{
+		uploads: map[string]repository.MultipartUpload{
+			"upload-1": {
+				BucketID: bucketID,
+				UploadID: "upload-1",
+				Parts: []repository.UploadPart{
+					{PartNumber: 1, ETag: `"old"`, Chunks: []repository.FileChunk{oldChunk}},
+				},
+			},
+		},
+		events: &events,
+	}
+	svc.uploadChunks = func(_ context.Context, r io.Reader, _ []repository.Source, _ int, _ SourceSelector) ([]repository.FileChunk, error) {
+		if _, err := io.Copy(io.Discard, r); err != nil {
+			return nil, err
+		}
+		return []repository.FileChunk{{SourceID: sourceID, Name: "new-part-chunk", Size: 4}}, nil
+	}
+	svc.deleteChunks = func(_ context.Context, chunks []repository.FileChunk) error {
+		deleted = append(deleted, chunks...)
+		for _, chunk := range chunks {
+			events = append(events, "delete "+chunk.Name)
+		}
+		return nil
+	}
+
+	result, err := svc.UploadMultipartPartRecord(
+		context.Background(),
+		&repository.Bucket{ID: bucketID, SourceIDs: []primitive.ObjectID{sourceID}},
+		&repository.MultipartUpload{BucketID: bucketID, UploadID: "upload-1", Parts: []repository.UploadPart{{PartNumber: 1, ETag: `"old"`, Chunks: []repository.FileChunk{oldChunk}}}},
+		1,
+		bytes.NewBufferString("data"),
+		5,
+	)
+	if err != nil {
+		t.Fatalf("UploadMultipartPartRecord returned error: %v", err)
+	}
+	if result.Part.PartNumber != 1 || len(result.Part.Chunks) != 1 || result.Part.Chunks[0].Name != "new-part-chunk" {
+		t.Fatalf("expected replacement part to use new chunk, got %#v", result.Part)
+	}
+	if len(deleted) != 1 || deleted[0].Name != "old-part-chunk" {
+		t.Fatalf("expected previous chunk cleanup after replacement, got %#v", deleted)
+	}
+	if len(events) != 2 || events[0] != "set part" || events[1] != "delete old-part-chunk" {
+		t.Fatalf("expected metadata write before old chunk cleanup, got %#v", events)
+	}
+	got := svc.multipart.(*fakeMultipartUploads).uploads["upload-1"]
+	if len(got.Parts) != 1 || got.Parts[0].Chunks[0].Name != "new-part-chunk" {
+		t.Fatalf("expected stored metadata to contain replacement part, got %#v", got.Parts)
+	}
+}
+
+func TestObjectServiceUploadMultipartPartSetFailureDeletesOnlyNewChunks(t *testing.T) {
+	bucketID := primitive.NewObjectID()
+	sourceID := primitive.NewObjectID()
+	oldChunk := repository.FileChunk{SourceID: sourceID, Name: "old-part-chunk", Size: 5}
+	var deleted []repository.FileChunk
+	var events []string
+	svc := testObjectService(newFakeObjectFiles(), &deleted)
+	svc.sources = &fakeObjectSources{sources: []repository.Source{{ID: sourceID}}}
+	svc.multipart = &fakeMultipartUploads{
+		uploads: map[string]repository.MultipartUpload{
+			"upload-1": {
+				BucketID: bucketID,
+				UploadID: "upload-1",
+				Parts: []repository.UploadPart{
+					{PartNumber: 1, ETag: `"old"`, Chunks: []repository.FileChunk{oldChunk}},
+				},
+			},
+		},
+		setErr: errors.New("set part failed"),
+		events: &events,
+	}
+	svc.uploadChunks = func(_ context.Context, r io.Reader, _ []repository.Source, _ int, _ SourceSelector) ([]repository.FileChunk, error) {
+		if _, err := io.Copy(io.Discard, r); err != nil {
+			return nil, err
+		}
+		return []repository.FileChunk{{SourceID: sourceID, Name: "new-part-chunk", Size: 4}}, nil
+	}
+	svc.deleteChunks = func(_ context.Context, chunks []repository.FileChunk) error {
+		deleted = append(deleted, chunks...)
+		for _, chunk := range chunks {
+			events = append(events, "delete "+chunk.Name)
+		}
+		return nil
+	}
+
+	_, err := svc.UploadMultipartPartRecord(
+		context.Background(),
+		&repository.Bucket{ID: bucketID, SourceIDs: []primitive.ObjectID{sourceID}},
+		&repository.MultipartUpload{BucketID: bucketID, UploadID: "upload-1", Parts: []repository.UploadPart{{PartNumber: 1, ETag: `"old"`, Chunks: []repository.FileChunk{oldChunk}}}},
+		1,
+		bytes.NewBufferString("data"),
+		5,
+	)
+	if err == nil {
+		t.Fatal("expected metadata replacement error")
+	}
+	if len(deleted) != 1 || deleted[0].Name != "new-part-chunk" {
+		t.Fatalf("expected new chunk cleanup after metadata failure, got %#v", deleted)
+	}
+	if len(events) != 2 || events[0] != "set part" || events[1] != "delete new-part-chunk" {
+		t.Fatalf("expected failed metadata write before new chunk cleanup, got %#v", events)
+	}
+	got := svc.multipart.(*fakeMultipartUploads).uploads["upload-1"]
+	if len(got.Parts) != 1 || got.Parts[0].Chunks[0].Name != "old-part-chunk" {
+		t.Fatalf("expected existing metadata to remain unchanged, got %#v", got.Parts)
+	}
 }
 
 func fileKey(bucketID primitive.ObjectID, name string) string {

--- a/api-go/internal/repository/multipart.go
+++ b/api-go/internal/repository/multipart.go
@@ -111,35 +111,40 @@ func (r *MultipartUploadRepository) CountByPartChunkExcludingBucket(ctx context.
 	})
 }
 
-func (r *MultipartUploadRepository) SetPart(ctx context.Context, uploadID string, part UploadPart) error {
-	partDoc := bson.D{
-		{Key: "part_number", Value: part.PartNumber},
-		{Key: "etag", Value: part.ETag},
-		{Key: "size", Value: part.Size},
-		{Key: "chunks", Value: part.Chunks},
+func (r *MultipartUploadRepository) SetPart(ctx context.Context, uploadID string, part UploadPart) (*UploadPart, error) {
+	update := mongo.Pipeline{
+		{{
+			Key: "$set",
+			Value: bson.D{{
+				Key: "parts",
+				Value: bson.D{{
+					Key: "$concatArrays",
+					Value: bson.A{
+						bson.D{{
+							Key: "$filter",
+							Value: bson.D{
+								{Key: "input", Value: bson.D{{Key: "$ifNull", Value: bson.A{"$parts", bson.A{}}}}},
+								{Key: "as", Value: "part"},
+								{Key: "cond", Value: bson.D{{Key: "$ne", Value: bson.A{"$$part.part_number", part.PartNumber}}}},
+							},
+						}},
+						bson.A{part},
+					},
+				}},
+			}},
+		}},
 	}
-	partArrayValue := bson.D{{Key: "$literal", Value: bson.A{partDoc}}}
-	partsOrEmpty := bson.D{{Key: "$ifNull", Value: bson.A{"$parts", bson.A{}}}}
-	otherParts := bson.D{{Key: "$filter", Value: bson.D{
-		{Key: "input", Value: partsOrEmpty},
-		{Key: "as", Value: "part"},
-		{Key: "cond", Value: bson.D{{Key: "$ne", Value: bson.A{"$$part.part_number", part.PartNumber}}}},
-	}}}
-	partsExpr := bson.D{{Key: "$concatArrays", Value: bson.A{otherParts, partArrayValue}}}
-
-	res, err := r.coll.UpdateOne(ctx,
-		bson.M{"upload_id": uploadID},
-		mongo.Pipeline{
-			bson.D{{Key: "$set", Value: bson.D{{Key: "parts", Value: partsExpr}}}},
-		},
-	)
-	if err != nil {
-		return err
+	var previousUpload MultipartUpload
+	if err := r.coll.FindOneAndUpdate(ctx, bson.M{"upload_id": uploadID}, update).Decode(&previousUpload); err != nil {
+		return nil, err
 	}
-	if res.MatchedCount == 0 {
-		return mongo.ErrNoDocuments
+	for _, existing := range previousUpload.Parts {
+		if existing.PartNumber == part.PartNumber {
+			partCopy := existing
+			return &partCopy, nil
+		}
 	}
-	return nil
+	return nil, nil
 }
 
 func (r *MultipartUploadRepository) DeleteByBucket(ctx context.Context, bucketID primitive.ObjectID) error {

--- a/api-go/internal/repository/multipart_test.go
+++ b/api-go/internal/repository/multipart_test.go
@@ -57,8 +57,12 @@ func TestMultipartUploadRepositorySetPartReplacesWithoutDroppingParts(t *testing
 		Size:       9,
 		Chunks:     []FileChunk{{SourceID: sourceID, Name: "new-part-1", Order: 0, Size: 9}},
 	}
-	if err := repo.SetPart(ctx, uploadID, replacement); err != nil {
+	previous, err := repo.SetPart(ctx, uploadID, replacement)
+	if err != nil {
 		t.Fatal(err)
+	}
+	if previous == nil || previous.ETag != `"old"` {
+		t.Fatalf("expected previous part to be returned, got %+v", previous)
 	}
 
 	got, err := repo.GetByUploadID(ctx, uploadID)
@@ -80,8 +84,12 @@ func TestMultipartUploadRepositorySetPartReplacesWithoutDroppingParts(t *testing
 		Size:       11,
 		Chunks:     []FileChunk{{SourceID: sourceID, Name: "added-part-3", Order: 2, Size: 11}},
 	}
-	if err := repo.SetPart(ctx, uploadID, added); err != nil {
+	previous, err = repo.SetPart(ctx, uploadID, added)
+	if err != nil {
 		t.Fatal(err)
+	}
+	if previous != nil {
+		t.Fatalf("expected no previous part for insert, got %+v", previous)
 	}
 
 	got, err = repo.GetByUploadID(ctx, uploadID)
@@ -95,7 +103,7 @@ func TestMultipartUploadRepositorySetPartReplacesWithoutDroppingParts(t *testing
 	assertMultipartPart(t, got.Parts, 2, `"kept"`, "kept-part-2")
 	assertMultipartPart(t, got.Parts, 3, `"added"`, "added-part-3")
 
-	err = repo.SetPart(ctx, "missing-upload", added)
+	_, err = repo.SetPart(ctx, "missing-upload", added)
 	if err != mongo.ErrNoDocuments {
 		t.Fatalf("expected ErrNoDocuments for missing upload, got %v", err)
 	}


### PR DESCRIPTION
## Summary

- move multipart UploadPart mutation into ObjectService so metadata replacement and chunk cleanup order are explicit
- replace MultipartUploadRepository.SetPart pull/push with a single atomic FindOneAndUpdate pipeline that returns the previous part for post-commit cleanup
- clean previous part chunks only after successful metadata replacement; clean new chunks when metadata replacement fails
- preserve bucket cleanup reference-count helpers from current main while rebasing the multipart replacement work
- add focused manager/repository tests for replacement cleanup order, metadata failure cleanup, and previous-part return semantics

## Validation

- Local Go tests/lint/builds and formatting checks were not run after the latest rebase per resource policy; Woodpecker should validate the branch.

Closes THE-553