### PR TITLE
test(api-go): add S3 error coverage plan

### DIFF
--- a/api-go/internal/e2e/s3_compat_auth_test.go
+++ b/api-go/internal/e2e/s3_compat_auth_test.go
@@ -94,8 +94,10 @@ func TestS3CompatWrongBucketCredentialsDoNotExposeObjectBytes(t *testing.T) {
 	if status == http.StatusOK {
 		t.Fatalf("GET with wrong bucket credentials: expected non-200, got 200: %s", body)
 	}
-	if bytes.Contains(body, objectContent) {
-		t.Fatalf("GET with wrong bucket credentials exposed object bytes: %q", body)
+	for i := 0; i <= len(objectContent)-8; i++ {
+		if fragment := objectContent[i : i+8]; bytes.Contains(body, fragment) {
+			t.Fatalf("GET with wrong bucket credentials exposed object byte fragment %q in response %q", fragment, body)
+		}
 	}
 }
 

--- a/api-go/internal/e2e/s3_compat_auth_test.go
+++ b/api-go/internal/e2e/s3_compat_auth_test.go
@@ -57,6 +57,48 @@ func TestS3CompatAccessKeyAuth(t *testing.T) {
 	}
 }
 
+func TestS3CompatWrongBucketCredentialsDoNotExposeObjectBytes(t *testing.T) {
+	env, ok := loadS3E2EEnv()
+	if !ok {
+		t.Skip("E2E_S3_ENDPOINT not set; skipping S3 E2E tests")
+	}
+
+	ts, _ := newTestServer(t)
+	ensureMinIOBucket(t, env)
+
+	suffix := uniqueSuffix()
+	username, password := createTestUser(t, ts, suffix)
+	sourceID := createS3Source(t, ts, username, password, "src-"+suffix, env)
+	ownerBucket := createBucket(t, ts, username, password, "owner-bkt-"+suffix, sourceID)
+	otherBucket := createBucket(t, ts, username, password, "other-bkt-"+suffix, sourceID)
+
+	t.Cleanup(func() {
+		apiDelete(t, ts, "/api/v1/buckets/"+otherBucket.ID, username, password)
+		apiDelete(t, ts, "/api/v1/buckets/"+ownerBucket.ID, username, password)
+		apiDelete(t, ts, "/api/v1/sources/"+sourceID, username, password)
+	})
+
+	objectKey := "private-" + suffix + ".txt"
+	objectContent := []byte("private object bytes " + suffix)
+	s3URL := fmt.Sprintf("%s/api/s3/%s/%s", ts.URL, ownerBucket.Key, objectKey)
+
+	status, body := s3Do(t, http.MethodPut, s3URL, ownerBucket.AccessKey, ownerBucket.AccessSecret, env.Region, objectContent)
+	if status != http.StatusOK {
+		t.Fatalf("PUT private object: expected 200, got %d: %s", status, body)
+	}
+	t.Cleanup(func() {
+		s3Do(t, http.MethodDelete, s3URL, ownerBucket.AccessKey, ownerBucket.AccessSecret, env.Region, nil)
+	})
+
+	status, body = s3Do(t, http.MethodGet, s3URL, otherBucket.AccessKey, otherBucket.AccessSecret, env.Region, nil)
+	if status == http.StatusOK {
+		t.Fatalf("GET with wrong bucket credentials: expected non-200, got 200: %s", body)
+	}
+	if bytes.Contains(body, objectContent) {
+		t.Fatalf("GET with wrong bucket credentials exposed object bytes: %q", body)
+	}
+}
+
 func TestS3CompatPresignedGetObject(t *testing.T) {
 	env, ok := loadS3E2EEnv()
 	if !ok {

--- a/api-go/internal/e2e/s3_compat_object_test.go
+++ b/api-go/internal/e2e/s3_compat_object_test.go
@@ -102,6 +102,32 @@ func TestS3CompatObjectLifecycle(t *testing.T) {
 	}
 }
 
+func TestS3CompatMissingObjectReturnsNoSuchKey(t *testing.T) {
+	env, ok := loadS3E2EEnv()
+	if !ok {
+		t.Skip("E2E_S3_ENDPOINT not set; skipping S3 E2E tests")
+	}
+
+	suffix := uniqueSuffix()
+	ts, bucket := setupS3CompatTest(t, env, suffix)
+	s3URL := fmt.Sprintf("%s/api/s3/%s/missing-%s.txt", ts.URL, bucket.Key, suffix)
+
+	status, body := s3Do(t, http.MethodGet, s3URL, bucket.AccessKey, bucket.AccessSecret, env.Region, nil)
+	if status != http.StatusNotFound {
+		t.Fatalf("GET missing object: expected 404, got %d: %s", status, body)
+	}
+
+	var errResp struct {
+		Code string `xml:"Code"`
+	}
+	if err := xml.Unmarshal(body, &errResp); err != nil {
+		t.Fatalf("decode missing object error: %v body=%s", err, body)
+	}
+	if errResp.Code != "NoSuchKey" {
+		t.Fatalf("GET missing object: expected NoSuchKey, got %q", errResp.Code)
+	}
+}
+
 func TestS3CompatCopyObject(t *testing.T) {
 	env, ok := loadS3E2EEnv()
 	if !ok {

--- a/docs/api-go-testing-plan.md
+++ b/docs/api-go-testing-plan.md
@@ -1,0 +1,59 @@
+# api-go S3/API Testing Plan
+
+## Purpose
+
+This plan scopes the first bounded QA slice for public GitHub issue #89. It records the current `api-go` S3/API coverage, identifies the most useful near-term gaps, and keeps new work aligned with the existing Woodpecker-only validation path.
+
+## Current Coverage
+
+### `api-go/internal/e2e/s3_compat_test.go`
+
+This file covers API-backed source and bucket creation through the Go E2E harness. It verifies that created S3 sources appear in the source list, bucket S3 access credentials are issued, and deleting an in-use source returns `409 Conflict`.
+
+The broader Go S3 E2E suite is split into sibling files under `api-go/internal/e2e/`:
+
+- `s3_compat_object_test.go` covers object upload, download, overwrite, delete, range reads, `HEAD`, and copy behavior.
+- `s3_compat_list_test.go` covers ListObjects/ListObjectsV2 prefix, delimiter, and pagination behavior.
+- `s3_compat_delete_test.go` covers multi-object delete behavior.
+- `s3_compat_multipart_test.go` covers multipart create, upload part, list uploads, list parts, complete, abort, and error paths.
+- `s3_compat_auth_test.go` covers access-key authentication, signature failures, unsigned requests, presigned GET/PUT, and expired presigned URLs.
+
+### `api-go/e2e/test_api_e2e.py`
+
+The Python E2E suite exercises the public API through the async test client and the AWS SDK-compatible client path. It covers source lifecycle checks, HTTP and S3 upload/download interoperability, S3 overwrite behavior, ListObjectsV2 prefix/delimiter/pagination, ranged GET, `HEAD`, copy object, multi-object delete, single-object delete idempotency, source delete conflicts, and multipart upload flow.
+
+This suite is useful as a cross-client compatibility signal because it goes through `aiobotocore`, but it should stay focused on end-to-end API compatibility rather than duplicating every Go handler edge case.
+
+### `api-go/internal/s3compat/client_test.go`
+
+The unit tests cover S3 source client configuration parsing and pagination handling in the internal S3-compatible source client. They do not exercise HTTP handler error shapes, auth boundaries, or object metadata behavior.
+
+### `.woodpecker/api-go.yml`
+
+The required API Go pull-request pipeline runs:
+
+- `golangci-lint run`
+- `go test ./...`
+- Python E2E through `docker-compose.e2e.yml` with local MinIO
+- Go S3 E2E through `docker-compose.go-e2e.yml` with local MinIO
+
+This is the correct validation target for CPU-heavy and Docker-backed checks. Local agent runs should stay limited to lightweight review unless explicitly requested.
+
+## First Coverage Slice
+
+The first implemented slice targets S3 error behavior that protects compatibility and data isolation:
+
+- Signed `GET` for a missing object returns `404` with S3 XML error code `NoSuchKey`.
+- Credentials for one bucket cannot read object bytes from another bucket, even when the object key is known.
+
+These checks live in the existing Go S3 E2E suite so they run in the Woodpecker API Go pipeline without new CI commands.
+
+## Prioritized Backlog
+
+1. S3 error-shape matrix for missing bucket, missing upload, unsupported copy metadata directive, invalid range, and auth mismatch paths.
+2. HTTP API/S3 parity checks for file metadata after S3 overwrite, copy, delete, and multipart completion.
+3. Negative auth coverage across presigned URLs, wrong bucket keys, wrong access keys, and cross-bucket copy attempts.
+
+## Validation
+
+No CI behavior changes are required. Woodpecker `.woodpecker/api-go.yml` remains the validation source for Docker-backed E2E execution.


### PR DESCRIPTION
## Summary

- Add `docs/api-go-testing-plan.md` mapping current api-go S3/API coverage and the next prioritized QA slices.
- Add Go S3 E2E coverage for missing-object `NoSuchKey` XML behavior.
- Add Go S3 E2E coverage ensuring credentials for another bucket do not expose object bytes.

Links: Paperclip THE-396, GitHub issue #89.

## Validation

- `git diff --check`
- Not run: Go tests, Docker Compose, or E2E locally. Per THE-396, runtime validation should run in Woodpecker only.