### PR TITLE
Implement minimal S3 object metadata persistence

### DIFF
--- a/api-go/e2e/sfree_client.py
+++ b/api-go/e2e/sfree_client.py
@@ -215,7 +215,16 @@ class SFreeClient:
         async with self._http.delete(f"{self.config.buckets_url}/{bucket_id}/files/{file_id}", auth=auth):
             return
 
-    async def upload_file_s3(self, access_key: str, access_secret: str, bucket_key: str, object_key: str, content: bytes) -> None:
+    async def upload_file_s3(
+        self,
+        access_key: str,
+        access_secret: str,
+        bucket_key: str,
+        object_key: str,
+        content: bytes,
+        content_type: str | None = None,
+        metadata: dict[str, str] | None = None,
+    ) -> None:
         session = get_session()
         async with session.create_client(
             "s3",
@@ -226,7 +235,12 @@ class SFreeClient:
                 access_secret=access_secret,
             ),
         ) as s3_client:
-            await s3_client.put_object(Bucket=bucket_key, Key=object_key, Body=content)
+            payload: dict[str, Any] = {"Bucket": bucket_key, "Key": object_key, "Body": content}
+            if content_type is not None:
+                payload["ContentType"] = content_type
+            if metadata is not None:
+                payload["Metadata"] = metadata
+            await s3_client.put_object(**payload)
 
     async def delete_object_s3(self, access_key: str, access_secret: str, bucket_key: str, object_key: str) -> None:
         session = get_session()

--- a/api-go/e2e/test_api_e2e.py
+++ b/api-go/e2e/test_api_e2e.py
@@ -252,6 +252,42 @@ async def test_s3_sdk_head_object_returns_metadata(client, e2e_context):
     assert response["LastModified"]
 
 
+async def test_s3_sdk_object_content_type_and_user_metadata(client, e2e_context):
+    filename = f"e2e-sdk-metadata-{uuid4().hex[:8]}.json"
+    payload = b'{"sdk":true}'
+
+    await client.upload_file_s3(
+        access_key=e2e_context.access_key,
+        access_secret=e2e_context.access_secret,
+        bucket_key=e2e_context.bucket_key,
+        object_key=filename,
+        content=payload,
+        content_type="application/json",
+        metadata={"owner": "alice", "trace-id": "trace-123"},
+    )
+
+    head = await client.head_object_s3(
+        access_key=e2e_context.access_key,
+        access_secret=e2e_context.access_secret,
+        bucket_key=e2e_context.bucket_key,
+        object_key=filename,
+    )
+    assert head["ResponseMetadata"]["HTTPStatusCode"] == 200
+    assert head["ContentType"] == "application/json"
+    assert head["Metadata"] == {"owner": "alice", "trace-id": "trace-123"}
+
+    get = await client.get_object_s3(
+        access_key=e2e_context.access_key,
+        access_secret=e2e_context.access_secret,
+        bucket_key=e2e_context.bucket_key,
+        object_key=filename,
+    )
+    assert get["ResponseMetadata"]["HTTPStatusCode"] == 200
+    assert get["Body"] == payload
+    assert get["ContentType"] == "application/json"
+    assert get["Metadata"] == {"owner": "alice", "trace-id": "trace-123"}
+
+
 async def test_s3_sdk_copy_object_compatibility(client, e2e_context):
     suffix = uuid4().hex[:8]
     source_key = f"e2e-sdk-copy-source-{suffix}.txt"

--- a/api-go/internal/e2e/s3_compat_object_test.go
+++ b/api-go/internal/e2e/s3_compat_object_test.go
@@ -219,6 +219,103 @@ func TestS3CompatCopyObject(t *testing.T) {
 	}
 }
 
+func TestS3CompatObjectMetadataHeaders(t *testing.T) {
+	env, ok := loadS3E2EEnv()
+	if !ok {
+		t.Skip("E2E_S3_ENDPOINT not set; skipping S3 E2E tests")
+	}
+
+	ts, _ := newTestServer(t)
+	ensureMinIOBucket(t, env)
+
+	suffix := uniqueSuffix()
+	username, password := createTestUser(t, ts, suffix)
+	sourceID := createS3Source(t, ts, username, password, "src-"+suffix, env)
+	bucket := createBucket(t, ts, username, password, "bkt-"+suffix, sourceID)
+
+	t.Cleanup(func() {
+		apiDelete(t, ts, "/api/v1/buckets/"+bucket.ID, username, password)
+		apiDelete(t, ts, "/api/v1/sources/"+sourceID, username, password)
+	})
+
+	objectKey := "metadata-" + suffix + ".json"
+	copyKey := "metadata-copy-" + suffix + ".json"
+	objectContent := []byte(`{"ok":true}`)
+	s3URL := func(key string) string {
+		return fmt.Sprintf("%s/api/s3/%s/%s", ts.URL, bucket.Key, key)
+	}
+	putHeaders := map[string]string{
+		"Content-Type":        "application/json",
+		"x-amz-meta-owner":    "Alice",
+		"X-Amz-Meta-Trace-ID": "trace-123",
+	}
+
+	status, _, body := s3DoWithHeaders(t, http.MethodPut, s3URL(objectKey), bucket.AccessKey, bucket.AccessSecret, env.Region, objectContent, putHeaders)
+	if status != http.StatusOK {
+		t.Fatalf("PUT object: expected 200, got %d: %s", status, body)
+	}
+
+	status, headers, body := s3DoWithHeaders(t, http.MethodHead, s3URL(objectKey), bucket.AccessKey, bucket.AccessSecret, env.Region, nil, nil)
+	if status != http.StatusOK {
+		t.Fatalf("HEAD object: expected 200, got %d: %s", status, body)
+	}
+	assertObjectMetadataHeaders(t, headers, "application/json", "Alice", "trace-123")
+
+	status, headers, body = s3DoWithHeaders(t, http.MethodGet, s3URL(objectKey), bucket.AccessKey, bucket.AccessSecret, env.Region, nil, nil)
+	if status != http.StatusOK || !bytes.Equal(body, objectContent) {
+		t.Fatalf("GET full object mismatch: status=%d body=%q", status, body)
+	}
+	assertObjectMetadataHeaders(t, headers, "application/json", "Alice", "trace-123")
+
+	status, headers, body = s3DoWithHeaders(t, http.MethodGet, s3URL(objectKey), bucket.AccessKey, bucket.AccessSecret, env.Region, nil, map[string]string{"Range": "bytes=0-1"})
+	if status != http.StatusPartialContent || string(body) != `{"` {
+		t.Fatalf("GET range mismatch: status=%d body=%q", status, body)
+	}
+	if got, want := headers.Get("Content-Length"), "2"; got != want {
+		t.Fatalf("GET range Content-Length mismatch: got %q want %q", got, want)
+	}
+	assertObjectMetadataHeaders(t, headers, "application/json", "Alice", "trace-123")
+
+	copyHeaders := map[string]string{"x-amz-copy-source": "/" + bucket.Key + "/" + objectKey}
+	status, _, body = s3DoWithHeaders(t, http.MethodPut, s3URL(copyKey), bucket.AccessKey, bucket.AccessSecret, env.Region, nil, copyHeaders)
+	if status != http.StatusOK {
+		t.Fatalf("CopyObject: expected 200, got %d: %s", status, body)
+	}
+	status, headers, body = s3DoWithHeaders(t, http.MethodHead, s3URL(copyKey), bucket.AccessKey, bucket.AccessSecret, env.Region, nil, nil)
+	if status != http.StatusOK {
+		t.Fatalf("HEAD copied object: expected 200, got %d: %s", status, body)
+	}
+	assertObjectMetadataHeaders(t, headers, "application/json", "Alice", "trace-123")
+
+	status, _, body = s3DoWithHeaders(t, http.MethodPut, s3URL(objectKey), bucket.AccessKey, bucket.AccessSecret, env.Region, []byte("plain"), map[string]string{"Content-Type": "text/plain"})
+	if status != http.StatusOK {
+		t.Fatalf("PUT overwrite object: expected 200, got %d: %s", status, body)
+	}
+	status, headers, body = s3DoWithHeaders(t, http.MethodHead, s3URL(objectKey), bucket.AccessKey, bucket.AccessSecret, env.Region, nil, nil)
+	if status != http.StatusOK {
+		t.Fatalf("HEAD overwritten object: expected 200, got %d: %s", status, body)
+	}
+	if got := headers.Get("Content-Type"); got != "text/plain" {
+		t.Fatalf("expected overwritten Content-Type, got %q", got)
+	}
+	if got := headers.Get("x-amz-meta-owner"); got != "" {
+		t.Fatalf("expected overwritten metadata to be empty, got %q", got)
+	}
+}
+
+func assertObjectMetadataHeaders(t *testing.T, headers http.Header, contentType, owner, traceID string) {
+	t.Helper()
+	if got := headers.Get("Content-Type"); got != contentType {
+		t.Fatalf("Content-Type mismatch: got %q want %q", got, contentType)
+	}
+	if got := headers.Get("x-amz-meta-owner"); got != owner {
+		t.Fatalf("x-amz-meta-owner mismatch: got %q want %q", got, owner)
+	}
+	if got := headers.Get("x-amz-meta-trace-id"); got != traceID {
+		t.Fatalf("x-amz-meta-trace-id mismatch: got %q want %q", got, traceID)
+	}
+}
+
 func TestS3CompatGetObjectRange(t *testing.T) {
 	env, ok := loadS3E2EEnv()
 	if !ok {

--- a/api-go/internal/handlers/bucket.go
+++ b/api-go/internal/handlers/bucket.go
@@ -431,7 +431,7 @@ func UploadFile(bucketRepo *repository.BucketRepository, sourceRepo *repository.
 		}
 		defer func() { _ = f.Close() }()
 
-		result, err := objectSvc.PutObject(ctx, bucketDoc, fh.Filename, f, chunkSize)
+		result, err := objectSvc.PutObject(ctx, bucketDoc, fh.Filename, f, chunkSize, objectContentType(fh.Header.Get("Content-Type")), nil)
 		if err != nil {
 			if errors.Is(err, manager.ErrNoSources) {
 				c.Status(http.StatusBadRequest)

--- a/api-go/internal/handlers/s3.go
+++ b/api-go/internal/handlers/s3.go
@@ -22,6 +22,8 @@ import (
 const (
 	maxDeleteObjects                = 1000
 	maxDeleteObjectsRequestBodySize = 8 * 1024 * 1024
+	defaultObjectContentType        = "application/octet-stream"
+	userMetadataHeaderPrefix        = "x-amz-meta-"
 )
 
 var (
@@ -297,7 +299,41 @@ func setObjectHeaders(c *gin.Context, fileDoc *repository.File, total int64) {
 	c.Header("ETag", manager.ObjectETag(*fileDoc))
 	c.Header("Last-Modified", fileDoc.CreatedAt.UTC().Format(http.TimeFormat))
 	c.Header("Content-Length", strconv.FormatInt(total, 10))
-	c.Header("Content-Type", "application/octet-stream")
+	c.Header("Content-Type", objectContentType(fileDoc.ContentType))
+	for key, value := range fileDoc.UserMetadata {
+		c.Header(userMetadataHeaderPrefix+key, value)
+	}
+}
+
+func objectContentType(contentType string) string {
+	contentType = strings.TrimSpace(contentType)
+	if contentType == "" {
+		return defaultObjectContentType
+	}
+	return contentType
+}
+
+func requestObjectContentType(r *http.Request) string {
+	return objectContentType(r.Header.Get("Content-Type"))
+}
+
+func requestObjectUserMetadata(r *http.Request) map[string]string {
+	metadata := make(map[string]string)
+	for name, values := range r.Header {
+		name = strings.ToLower(name)
+		if !strings.HasPrefix(name, userMetadataHeaderPrefix) {
+			continue
+		}
+		key := strings.TrimPrefix(name, userMetadataHeaderPrefix)
+		if key == "" || len(values) == 0 {
+			continue
+		}
+		metadata[key] = values[0]
+	}
+	if len(metadata) == 0 {
+		return nil
+	}
+	return metadata
 }
 
 // preflightObjectRange checks the first response byte before success headers are
@@ -427,7 +463,7 @@ func PutObject(bucketRepo *repository.BucketRepository, sourceRepo *repository.S
 		if !ok {
 			return
 		}
-		result, err := objectSvc.PutObject(ctx, bucketDoc, name, c.Request.Body, chunkSize)
+		result, err := objectSvc.PutObject(ctx, bucketDoc, name, c.Request.Body, chunkSize, requestObjectContentType(c.Request), requestObjectUserMetadata(c.Request))
 		if err != nil {
 			if errors.Is(err, manager.ErrNoSources) {
 				writeS3Error(c, http.StatusBadRequest, "InvalidRequest", "")

--- a/api-go/internal/handlers/s3_get_test.go
+++ b/api-go/internal/handlers/s3_get_test.go
@@ -124,10 +124,12 @@ func getObjectFailureTestHandler(t *testing.T) gin.HandlerFunc {
 	}
 	fileRepo := fakeObjectFileReader{
 		file: &repository.File{
-			ID:        primitive.NewObjectID(),
-			BucketID:  bucketID,
-			Name:      "object.txt",
-			CreatedAt: time.Unix(1700000000, 0).UTC(),
+			ID:           primitive.NewObjectID(),
+			BucketID:     bucketID,
+			Name:         "object.txt",
+			CreatedAt:    time.Unix(1700000000, 0).UTC(),
+			ContentType:  "text/plain",
+			UserMetadata: map[string]string{"owner": "alice", "trace-id": "abc-123"},
 			Chunks: []repository.FileChunk{
 				{SourceID: sourceID, Name: "chunk-1", Order: 0, Size: 7, Checksum: "bad"},
 			},
@@ -251,5 +253,53 @@ func TestGetObjectStreamsBodyAfterBoundedPreflight(t *testing.T) {
 	}
 	if body := w.Body.String(); body != "complete" {
 		t.Fatalf("unexpected body: %s", body)
+	}
+	if got := w.Header().Get("Content-Type"); got != "text/plain" {
+		t.Fatalf("expected stored Content-Type, got %q", got)
+	}
+	if got := w.Header().Get("x-amz-meta-owner"); got != "alice" {
+		t.Fatalf("expected stored owner metadata, got %q", got)
+	}
+	if got := w.Header().Get("x-amz-meta-trace-id"); got != "abc-123" {
+		t.Fatalf("expected stored trace metadata, got %q", got)
+	}
+}
+
+func TestGetObjectRangeReturnsStoredMetadataHeaders(t *testing.T) {
+	origStreamRange := streamS3ObjectRange
+	t.Cleanup(func() { streamS3ObjectRange = origStreamRange })
+	streamS3ObjectRange = func(_ context.Context, _ *repository.SourceRepository, _ *repository.File, w io.Writer, start, end int64) error {
+		if end >= start {
+			_, _ = io.WriteString(w, "cde")
+		}
+		return nil
+	}
+
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("accessKey", "access-key")
+		c.Next()
+	})
+	r.GET("/api/s3/:bucket/*object", getObjectFailureTestHandler(t))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/s3/bucket/object.txt", nil)
+	req.Header.Set("Range", "bytes=2-4")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusPartialContent {
+		t.Fatalf("expected 206, got %d", w.Code)
+	}
+	if got := w.Header().Get("Content-Length"); got != "3" {
+		t.Fatalf("expected ranged Content-Length, got %q", got)
+	}
+	if got := w.Header().Get("Content-Range"); got != "bytes 2-4/7" {
+		t.Fatalf("expected Content-Range, got %q", got)
+	}
+	if got := w.Header().Get("Content-Type"); got != "text/plain" {
+		t.Fatalf("expected stored Content-Type, got %q", got)
+	}
+	if got := w.Header().Get("x-amz-meta-owner"); got != "alice" {
+		t.Fatalf("expected stored metadata, got %q", got)
 	}
 }

--- a/api-go/internal/handlers/s3_multipart.go
+++ b/api-go/internal/handlers/s3_multipart.go
@@ -211,10 +211,12 @@ func createMultipartUpload(c *gin.Context, bucketRepo *repository.BucketReposito
 	}
 	uploadID := primitive.NewObjectID().Hex()
 	mu := repository.MultipartUpload{
-		BucketID:  bucketDoc.ID,
-		ObjectKey: objectKey,
-		UploadID:  uploadID,
-		CreatedAt: time.Now().UTC(),
+		BucketID:     bucketDoc.ID,
+		ObjectKey:    objectKey,
+		UploadID:     uploadID,
+		CreatedAt:    time.Now().UTC(),
+		ContentType:  requestObjectContentType(c.Request),
+		UserMetadata: requestObjectUserMetadata(c.Request),
 	}
 	if _, err := mpRepo.Create(ctx, mu); err != nil {
 		slog.ErrorContext(ctx, "create multipart upload", slog.String("error", err.Error()))

--- a/api-go/internal/handlers/s3_test.go
+++ b/api-go/internal/handlers/s3_test.go
@@ -119,6 +119,31 @@ func TestParseObjectRange(t *testing.T) {
 	}
 }
 
+func TestRequestObjectMetadataExtraction(t *testing.T) {
+	t.Parallel()
+
+	req := httptest.NewRequest(http.MethodPut, "/api/s3/bucket/object.txt", nil)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-amz-meta-Owner", "Alice")
+	req.Header.Set("X-Amz-Meta-Trace-ID", "abc-123")
+
+	if got := requestObjectContentType(req); got != "application/json" {
+		t.Fatalf("expected content type, got %q", got)
+	}
+	got := requestObjectUserMetadata(req)
+	if got["owner"] != "Alice" || got["trace-id"] != "abc-123" {
+		t.Fatalf("expected normalized metadata, got %#v", got)
+	}
+
+	emptyReq := httptest.NewRequest(http.MethodPut, "/api/s3/bucket/object.txt", nil)
+	if got := requestObjectContentType(emptyReq); got != defaultObjectContentType {
+		t.Fatalf("expected default content type, got %q", got)
+	}
+	if got := requestObjectUserMetadata(emptyReq); got != nil {
+		t.Fatalf("expected nil metadata, got %#v", got)
+	}
+}
+
 func TestParseListMaxKeys(t *testing.T) {
 	t.Parallel()
 

--- a/api-go/internal/manager/s3_object.go
+++ b/api-go/internal/manager/s3_object.go
@@ -143,7 +143,7 @@ func NewObjectService(sourceRepo *repository.SourceRepository, fileRepo *reposit
 	return svc
 }
 
-func (s *ObjectService) PutObject(ctx context.Context, bucket *repository.Bucket, name string, body io.Reader, chunkSize int) (PutObjectResult, error) {
+func (s *ObjectService) PutObject(ctx context.Context, bucket *repository.Bucket, name string, body io.Reader, chunkSize int, contentType string, userMetadata map[string]string) (PutObjectResult, error) {
 	sources, err := s.sources.ListByIDs(ctx, bucket.SourceIDs)
 	if err != nil {
 		return PutObjectResult{}, err
@@ -157,7 +157,14 @@ func (s *ObjectService) PutObject(ctx context.Context, bucket *repository.Bucket
 		return PutObjectResult{}, err
 	}
 
-	fileDoc := repository.File{BucketID: bucket.ID, Name: name, CreatedAt: s.now(), Chunks: chunks}
+	fileDoc := repository.File{
+		BucketID:     bucket.ID,
+		Name:         name,
+		CreatedAt:    s.now(),
+		Chunks:       chunks,
+		ContentType:  contentType,
+		UserMetadata: cloneStringMap(userMetadata),
+	}
 	currentFile, previousFile, err := s.files.ReplaceByName(ctx, fileDoc)
 	if err != nil {
 		_ = s.deleteChunks(ctx, chunks)
@@ -229,7 +236,14 @@ func (s *ObjectService) CopyObject(ctx context.Context, sourceBucket, destBucket
 	}
 
 	chunks := append([]repository.FileChunk(nil), sourceFile.Chunks...)
-	copyFile := repository.File{BucketID: destBucket.ID, Name: destKey, CreatedAt: s.now(), Chunks: chunks}
+	copyFile := repository.File{
+		BucketID:     destBucket.ID,
+		Name:         destKey,
+		CreatedAt:    s.now(),
+		Chunks:       chunks,
+		ContentType:  sourceFile.ContentType,
+		UserMetadata: cloneStringMap(sourceFile.UserMetadata),
+	}
 	currentFile, previousFile, err := s.files.ReplaceByName(ctx, copyFile)
 	if err != nil {
 		return CopyObjectResult{}, err
@@ -371,10 +385,12 @@ func (s *ObjectService) CompleteMultipartUploadRecord(ctx context.Context, bucke
 	}
 
 	fileDoc := repository.File{
-		BucketID:  bucketID,
-		Name:      mu.ObjectKey,
-		CreatedAt: s.now(),
-		Chunks:    allChunks,
+		BucketID:     bucketID,
+		Name:         mu.ObjectKey,
+		CreatedAt:    s.now(),
+		Chunks:       allChunks,
+		ContentType:  mu.ContentType,
+		UserMetadata: cloneStringMap(mu.UserMetadata),
 	}
 	saved, previousFile, err := s.files.ReplaceByName(ctx, fileDoc)
 	if err != nil {
@@ -511,6 +527,17 @@ func multipartPartETag(chunks []repository.FileChunk) string {
 		_, _ = h.Write([]byte(chunk.Name))
 	}
 	return fmt.Sprintf("\"%s\"", hex.EncodeToString(h.Sum(nil)))
+}
+
+func cloneStringMap(values map[string]string) map[string]string {
+	if len(values) == 0 {
+		return nil
+	}
+	clone := make(map[string]string, len(values))
+	for key, value := range values {
+		clone[key] = value
+	}
+	return clone
 }
 
 func multipartETag(requestedParts []CompleteMultipartPart, partMap map[int]repository.UploadPart) string {

--- a/api-go/internal/manager/s3_object_test.go
+++ b/api-go/internal/manager/s3_object_test.go
@@ -422,7 +422,7 @@ func TestObjectServicePutObjectUpdatesFileAndDeletesOldChunks(t *testing.T) {
 	var deleted []repository.FileChunk
 	svc := testObjectService(files, &deleted)
 
-	result, err := svc.PutObject(context.Background(), &repository.Bucket{ID: bucketID}, "object.txt", bytes.NewBufferString("data"), 5)
+	result, err := svc.PutObject(context.Background(), &repository.Bucket{ID: bucketID}, "object.txt", bytes.NewBufferString("data"), 5, "text/plain", map[string]string{"owner": "alice"})
 	if err != nil {
 		t.Fatalf("PutObject returned error: %v", err)
 	}
@@ -432,8 +432,37 @@ func TestObjectServicePutObjectUpdatesFileAndDeletesOldChunks(t *testing.T) {
 	if len(result.File.Chunks) != 1 || result.File.Chunks[0].Name != "new-chunk" {
 		t.Fatalf("expected saved file to use uploaded chunk, got %#v", result.File.Chunks)
 	}
+	if result.File.ContentType != "text/plain" || result.File.UserMetadata["owner"] != "alice" {
+		t.Fatalf("expected saved object metadata, got content_type=%q metadata=%#v", result.File.ContentType, result.File.UserMetadata)
+	}
 	if len(deleted) != 1 || deleted[0].Name != "old-chunk" {
 		t.Fatalf("expected old chunk cleanup, got %#v", deleted)
+	}
+}
+
+func TestObjectServicePutObjectOverwriteReplacesMetadata(t *testing.T) {
+	bucketID := primitive.NewObjectID()
+	existing := repository.File{
+		ID:           primitive.NewObjectID(),
+		BucketID:     bucketID,
+		Name:         "object.txt",
+		ContentType:  "text/plain",
+		UserMetadata: map[string]string{"old": "value"},
+		Chunks:       []repository.FileChunk{{SourceID: primitive.NewObjectID(), Name: "old-chunk", Size: 9}},
+	}
+	files := newFakeObjectFiles(existing)
+	var deleted []repository.FileChunk
+	svc := testObjectService(files, &deleted)
+
+	result, err := svc.PutObject(context.Background(), &repository.Bucket{ID: bucketID}, "object.txt", bytes.NewBufferString("data"), 5, "application/json", nil)
+	if err != nil {
+		t.Fatalf("PutObject returned error: %v", err)
+	}
+	if result.File.ContentType != "application/json" {
+		t.Fatalf("expected replacement content type, got %q", result.File.ContentType)
+	}
+	if len(result.File.UserMetadata) != 0 {
+		t.Fatalf("expected metadata to be replaced with empty set, got %#v", result.File.UserMetadata)
 	}
 }
 
@@ -444,7 +473,7 @@ func TestObjectServicePutObjectCreateFailureDeletesUploadedChunks(t *testing.T) 
 	var deleted []repository.FileChunk
 	svc := testObjectService(files, &deleted)
 
-	_, err := svc.PutObject(context.Background(), &repository.Bucket{ID: bucketID}, "object.txt", bytes.NewBufferString("data"), 5)
+	_, err := svc.PutObject(context.Background(), &repository.Bucket{ID: bucketID}, "object.txt", bytes.NewBufferString("data"), 5, "application/octet-stream", nil)
 	if err == nil {
 		t.Fatal("expected PutObject create error")
 	}
@@ -466,7 +495,7 @@ func TestObjectServicePutObjectOverwriteFailureDeletesUploadedChunks(t *testing.
 	var deleted []repository.FileChunk
 	svc := testObjectService(files, &deleted)
 
-	_, err := svc.PutObject(context.Background(), &repository.Bucket{ID: bucketID}, "object.txt", bytes.NewBufferString("data"), 5)
+	_, err := svc.PutObject(context.Background(), &repository.Bucket{ID: bucketID}, "object.txt", bytes.NewBufferString("data"), 5, "application/octet-stream", nil)
 	if err == nil {
 		t.Fatal("expected PutObject overwrite error")
 	}
@@ -482,7 +511,7 @@ func TestObjectServiceCopyObjectPreservesChunksAndCleansOverwrittenDestination(t
 	sourceChunk := repository.FileChunk{SourceID: primitive.NewObjectID(), Name: "source-chunk", Size: 12}
 	oldDestChunk := repository.FileChunk{SourceID: primitive.NewObjectID(), Name: "old-dest-chunk", Size: 8}
 	files := newFakeObjectFiles(
-		repository.File{ID: primitive.NewObjectID(), BucketID: sourceBucketID, Name: "source.txt", Chunks: []repository.FileChunk{sourceChunk}},
+		repository.File{ID: primitive.NewObjectID(), BucketID: sourceBucketID, Name: "source.txt", ContentType: "image/png", UserMetadata: map[string]string{"owner": "alice"}, Chunks: []repository.FileChunk{sourceChunk}},
 		repository.File{ID: primitive.NewObjectID(), BucketID: destBucketID, Name: "dest.txt", Chunks: []repository.FileChunk{oldDestChunk}},
 	)
 	var deleted []repository.FileChunk
@@ -500,6 +529,9 @@ func TestObjectServiceCopyObjectPreservesChunksAndCleansOverwrittenDestination(t
 	}
 	if len(result.File.Chunks) != 1 || result.File.Chunks[0].Name != sourceChunk.Name {
 		t.Fatalf("expected copied file to reference source chunk, got %#v", result.File.Chunks)
+	}
+	if result.File.ContentType != "image/png" || result.File.UserMetadata["owner"] != "alice" {
+		t.Fatalf("expected copied metadata, got content_type=%q metadata=%#v", result.File.ContentType, result.File.UserMetadata)
 	}
 	if len(deleted) != 1 || deleted[0].Name != oldDestChunk.Name {
 		t.Fatalf("expected overwritten destination chunk cleanup, got %#v", deleted)
@@ -749,9 +781,11 @@ func TestObjectServiceCompleteMultipartUploadBuildsFinalFileAndCleansUnusedChunk
 	svc := testObjectService(files, &deleted)
 	svc.multipart = &fakeMultipartUploads{uploads: map[string]repository.MultipartUpload{
 		"upload-1": {
-			BucketID:  bucketID,
-			ObjectKey: "object.txt",
-			UploadID:  "upload-1",
+			BucketID:     bucketID,
+			ObjectKey:    "object.txt",
+			UploadID:     "upload-1",
+			ContentType:  "application/x-ndjson",
+			UserMetadata: map[string]string{"batch": "42"},
 			Parts: []repository.UploadPart{
 				{PartNumber: 1, ETag: `"d41d8cd98f00b204e9800998ecf8427e"`, Chunks: []repository.FileChunk{part1ChunkA, part1ChunkB}},
 				{PartNumber: 2, ETag: `"0cc175b9c0f1b6a831c399e269772661"`, Chunks: []repository.FileChunk{part2Chunk}},
@@ -776,6 +810,9 @@ func TestObjectServiceCompleteMultipartUploadBuildsFinalFileAndCleansUnusedChunk
 	}
 	if result.File.Chunks[0].Checksum != part1ChunkA.Checksum {
 		t.Fatalf("expected checksum to be preserved")
+	}
+	if result.File.ContentType != "application/x-ndjson" || result.File.UserMetadata["batch"] != "42" {
+		t.Fatalf("expected multipart metadata to be preserved, got content_type=%q metadata=%#v", result.File.ContentType, result.File.UserMetadata)
 	}
 	if len(deleted) != 2 {
 		t.Fatalf("expected old file chunk and unreferenced part cleanup, got %#v", deleted)

--- a/api-go/internal/repository/file.go
+++ b/api-go/internal/repository/file.go
@@ -23,11 +23,13 @@ type FileChunk struct {
 }
 
 type File struct {
-	ID        primitive.ObjectID `bson:"_id,omitempty"`
-	BucketID  primitive.ObjectID `bson:"bucket_id"`
-	Name      string             `bson:"name"`
-	CreatedAt time.Time          `bson:"created_at"`
-	Chunks    []FileChunk        `bson:"chunks"`
+	ID           primitive.ObjectID `bson:"_id,omitempty"`
+	BucketID     primitive.ObjectID `bson:"bucket_id"`
+	Name         string             `bson:"name"`
+	CreatedAt    time.Time          `bson:"created_at"`
+	Chunks       []FileChunk        `bson:"chunks"`
+	ContentType  string             `bson:"content_type,omitempty"`
+	UserMetadata map[string]string  `bson:"user_metadata,omitempty"`
 }
 
 type FileRepository struct {
@@ -272,10 +274,12 @@ func (r *FileRepository) DeleteByBucket(ctx context.Context, bucketID primitive.
 func (r *FileRepository) UpdateByID(ctx context.Context, f File) (*File, error) {
 	f.CreatedAt = f.CreatedAt.UTC()
 	res, err := r.coll.UpdateOne(ctx, bson.M{"_id": f.ID}, bson.M{"$set": bson.M{
-		"bucket_id":  f.BucketID,
-		"name":       f.Name,
-		"created_at": f.CreatedAt,
-		"chunks":     f.Chunks,
+		"bucket_id":     f.BucketID,
+		"name":          f.Name,
+		"created_at":    f.CreatedAt,
+		"chunks":        f.Chunks,
+		"content_type":  f.ContentType,
+		"user_metadata": f.UserMetadata,
 	}})
 	if err != nil {
 		return nil, err
@@ -316,10 +320,12 @@ func (r *FileRepository) ReplaceByName(ctx context.Context, f File) (*File, *Fil
 func (r *FileRepository) replaceByName(ctx context.Context, f File, upsert bool) (*File, error) {
 	update := bson.M{
 		"$set": bson.M{
-			"bucket_id":  f.BucketID,
-			"name":       f.Name,
-			"created_at": f.CreatedAt,
-			"chunks":     f.Chunks,
+			"bucket_id":     f.BucketID,
+			"name":          f.Name,
+			"created_at":    f.CreatedAt,
+			"chunks":        f.Chunks,
+			"content_type":  f.ContentType,
+			"user_metadata": f.UserMetadata,
 		},
 	}
 	if upsert {

--- a/api-go/internal/repository/file_test.go
+++ b/api-go/internal/repository/file_test.go
@@ -25,10 +25,12 @@ func TestFileRepositoryUniqueBucketNameAndReplace(t *testing.T) {
 	firstChunks := []FileChunk{{SourceID: sourceID, Name: "chunk-a", Order: 0, Size: 5}}
 
 	created, previous, err := repo.ReplaceByName(ctx, File{
-		BucketID:  bucketID,
-		Name:      name,
-		CreatedAt: time.Now(),
-		Chunks:    firstChunks,
+		BucketID:     bucketID,
+		Name:         name,
+		CreatedAt:    time.Now(),
+		Chunks:       firstChunks,
+		ContentType:  "text/plain",
+		UserMetadata: map[string]string{"owner": "alice"},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -52,10 +54,12 @@ func TestFileRepositoryUniqueBucketNameAndReplace(t *testing.T) {
 
 	secondChunks := []FileChunk{{SourceID: sourceID, Name: "chunk-b", Order: 0, Size: 7}}
 	updated, previous, err := repo.ReplaceByName(ctx, File{
-		BucketID:  bucketID,
-		Name:      name,
-		CreatedAt: time.Now(),
-		Chunks:    secondChunks,
+		BucketID:     bucketID,
+		Name:         name,
+		CreatedAt:    time.Now(),
+		Chunks:       secondChunks,
+		ContentType:  "application/json",
+		UserMetadata: map[string]string{"owner": "bob"},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -69,6 +73,9 @@ func TestFileRepositoryUniqueBucketNameAndReplace(t *testing.T) {
 	if len(previous.Chunks) != 1 || previous.Chunks[0].Name != "chunk-a" {
 		t.Fatalf("expected previous chunks, got %+v", previous.Chunks)
 	}
+	if previous.ContentType != "text/plain" || previous.UserMetadata["owner"] != "alice" {
+		t.Fatalf("expected previous metadata, got content_type=%q metadata=%#v", previous.ContentType, previous.UserMetadata)
+	}
 
 	got, err := repo.GetByName(ctx, bucketID, name)
 	if err != nil {
@@ -76,6 +83,9 @@ func TestFileRepositoryUniqueBucketNameAndReplace(t *testing.T) {
 	}
 	if got.ID != created.ID || len(got.Chunks) != 1 || got.Chunks[0].Name != "chunk-b" {
 		t.Fatalf("unexpected authoritative file: %+v", got)
+	}
+	if got.ContentType != "application/json" || got.UserMetadata["owner"] != "bob" {
+		t.Fatalf("unexpected authoritative metadata: content_type=%q metadata=%#v", got.ContentType, got.UserMetadata)
 	}
 
 	files, err := repo.ListByBucket(ctx, bucketID)

--- a/api-go/internal/repository/multipart.go
+++ b/api-go/internal/repository/multipart.go
@@ -18,12 +18,14 @@ type UploadPart struct {
 }
 
 type MultipartUpload struct {
-	ID        primitive.ObjectID `bson:"_id,omitempty"`
-	BucketID  primitive.ObjectID `bson:"bucket_id"`
-	ObjectKey string             `bson:"object_key"`
-	UploadID  string             `bson:"upload_id"`
-	Parts     []UploadPart       `bson:"parts"`
-	CreatedAt time.Time          `bson:"created_at"`
+	ID           primitive.ObjectID `bson:"_id,omitempty"`
+	BucketID     primitive.ObjectID `bson:"bucket_id"`
+	ObjectKey    string             `bson:"object_key"`
+	UploadID     string             `bson:"upload_id"`
+	Parts        []UploadPart       `bson:"parts"`
+	CreatedAt    time.Time          `bson:"created_at"`
+	ContentType  string             `bson:"content_type,omitempty"`
+	UserMetadata map[string]string  `bson:"user_metadata,omitempty"`
 }
 
 type MultipartUploadRepository struct {

--- a/docs/s3-compatibility.md
+++ b/docs/s3-compatibility.md
@@ -8,7 +8,7 @@ Reference: [Amazon S3 API operations](https://docs.aws.amazon.com/AmazonS3/lates
 
 ## Summary
 
-SFree supports the core object lifecycle: upload, download, head, copy, single-delete, multi-delete, ListObjectsV2, byte-range downloads, and multipart upload. The main compatibility gaps are bucket-discovery calls used by general-purpose clients, metadata fidelity, checksums, and advanced bucket/object APIs.
+SFree supports the core object lifecycle: upload, download, head, copy, single-delete, multi-delete, ListObjectsV2, byte-range downloads, and multipart upload. The main compatibility gaps are bucket-discovery calls used by general-purpose clients, checksums, and advanced bucket/object APIs.
 
 Validated v0.2 SDK compatibility scope:
 
@@ -17,6 +17,7 @@ Validated v0.2 SDK compatibility scope:
 3. DeleteObjects multi-delete.
 4. CopyObject for same-user same-bucket and cross-bucket copies.
 5. Multipart upload lifecycle.
+6. PutObject/HeadObject/GetObject preservation for `Content-Type` and `x-amz-meta-*` user metadata.
 
 Bucket administration APIs, ACLs, versioning, lifecycle, object lock, tagging, and policy APIs are not v0.2.0 targets.
 
@@ -26,11 +27,11 @@ Bucket administration APIs, ACLs, versioning, lifecycle, object lock, tagging, a
 
 | S3 operation | Status | Notes |
 | --- | --- | --- |
-| GetObject | Partial | Basic full-object download and byte `Range` requests work. Conditional headers, response header overrides, and checksum-related response semantics are missing. |
-| PutObject | Partial | Basic upload and overwrite work. Content-Type, user metadata, object tags, storage class, checksum validation, and server-side encryption headers are ignored. |
+| GetObject | Partial | Basic full-object download and byte `Range` requests work. Stored Content-Type and user metadata are returned. Conditional headers, response header overrides, and checksum-related response semantics are missing. |
+| PutObject | Partial | Basic upload and overwrite work. Content-Type and `x-amz-meta-*` user metadata are persisted. Object tags, storage class, checksum validation, and server-side encryption headers are ignored. |
 | DeleteObject | Implemented | Single-object delete is idempotent and returns no content for missing keys. |
-| HeadObject | Partial | Returns ETag, Last-Modified, Content-Length, and Content-Type. Range awareness, checksum headers, metadata, and conditional request behavior are missing. |
-| CopyObject | Partial | Basic same-bucket and cross-bucket copies are implemented and covered by Go and Python SDK E2E. `x-amz-metadata-directive: REPLACE` returns XML `NotImplemented`; broader metadata-copy fidelity remains limited while metadata persistence is not on `origin/main`. |
+| HeadObject | Partial | Returns ETag, Last-Modified, Content-Length, Content-Type, and user metadata. Range awareness, checksum headers, and conditional request behavior are missing. |
+| CopyObject | Partial | Basic same-bucket and cross-bucket copies are implemented and covered by Go and Python SDK E2E. COPY preserves object bytes, Content-Type, and user metadata. `x-amz-metadata-directive: REPLACE` returns XML `NotImplemented`. |
 | DeleteObjects | Implemented | SDK multi-delete is covered by `test_s3_sdk_delete_objects_removes_multiple_keys`, including missing-key idempotency. |
 | GetObjectAcl / PutObjectAcl | Missing | ACLs are not modeled in the S3 API. |
 | GetObjectTagging / PutObjectTagging / DeleteObjectTagging | Missing | Object tags are not stored. |
@@ -49,9 +50,9 @@ Bucket administration APIs, ACLs, versioning, lifecycle, object lock, tagging, a
 
 | S3 operation | Status | Notes |
 | --- | --- | --- |
-| CreateMultipartUpload | Implemented | `POST /api/s3/{bucket}/{key}?uploads`. |
+| CreateMultipartUpload | Implemented | `POST /api/s3/{bucket}/{key}?uploads`; captures Content-Type and user metadata for completion. |
 | UploadPart | Implemented | `PUT /api/s3/{bucket}/{key}?uploadId=...&partNumber=...`. |
-| CompleteMultipartUpload | Implemented | Validates part existence, ETags, and ascending part order. |
+| CompleteMultipartUpload | Implemented | Validates part existence, ETags, ascending part order, and persists metadata captured during CreateMultipartUpload. |
 | AbortMultipartUpload | Implemented | Deletes uploaded part chunks and the multipart record. |
 | ListMultipartUploads | Partial | Lists active uploads for a bucket but lacks prefix, delimiter, key-marker, upload-id-marker, and pagination support. |
 | ListParts | Partial | Lists uploaded parts but lacks pagination and part-number-marker support. |
@@ -78,8 +79,8 @@ Bucket administration APIs, ACLs, versioning, lifecycle, object lock, tagging, a
 | Virtual-hosted-style addressing | Missing | Only path-style routing under `/api/s3/{bucket}` is supported. |
 | Range requests | Partial | GetObject byte ranges and `Accept-Ranges` are covered by Go e2e and the Python SDK e2e fixture. HeadObject range behavior is not validated as a v0.2 SDK path. |
 | Conditional requests | Missing | `If-Match`, `If-None-Match`, `If-Modified-Since`, and related headers are not evaluated. |
-| User metadata | Missing | `x-amz-meta-*` headers are not persisted or returned. |
-| Content-Type persistence | Missing | Downloads always return `application/octet-stream`. |
+| User metadata | Partial | `x-amz-meta-*` headers are stored with lowercase keys, returned on HeadObject/GetObject, replaced on overwrite, and preserved by CopyObject COPY. Metadata search/listing and tags are not supported. |
+| Content-Type persistence | Partial | PutObject and CreateMultipartUpload store request Content-Type; HeadObject/GetObject return it and legacy objects default to `application/octet-stream`. |
 | Checksums | Missing | S3 checksum headers are not validated or returned. |
 | Server-side encryption headers | Missing | SSE request headers are not interpreted. |
 
@@ -123,10 +124,10 @@ These checks are based on the current S3 API surface and known request patterns 
 | --- | --- | --- |
 | `aws s3 ls` | No | `ListBuckets` is missing. |
 | `aws s3 ls s3://bucket/` | Expected for direct bucket paths | High-level `aws s3` listing uses ListObjectsV2, which is now covered through SDK tests; live AWS CLI validation is not automated in this PR. |
-| `aws s3 cp local s3://bucket/key` | Yes for simple uploads | PutObject works; metadata/content-type persistence is missing. |
+| `aws s3 cp local s3://bucket/key` | Yes for simple uploads | PutObject works, including Content-Type and user metadata persistence. |
 | `aws s3 cp s3://bucket/key local` | Yes for full-object downloads | GetObject works. |
 | `aws s3 rm s3://bucket/key` | Yes | DeleteObject works. |
-| `aws s3 sync` | Partial | ListObjectsV2, DeleteObjects, and basic CopyObject are covered; metadata behavior and stronger ETag/checksum compatibility remain gaps. |
+| `aws s3 sync` | Partial | ListObjectsV2, DeleteObjects, CopyObject COPY, and basic metadata behavior are covered; stronger ETag/checksum compatibility remains a gap. |
 | `aws s3 presign s3://bucket/key` | Yes for downloads | Presigned SigV4 requests are supported. |
 
 ### MinIO Client (`mc`)


### PR DESCRIPTION
## Summary
- persist S3 object Content-Type and normalized x-amz-meta-* user metadata on file documents
- return stored metadata headers from HeadObject and full/ranged GetObject
- preserve metadata for CopyObject COPY and multipart create/complete flows
- add focused Go handler/manager/repository coverage plus Go/Python S3 E2E coverage
- update S3 compatibility and QA audit docs

Links #164

## Validation
- gofmt on touched Go files
- git diff --check

CPU-heavy local test suites, local Docker/full-stack E2E, and Playwright were not run on this limited machine. Woodpecker should validate backend unit/integration/E2E surfaces for this PR.