### PR TITLE
Add filename search to bucket file list API

### DIFF
--- a/api-go/internal/docs/docs.go
+++ b/api-go/internal/docs/docs.go
@@ -372,6 +372,12 @@ const docTemplate = `{
                         "name": "id",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filename search query",
+                        "name": "q",
+                        "in": "query"
                     }
                 ],
                 "responses": {

--- a/api-go/internal/docs/openapi.go
+++ b/api-go/internal/docs/openapi.go
@@ -664,6 +664,14 @@ const openAPIJSON = `{
         "parameters": [
           {
             "$ref": "#/components/parameters/ID"
+          },
+          {
+            "name": "q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Case-insensitive filename search query"
           }
         ],
         "responses": {

--- a/api-go/internal/handlers/bucket.go
+++ b/api-go/internal/handlers/bucket.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/example/sfree/api-go/internal/cryptoutil"
@@ -426,6 +427,7 @@ func UploadFile(bucketRepo *repository.BucketRepository, sourceRepo *repository.
 // @Tags buckets
 // @Produce json
 // @Param id path string true "Bucket ID"
+// @Param q query string false "Filename search query"
 // @Success 200 {array} fileResponse
 // @Failure 400 {string} string ""
 // @Failure 401 {string} string ""
@@ -447,7 +449,7 @@ func ListFiles(bucketRepo *repository.BucketRepository, fileRepo *repository.Fil
 			return
 		}
 		bucketID := acc.Bucket.ID
-		files, err := fileRepo.ListByBucket(c.Request.Context(), bucketID)
+		files, err := fileRepo.ListByBucketByNameQuery(c.Request.Context(), bucketID, strings.TrimSpace(c.Query("q")))
 		if err != nil {
 			slog.ErrorContext(ctx, "list files: list files", slog.String("error", err.Error()))
 			c.Status(http.StatusInternalServerError)

--- a/api-go/internal/handlers/bucket_test.go
+++ b/api-go/internal/handlers/bucket_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/example/sfree/api-go/internal/db"
 	"github.com/example/sfree/api-go/internal/repository"
 	"github.com/gin-gonic/gin"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 	"golang.org/x/crypto/bcrypt"
 )
 
@@ -91,4 +92,105 @@ func TestCreateBucket(t *testing.T) {
 	if w2.Code != http.StatusUnauthorized {
 		t.Fatalf("expected 401, got %d", w2.Code)
 	}
+}
+
+func TestListFilesSearchQueryWithGrantAccess(t *testing.T) {
+	bucketRepo, fileRepo, grantRepo := newBucketFileHandlerTestRepos(t)
+	ctx := context.Background()
+	ownerID := primitive.NewObjectID()
+	viewerID := primitive.NewObjectID()
+	bucket := createBucketFileTestBucket(t, ctx, bucketRepo, ownerID)
+	otherBucket := createBucketFileTestBucket(t, ctx, bucketRepo, primitive.NewObjectID())
+
+	if _, err := grantRepo.Create(ctx, repository.BucketGrant{
+		BucketID:  bucket.ID,
+		UserID:    viewerID,
+		Role:      repository.RoleViewer,
+		GrantedBy: ownerID,
+		CreatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Now().UTC()
+	for _, file := range []repository.File{
+		{BucketID: bucket.ID, Name: "annual-report.pdf", CreatedAt: now},
+		{BucketID: bucket.ID, Name: "notes.txt", CreatedAt: now},
+		{BucketID: otherBucket.ID, Name: "other-report.pdf", CreatedAt: now},
+	} {
+		if _, err := fileRepo.Create(ctx, file); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	router := gin.New()
+	router.GET("/buckets/:id/files", setUserID(viewerID.Hex()), ListFiles(bucketRepo, fileRepo, grantRepo))
+	req, _ := http.NewRequest(http.MethodGet, "/buckets/"+bucket.ID.Hex()+"/files?q=REPORT", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var resp []fileResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+	if len(resp) != 1 || resp[0].Name != "annual-report.pdf" {
+		t.Fatalf("unexpected files: %+v", resp)
+	}
+
+	noAccessRouter := gin.New()
+	noAccessRouter.GET("/buckets/:id/files", setUserID(primitive.NewObjectID().Hex()), ListFiles(bucketRepo, fileRepo, grantRepo))
+	noAccessReq, _ := http.NewRequest(http.MethodGet, "/buckets/"+bucket.ID.Hex()+"/files?q=report", nil)
+	noAccessW := httptest.NewRecorder()
+	noAccessRouter.ServeHTTP(noAccessW, noAccessReq)
+	if noAccessW.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", noAccessW.Code)
+	}
+}
+
+func newBucketFileHandlerTestRepos(t *testing.T) (*repository.BucketRepository, *repository.FileRepository, *repository.BucketGrantRepository) {
+	t.Helper()
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	mongoConn, err := db.Connect(context.Background(), cfg.Mongo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	testDB := mongoConn.Client.Database("sfree_bucket_file_handlers_" + primitive.NewObjectID().Hex())
+	t.Cleanup(func() {
+		_ = testDB.Drop(context.Background())
+		_ = mongoConn.Close(context.Background())
+	})
+	bucketRepo, err := repository.NewBucketRepository(testDB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fileRepo, err := repository.NewFileRepository(testDB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	grantRepo, err := repository.NewBucketGrantRepository(testDB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return bucketRepo, fileRepo, grantRepo
+}
+
+func createBucketFileTestBucket(t *testing.T, ctx context.Context, repo *repository.BucketRepository, ownerID primitive.ObjectID) *repository.Bucket {
+	t.Helper()
+	suffix := primitive.NewObjectID().Hex()
+	bucket, err := repo.Create(ctx, repository.Bucket{
+		UserID:          ownerID,
+		Key:             "bucket-" + suffix,
+		AccessKey:       "access-" + suffix,
+		AccessSecretEnc: "secret-" + suffix,
+		CreatedAt:       time.Now().UTC(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return bucket
 }

--- a/api-go/internal/repository/file.go
+++ b/api-go/internal/repository/file.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"context"
 	"regexp"
+	"strings"
 	"time"
 
 	"go.mongodb.org/mongo-driver/bson"
@@ -161,7 +162,15 @@ func (r *FileRepository) CountByChunk(ctx context.Context, sourceID primitive.Ob
 }
 
 func (r *FileRepository) ListByBucket(ctx context.Context, bucketID primitive.ObjectID) ([]File, error) {
-	return r.ListByBucketWithPrefix(ctx, bucketID, "")
+	return r.ListByBucketByNameQuery(ctx, bucketID, "")
+}
+
+func (r *FileRepository) ListByBucketByNameQuery(ctx context.Context, bucketID primitive.ObjectID, query string) ([]File, error) {
+	filter := bson.M{"bucket_id": bucketID}
+	if query = strings.TrimSpace(query); query != "" {
+		filter["name"] = bson.M{"$regex": regexp.QuoteMeta(query), "$options": "i"}
+	}
+	return r.listByBucketFilter(ctx, filter)
 }
 
 func (r *FileRepository) ListByBucketWithPrefix(ctx context.Context, bucketID primitive.ObjectID, prefix string) ([]File, error) {
@@ -169,6 +178,10 @@ func (r *FileRepository) ListByBucketWithPrefix(ctx context.Context, bucketID pr
 	if prefix != "" {
 		filter["name"] = bson.M{"$regex": "^" + regexp.QuoteMeta(prefix)}
 	}
+	return r.listByBucketFilter(ctx, filter)
+}
+
+func (r *FileRepository) listByBucketFilter(ctx context.Context, filter bson.M) ([]File, error) {
 	cursor, err := r.coll.Find(ctx, filter, options.Find().SetSort(bson.D{{Key: "name", Value: 1}}))
 	if err != nil {
 		return nil, err

--- a/api-go/internal/repository/file_test.go
+++ b/api-go/internal/repository/file_test.go
@@ -118,6 +118,48 @@ func TestFileRepositoryMigratesLegacyBucketNameIndex(t *testing.T) {
 	}
 }
 
+func TestFileRepositoryListByBucketByNameQuery(t *testing.T) {
+	_, repo := newFileRepositoryTestDB(t)
+	ctx := context.Background()
+	bucketID := primitive.NewObjectID()
+	otherBucketID := primitive.NewObjectID()
+	now := time.Now().UTC()
+
+	for _, file := range []File{
+		{BucketID: bucketID, Name: "alpha.txt", CreatedAt: now},
+		{BucketID: bucketID, Name: "Quarterly Report.pdf", CreatedAt: now},
+		{BucketID: bucketID, Name: "report[1].txt", CreatedAt: now},
+		{BucketID: bucketID, Name: "report1.txt", CreatedAt: now},
+		{BucketID: otherBucketID, Name: "other-report.txt", CreatedAt: now},
+	} {
+		if _, err := repo.Create(ctx, file); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	matches, err := repo.ListByBucketByNameQuery(ctx, bucketID, "report")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertFileNames(t, matches, []string{"Quarterly Report.pdf", "report1.txt", "report[1].txt"})
+
+	literalMatches, err := repo.ListByBucketByNameQuery(ctx, bucketID, "report[1]")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertFileNames(t, literalMatches, []string{"report[1].txt"})
+
+	blankMatches, err := repo.ListByBucketByNameQuery(ctx, bucketID, "   ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	unfiltered, err := repo.ListByBucket(ctx, bucketID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertFileNames(t, blankMatches, fileNames(unfiltered))
+}
+
 func newFileRepositoryTestDB(t *testing.T) (*mongo.Database, *FileRepository) {
 	t.Helper()
 	cfg, err := config.Load()
@@ -138,4 +180,25 @@ func newFileRepositoryTestDB(t *testing.T) (*mongo.Database, *FileRepository) {
 		t.Fatal(err)
 	}
 	return testDB, repo
+}
+
+func assertFileNames(t *testing.T, files []File, want []string) {
+	t.Helper()
+	got := fileNames(files)
+	if len(got) != len(want) {
+		t.Fatalf("expected file names %v, got %v", want, got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("expected file names %v, got %v", want, got)
+		}
+	}
+}
+
+func fileNames(files []File) []string {
+	names := make([]string, 0, len(files))
+	for _, file := range files {
+		names = append(names, file.Name)
+	}
+	return names
 }


### PR DESCRIPTION
## Summary
- Add optional `q` query support to `GET /api/v1/buckets/:id/files`.
- Match bucket file names with a quoted, case-insensitive contains regex while preserving name ordering.
- Cover same-bucket matching, cross-bucket exclusion, regex escaping, blank queries, and grant-based handler access.
- Update OpenAPI/Swagger docs for the new `q` parameter.

## Behavior
Filename search is case-insensitive. Blank or whitespace-only `q` is treated like the existing unfiltered list.

## Validation
- `git diff --check`
- Local integration tests were not run per task instructions; Woodpecker should run them.

Links: parent THE-569, public GitHub issue #162.