### PR TITLE
Add source health API and source list status

### DIFF
--- a/api-go/internal/app/router_routes.go
+++ b/api-go/internal/app/router_routes.go
@@ -94,6 +94,7 @@ func registerSourceRoutes(router *gin.Engine, deps *routerDependencies) {
 	router.POST("/api/v1/sources/telegram", deps.auth, handlers.CreateTelegramSource(deps.sourceRepo))
 	router.POST("/api/v1/sources/s3", deps.auth, handlers.CreateS3Source(deps.sourceRepo))
 	router.GET("/api/v1/sources", deps.auth, handlers.ListSources(deps.sourceRepo))
+	router.GET("/api/v1/sources/:id/health", deps.auth, handlers.GetSourceHealth(deps.sourceRepo))
 	router.GET("/api/v1/sources/:id/info", deps.auth, handlers.GetSourceInfo(deps.sourceRepo))
 	router.GET("/api/v1/sources/:id/files/:file_id/download", deps.auth, handlers.DownloadSourceFile(deps.sourceRepo))
 	router.DELETE("/api/v1/sources/:id", deps.auth, handlers.DeleteSource(deps.sourceRepo, deps.bucketRepo))

--- a/api-go/internal/docs/openapi.go
+++ b/api-go/internal/docs/openapi.go
@@ -1123,6 +1123,49 @@ const openAPIJSON = `{
         }
       }
     },
+    "/api/v1/sources/{id}/health": {
+      "get": {
+        "tags": [
+          "sources"
+        ],
+        "summary": "Check storage source health",
+        "description": "Runs an on-demand lightweight provider probe. Google Drive may return native provider quota. S3-compatible and Telegram quota fields are null because no cheap native capacity value is available.",
+        "security": [
+          {
+            "basicAuth": []
+          },
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Source health",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SourceHealth"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/PlainError"
+          },
+          "401": {
+            "$ref": "#/components/responses/PlainError"
+          },
+          "404": {
+            "$ref": "#/components/responses/PlainError"
+          }
+        }
+      }
+    },
     "/api/v1/sources/{id}/info": {
       "get": {
         "tags": [
@@ -2119,6 +2162,63 @@ const openAPIJSON = `{
           },
           "path_style": {
             "type": "boolean"
+          }
+        }
+      },
+      "SourceHealth": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "gdrive",
+              "telegram",
+              "s3"
+            ]
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "healthy",
+              "degraded",
+              "unhealthy"
+            ]
+          },
+          "checked_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "latency_ms": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "reason_code": {
+            "type": "string",
+            "description": "Machine-readable health reason, such as ok, probe_failed, client_error, quota_low, or quota_exhausted."
+          },
+          "message": {
+            "type": "string"
+          },
+          "quota_total_bytes": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true,
+            "description": "Provider-native quota total when cheaply available. Null means unknown, including S3-compatible and Telegram sources."
+          },
+          "quota_used_bytes": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true,
+            "description": "Provider-native quota used when cheaply available. Null means unknown, including S3-compatible and Telegram sources."
+          },
+          "quota_free_bytes": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true,
+            "description": "Provider-native quota free when cheaply available. Null means unknown, including S3-compatible and Telegram sources."
           }
         }
       },

--- a/api-go/internal/handlers/source.go
+++ b/api-go/internal/handlers/source.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"log/slog"
@@ -12,6 +13,7 @@ import (
 	"github.com/example/sfree/api-go/internal/s3compat"
 	"github.com/example/sfree/api-go/internal/telegram"
 	"github.com/gin-gonic/gin"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
@@ -57,6 +59,23 @@ type sourceInfoResponse struct {
 	StorageTotal int64            `json:"storage_total"`
 	StorageUsed  int64            `json:"storage_used"`
 	StorageFree  int64            `json:"storage_free"`
+}
+
+type sourceHealthResponse struct {
+	ID              string    `json:"id"`
+	Type            string    `json:"type"`
+	Status          string    `json:"status"`
+	CheckedAt       time.Time `json:"checked_at"`
+	LatencyMS       int64     `json:"latency_ms"`
+	ReasonCode      string    `json:"reason_code"`
+	Message         string    `json:"message"`
+	QuotaTotalBytes *int64    `json:"quota_total_bytes"`
+	QuotaUsedBytes  *int64    `json:"quota_used_bytes"`
+	QuotaFreeBytes  *int64    `json:"quota_free_bytes"`
+}
+
+type sourceGetter interface {
+	GetByID(ctx context.Context, id primitive.ObjectID) (*repository.Source, error)
 }
 
 // CreateGDriveSource godoc
@@ -339,6 +358,77 @@ func getSourceInfo(repo *repository.SourceRepository, factory manager.SourceClie
 			StorageTotal: info.StorageTotal,
 			StorageUsed:  info.StorageUsed,
 			StorageFree:  info.StorageFree,
+		})
+	}
+}
+
+// GetSourceHealth godoc
+// @Summary Check source health
+// @Description Runs a lightweight on-demand provider probe. Google Drive returns native quota when available; S3-compatible and Telegram quota fields are null because no cheap native capacity is available.
+// @Tags sources
+// @Param id path string true "Source ID"
+// @Success 200 {object} sourceHealthResponse
+// @Failure 400 {string} string ""
+// @Failure 401 {string} string ""
+// @Failure 404 {string} string ""
+// @Failure 500 {string} string ""
+// @Security BasicAuth
+// @Router /api/v1/sources/{id}/health [get]
+func GetSourceHealth(repo *repository.SourceRepository) gin.HandlerFunc {
+	return getSourceHealth(repo, nil)
+}
+
+func getSourceHealth(repo sourceGetter, factory manager.SourceClientFactory) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		ctx := c.Request.Context()
+		if repo == nil {
+			slog.ErrorContext(ctx, "get source health: repository is nil")
+			c.Status(http.StatusServiceUnavailable)
+			return
+		}
+		userID, ok := authenticatedUserID(c)
+		if !ok {
+			return
+		}
+		id, ok := routeObjectID(c, "id")
+		if !ok {
+			return
+		}
+		src, err := repo.GetByID(c.Request.Context(), id)
+		if err != nil {
+			if err == mongo.ErrNoDocuments {
+				c.Status(http.StatusNotFound)
+				return
+			}
+			slog.ErrorContext(ctx, "get source health: get source", slog.String("error", err.Error()))
+			c.Status(http.StatusInternalServerError)
+			return
+		}
+		if src.UserID != userID {
+			c.Status(http.StatusNotFound)
+			return
+		}
+		health, err := manager.CheckSourceHealth(c.Request.Context(), src, factory)
+		if err != nil {
+			if err == manager.ErrUnsupportedSourceType {
+				c.Status(http.StatusBadRequest)
+				return
+			}
+			slog.ErrorContext(ctx, "get source health: check source", slog.String("error", err.Error()))
+			c.Status(http.StatusInternalServerError)
+			return
+		}
+		c.JSON(http.StatusOK, sourceHealthResponse{
+			ID:              health.SourceID,
+			Type:            health.SourceType,
+			Status:          string(health.Status),
+			CheckedAt:       health.CheckedAt,
+			LatencyMS:       health.LatencyMS,
+			ReasonCode:      health.ReasonCode,
+			Message:         health.Message,
+			QuotaTotalBytes: health.Quota.TotalBytes,
+			QuotaUsedBytes:  health.Quota.UsedBytes,
+			QuotaFreeBytes:  health.Quota.FreeBytes,
 		})
 	}
 }

--- a/api-go/internal/handlers/source_health_test.go
+++ b/api-go/internal/handlers/source_health_test.go
@@ -1,0 +1,158 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/example/sfree/api-go/internal/manager"
+	"github.com/example/sfree/api-go/internal/repository"
+	"github.com/gin-gonic/gin"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+type fakeSourceGetter struct {
+	source *repository.Source
+	err    error
+}
+
+func (f fakeSourceGetter) GetByID(context.Context, primitive.ObjectID) (*repository.Source, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.source, nil
+}
+
+type sourceHealthHandlerClient struct {
+	headErr error
+}
+
+func (c sourceHealthHandlerClient) Upload(context.Context, string, io.Reader) (string, error) {
+	return "", nil
+}
+
+func (c sourceHealthHandlerClient) Download(context.Context, string) (io.ReadCloser, error) {
+	return io.NopCloser(strings.NewReader("")), nil
+}
+
+func (c sourceHealthHandlerClient) Delete(context.Context, string) error {
+	return nil
+}
+
+func (c sourceHealthHandlerClient) HeadBucket(context.Context) error {
+	return c.headErr
+}
+
+func TestGetSourceHealthBadID(t *testing.T) {
+	t.Parallel()
+	r := gin.New()
+	r.GET("/sources/:id/health", setUserID(validUserID()), getSourceHealth(fakeSourceGetter{}, nil))
+
+	req, _ := http.NewRequest(http.MethodGet, "/sources/not-an-id/health", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestGetSourceHealthMissingSource(t *testing.T) {
+	t.Parallel()
+	r := gin.New()
+	r.GET("/sources/:id/health", setUserID(validUserID()), getSourceHealth(fakeSourceGetter{err: mongo.ErrNoDocuments}, nil))
+
+	req, _ := http.NewRequest(http.MethodGet, "/sources/"+primitive.NewObjectID().Hex()+"/health", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestGetSourceHealthNonOwnedSource(t *testing.T) {
+	t.Parallel()
+	source := &repository.Source{
+		ID:     primitive.NewObjectID(),
+		UserID: primitive.NewObjectID(),
+		Type:   repository.SourceTypeS3,
+	}
+	r := gin.New()
+	r.GET("/sources/:id/health", setUserID(validUserID()), getSourceHealth(fakeSourceGetter{source: source}, nil))
+
+	req, _ := http.NewRequest(http.MethodGet, "/sources/"+source.ID.Hex()+"/health", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestGetSourceHealthSuccessfulProbe(t *testing.T) {
+	t.Parallel()
+	userID := primitive.NewObjectID()
+	source := &repository.Source{
+		ID:     primitive.NewObjectID(),
+		UserID: userID,
+		Type:   repository.SourceTypeS3,
+	}
+	r := gin.New()
+	r.GET("/sources/:id/health", setUserID(userID.Hex()), getSourceHealth(fakeSourceGetter{source: source}, func(context.Context, *repository.Source) (manager.SourceClient, error) {
+		return sourceHealthHandlerClient{}, nil
+	}))
+
+	req, _ := http.NewRequest(http.MethodGet, "/sources/"+source.ID.Hex()+"/health", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var resp sourceHealthResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Status != string(manager.SourceHealthHealthy) || resp.ReasonCode != "ok" {
+		t.Fatalf("unexpected response: %+v", resp)
+	}
+	if resp.QuotaTotalBytes != nil || resp.QuotaUsedBytes != nil || resp.QuotaFreeBytes != nil {
+		t.Fatalf("expected null quota for s3, got %+v", resp)
+	}
+}
+
+func TestGetSourceHealthProviderFailureMapping(t *testing.T) {
+	t.Parallel()
+	userID := primitive.NewObjectID()
+	source := &repository.Source{
+		ID:     primitive.NewObjectID(),
+		UserID: userID,
+		Type:   repository.SourceTypeS3,
+	}
+	r := gin.New()
+	r.GET("/sources/:id/health", setUserID(userID.Hex()), getSourceHealth(fakeSourceGetter{source: source}, func(context.Context, *repository.Source) (manager.SourceClient, error) {
+		return sourceHealthHandlerClient{headErr: errors.New("access denied")}, nil
+	}))
+
+	req, _ := http.NewRequest(http.MethodGet, "/sources/"+source.ID.Hex()+"/health", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var resp sourceHealthResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Status != string(manager.SourceHealthUnhealthy) || resp.ReasonCode != "probe_failed" {
+		t.Fatalf("unexpected response: %+v", resp)
+	}
+}

--- a/api-go/internal/manager/source.go
+++ b/api-go/internal/manager/source.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"time"
 
 	"github.com/example/sfree/api-go/internal/gdrive"
 	"github.com/example/sfree/api-go/internal/repository"
@@ -21,6 +22,31 @@ type SourceInfo struct {
 	StorageTotal int64
 	StorageUsed  int64
 	StorageFree  int64
+}
+
+type SourceHealthStatus string
+
+const (
+	SourceHealthHealthy   SourceHealthStatus = "healthy"
+	SourceHealthDegraded  SourceHealthStatus = "degraded"
+	SourceHealthUnhealthy SourceHealthStatus = "unhealthy"
+)
+
+type SourceQuota struct {
+	TotalBytes *int64
+	UsedBytes  *int64
+	FreeBytes  *int64
+}
+
+type SourceHealth struct {
+	SourceID   string
+	SourceType string
+	Status     SourceHealthStatus
+	CheckedAt  time.Time
+	LatencyMS  int64
+	ReasonCode string
+	Message    string
+	Quota      SourceQuota
 }
 
 func InspectSource(ctx context.Context, src *repository.Source, factory SourceClientFactory) (SourceInfo, error) {
@@ -77,6 +103,84 @@ func InspectSource(ctx context.Context, src *repository.Source, factory SourceCl
 		return SourceInfo{Files: respFiles, StorageUsed: used}, nil
 	default:
 		return SourceInfo{}, ErrUnsupportedSourceType
+	}
+}
+
+func CheckSourceHealth(ctx context.Context, src *repository.Source, factory SourceClientFactory) (SourceHealth, error) {
+	if src == nil {
+		return SourceHealth{}, errors.New("nil source")
+	}
+	start := time.Now()
+	health := SourceHealth{
+		SourceID:   src.ID.Hex(),
+		SourceType: string(src.Type),
+		Status:     SourceHealthHealthy,
+		ReasonCode: "ok",
+		Message:    "Source is reachable.",
+	}
+	finish := func(status SourceHealthStatus, reasonCode, message string) SourceHealth {
+		health.Status = status
+		health.ReasonCode = reasonCode
+		health.Message = message
+		health.CheckedAt = time.Now().UTC()
+		health.LatencyMS = time.Since(start).Milliseconds()
+		return health
+	}
+
+	cli, err := sourceClientFor(ctx, src, factory)
+	if err != nil {
+		if err == ErrUnsupportedSourceType {
+			return SourceHealth{}, err
+		}
+		return finish(SourceHealthUnhealthy, "client_error", "Source configuration could not be initialized."), nil
+	}
+
+	switch src.Type {
+	case repository.SourceTypeGDrive:
+		infoClient, ok := cli.(interface {
+			StorageInfo(context.Context) (int64, int64, int64, error)
+		})
+		if !ok {
+			return SourceHealth{}, ErrUnsupportedSourceType
+		}
+		total, used, free, err := infoClient.StorageInfo(ctx)
+		if err != nil {
+			return finish(SourceHealthUnhealthy, "probe_failed", "Google Drive metadata probe failed."), nil
+		}
+		if total > 0 {
+			health.Quota = SourceQuota{TotalBytes: &total, UsedBytes: &used, FreeBytes: &free}
+			if free <= 0 {
+				return finish(SourceHealthUnhealthy, "quota_exhausted", "Google Drive quota is exhausted."), nil
+			}
+			if free*100/total < 5 {
+				return finish(SourceHealthDegraded, "quota_low", "Google Drive quota is nearly exhausted."), nil
+			}
+		}
+		return finish(SourceHealthHealthy, "ok", "Google Drive metadata is reachable."), nil
+	case repository.SourceTypeTelegram:
+		healthClient, ok := cli.(interface {
+			CheckChat(context.Context) error
+		})
+		if !ok {
+			return SourceHealth{}, ErrUnsupportedSourceType
+		}
+		if err := healthClient.CheckChat(ctx); err != nil {
+			return finish(SourceHealthUnhealthy, "probe_failed", "Telegram bot or chat is not reachable."), nil
+		}
+		return finish(SourceHealthHealthy, "ok", "Telegram bot and chat are reachable."), nil
+	case repository.SourceTypeS3:
+		healthClient, ok := cli.(interface {
+			HeadBucket(context.Context) error
+		})
+		if !ok {
+			return SourceHealth{}, ErrUnsupportedSourceType
+		}
+		if err := healthClient.HeadBucket(ctx); err != nil {
+			return finish(SourceHealthUnhealthy, "probe_failed", "S3 bucket metadata probe failed."), nil
+		}
+		return finish(SourceHealthHealthy, "ok", "S3 bucket metadata is reachable."), nil
+	default:
+		return SourceHealth{}, ErrUnsupportedSourceType
 	}
 }
 

--- a/api-go/internal/manager/source_health_test.go
+++ b/api-go/internal/manager/source_health_test.go
@@ -1,0 +1,150 @@
+package manager
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/example/sfree/api-go/internal/repository"
+	"github.com/example/sfree/api-go/internal/s3compat"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+type healthTestClient struct {
+	storageTotal int64
+	storageUsed  int64
+	storageFree  int64
+	storageErr   error
+	headErr      error
+	chatErr      error
+	headCalls    int
+	chatCalls    int
+	listCalls    int
+}
+
+func (c *healthTestClient) Upload(context.Context, string, io.Reader) (string, error) {
+	return "", nil
+}
+
+func (c *healthTestClient) Download(context.Context, string) (io.ReadCloser, error) {
+	return io.NopCloser(strings.NewReader("")), nil
+}
+
+func (c *healthTestClient) Delete(context.Context, string) error {
+	return nil
+}
+
+func (c *healthTestClient) StorageInfo(context.Context) (int64, int64, int64, error) {
+	return c.storageTotal, c.storageUsed, c.storageFree, c.storageErr
+}
+
+func (c *healthTestClient) HeadBucket(context.Context) error {
+	c.headCalls++
+	return c.headErr
+}
+
+func (c *healthTestClient) CheckChat(context.Context) error {
+	c.chatCalls++
+	return c.chatErr
+}
+
+func (c *healthTestClient) ListObjects(context.Context) ([]s3compat.ObjectInfo, int64, error) {
+	c.listCalls++
+	return nil, 0, nil
+}
+
+func TestCheckSourceHealthGDriveReturnsQuota(t *testing.T) {
+	t.Parallel()
+	cli := &healthTestClient{storageTotal: 1000, storageUsed: 400, storageFree: 600}
+	src := &repository.Source{ID: primitive.NewObjectID(), Type: repository.SourceTypeGDrive}
+
+	health, err := CheckSourceHealth(context.Background(), src, func(context.Context, *repository.Source) (SourceClient, error) {
+		return cli, nil
+	})
+	if err != nil {
+		t.Fatalf("check health: %v", err)
+	}
+	if health.Status != SourceHealthHealthy || health.ReasonCode != "ok" {
+		t.Fatalf("unexpected health: %+v", health)
+	}
+	if health.Quota.TotalBytes == nil || *health.Quota.TotalBytes != 1000 {
+		t.Fatalf("expected quota total, got %+v", health.Quota)
+	}
+}
+
+func TestCheckSourceHealthGDriveLowQuotaIsDegraded(t *testing.T) {
+	t.Parallel()
+	cli := &healthTestClient{storageTotal: 1000, storageUsed: 970, storageFree: 30}
+	src := &repository.Source{ID: primitive.NewObjectID(), Type: repository.SourceTypeGDrive}
+
+	health, err := CheckSourceHealth(context.Background(), src, func(context.Context, *repository.Source) (SourceClient, error) {
+		return cli, nil
+	})
+	if err != nil {
+		t.Fatalf("check health: %v", err)
+	}
+	if health.Status != SourceHealthDegraded || health.ReasonCode != "quota_low" {
+		t.Fatalf("unexpected health: %+v", health)
+	}
+}
+
+func TestCheckSourceHealthS3UsesBucketMetadataProbe(t *testing.T) {
+	t.Parallel()
+	cli := &healthTestClient{}
+	src := &repository.Source{ID: primitive.NewObjectID(), Type: repository.SourceTypeS3}
+
+	health, err := CheckSourceHealth(context.Background(), src, func(context.Context, *repository.Source) (SourceClient, error) {
+		return cli, nil
+	})
+	if err != nil {
+		t.Fatalf("check health: %v", err)
+	}
+	if health.Status != SourceHealthHealthy {
+		t.Fatalf("unexpected health: %+v", health)
+	}
+	if cli.headCalls != 1 {
+		t.Fatalf("expected one head bucket call, got %d", cli.headCalls)
+	}
+	if cli.listCalls != 0 {
+		t.Fatalf("health check must not list objects, got %d calls", cli.listCalls)
+	}
+	if health.Quota.TotalBytes != nil || health.Quota.UsedBytes != nil || health.Quota.FreeBytes != nil {
+		t.Fatalf("expected unknown quota for s3, got %+v", health.Quota)
+	}
+}
+
+func TestCheckSourceHealthTelegramFailureIsUnhealthy(t *testing.T) {
+	t.Parallel()
+	cli := &healthTestClient{chatErr: errors.New("chat not found")}
+	src := &repository.Source{ID: primitive.NewObjectID(), Type: repository.SourceTypeTelegram}
+
+	health, err := CheckSourceHealth(context.Background(), src, func(context.Context, *repository.Source) (SourceClient, error) {
+		return cli, nil
+	})
+	if err != nil {
+		t.Fatalf("check health: %v", err)
+	}
+	if health.Status != SourceHealthUnhealthy || health.ReasonCode != "probe_failed" {
+		t.Fatalf("unexpected health: %+v", health)
+	}
+	if cli.chatCalls != 1 {
+		t.Fatalf("expected one chat check, got %d", cli.chatCalls)
+	}
+}
+
+func TestCheckSourceHealthClientCreationFailureIsUnhealthy(t *testing.T) {
+	t.Parallel()
+	src := &repository.Source{ID: primitive.NewObjectID(), Type: repository.SourceTypeS3}
+
+	health, err := CheckSourceHealth(context.Background(), src, func(context.Context, *repository.Source) (SourceClient, error) {
+		return nil, errors.New("bad config")
+	})
+	if err != nil {
+		t.Fatalf("check health: %v", err)
+	}
+	if health.Status != SourceHealthUnhealthy || health.ReasonCode != "client_error" {
+		t.Fatalf("unexpected health: %+v", health)
+	}
+}

--- a/api-go/internal/resilience/wrapper.go
+++ b/api-go/internal/resilience/wrapper.go
@@ -459,3 +459,99 @@ func (w *wrapper) ListObjects(ctx context.Context) ([]s3compat.ObjectInfo, int64
 	w.cb.RecordFailure()
 	return nil, 0, lastErr
 }
+
+func (w *wrapper) HeadBucket(ctx context.Context) error {
+	inner, ok := w.inner.(interface {
+		HeadBucket(context.Context) error
+	})
+	if !ok {
+		return ErrUnsupportedOperation
+	}
+	if err := w.cb.Allow(); err != nil {
+		return err
+	}
+
+	var lastErr error
+	for attempt := 0; attempt <= w.retryCfg.MaxRetries; attempt++ {
+		if attempt > 0 {
+			delay := Backoff(attempt-1, w.retryCfg)
+			slog.WarnContext(ctx, "retrying head bucket",
+				slog.Int("attempt", attempt),
+				slog.Duration("backoff", delay),
+				slog.String("last_error", lastErr.Error()),
+			)
+			select {
+			case <-time.After(delay):
+			case <-ctx.Done():
+				w.cb.RecordFailure()
+				return ctx.Err()
+			}
+			if err := w.cb.Allow(); err != nil {
+				return err
+			}
+		}
+
+		reqCtx, cancel := context.WithTimeout(ctx, w.cfg.Timeout)
+		err := inner.HeadBucket(reqCtx)
+		cancel()
+		if err == nil {
+			w.cb.RecordSuccess()
+			return nil
+		}
+		lastErr = err
+		if !isRetryable(err) {
+			break
+		}
+	}
+
+	w.cb.RecordFailure()
+	return lastErr
+}
+
+func (w *wrapper) CheckChat(ctx context.Context) error {
+	inner, ok := w.inner.(interface {
+		CheckChat(context.Context) error
+	})
+	if !ok {
+		return ErrUnsupportedOperation
+	}
+	if err := w.cb.Allow(); err != nil {
+		return err
+	}
+
+	var lastErr error
+	for attempt := 0; attempt <= w.retryCfg.MaxRetries; attempt++ {
+		if attempt > 0 {
+			delay := Backoff(attempt-1, w.retryCfg)
+			slog.WarnContext(ctx, "retrying telegram chat check",
+				slog.Int("attempt", attempt),
+				slog.Duration("backoff", delay),
+				slog.String("last_error", lastErr.Error()),
+			)
+			select {
+			case <-time.After(delay):
+			case <-ctx.Done():
+				w.cb.RecordFailure()
+				return ctx.Err()
+			}
+			if err := w.cb.Allow(); err != nil {
+				return err
+			}
+		}
+
+		reqCtx, cancel := context.WithTimeout(ctx, w.cfg.Timeout)
+		err := inner.CheckChat(reqCtx)
+		cancel()
+		if err == nil {
+			w.cb.RecordSuccess()
+			return nil
+		}
+		lastErr = err
+		if !isRetryable(err) {
+			break
+		}
+	}
+
+	w.cb.RecordFailure()
+	return lastErr
+}

--- a/api-go/internal/s3compat/client.go
+++ b/api-go/internal/s3compat/client.go
@@ -30,6 +30,7 @@ type Client struct {
 	cfg           Config
 	s3            *s3.Client
 	listObjectsV2 func(ctx context.Context, params *s3.ListObjectsV2Input, optFns ...func(*s3.Options)) (*s3.ListObjectsV2Output, error)
+	headBucket    func(ctx context.Context, params *s3.HeadBucketInput, optFns ...func(*s3.Options)) (*s3.HeadBucketOutput, error)
 }
 
 func EncodeConfig(cfg Config) (string, error) {
@@ -76,7 +77,7 @@ func NewClient(ctx context.Context, cfg Config) (*Client, error) {
 		opts.BaseEndpoint = aws.String(cfg.Endpoint)
 		opts.UsePathStyle = cfg.PathStyle
 	})
-	return &Client{cfg: cfg, s3: s3Client, listObjectsV2: s3Client.ListObjectsV2}, nil
+	return &Client{cfg: cfg, s3: s3Client, listObjectsV2: s3Client.ListObjectsV2, headBucket: s3Client.HeadBucket}, nil
 }
 
 func (c *Client) Upload(ctx context.Context, name string, r io.Reader) (string, error) {
@@ -127,4 +128,13 @@ func (c *Client) ListObjects(ctx context.Context) ([]ObjectInfo, int64, error) {
 		token = resp.NextContinuationToken
 	}
 	return objects, total, nil
+}
+
+func (c *Client) HeadBucket(ctx context.Context) error {
+	headFn := c.headBucket
+	if headFn == nil {
+		headFn = c.s3.HeadBucket
+	}
+	_, err := headFn(ctx, &s3.HeadBucketInput{Bucket: aws.String(c.cfg.Bucket)})
+	return err
 }

--- a/api-go/internal/s3compat/client_test.go
+++ b/api-go/internal/s3compat/client_test.go
@@ -75,3 +75,27 @@ func TestListObjectsFollowsPagination(t *testing.T) {
 		t.Fatalf("unexpected total: %d", total)
 	}
 }
+
+func TestHeadBucketUsesBucketMetadataProbe(t *testing.T) {
+	t.Parallel()
+	cli := &Client{cfg: Config{Bucket: "bucket"}}
+	calls := 0
+	cli.headBucket = func(_ context.Context, input *s3.HeadBucketInput, _ ...func(*s3.Options)) (*s3.HeadBucketOutput, error) {
+		calls++
+		if aws.ToString(input.Bucket) != "bucket" {
+			t.Fatalf("unexpected bucket: %s", aws.ToString(input.Bucket))
+		}
+		return &s3.HeadBucketOutput{}, nil
+	}
+	cli.listObjectsV2 = func(context.Context, *s3.ListObjectsV2Input, ...func(*s3.Options)) (*s3.ListObjectsV2Output, error) {
+		t.Fatal("health probe must not list objects")
+		return nil, nil
+	}
+
+	if err := cli.HeadBucket(context.Background()); err != nil {
+		t.Fatalf("head bucket: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("unexpected calls count: %d", calls)
+	}
+}

--- a/api-go/internal/telegram/client.go
+++ b/api-go/internal/telegram/client.go
@@ -214,3 +214,33 @@ func (c *Client) Delete(ctx context.Context, name string) error {
 	}
 	return nil
 }
+
+func (c *Client) CheckChat(ctx context.Context) error {
+	form := url.Values{}
+	form.Set("chat_id", c.chatID)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseAPIURL+"/getChat", strings.NewReader(form.Encode()))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		data, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("telegram getChat failed: status=%d body=%s", resp.StatusCode, string(data))
+	}
+	var parsed struct {
+		OK bool `json:"ok"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		return err
+	}
+	if !parsed.OK {
+		return fmt.Errorf("telegram getChat invalid response")
+	}
+	return nil
+}

--- a/api-go/internal/telegram/client_test.go
+++ b/api-go/internal/telegram/client_test.go
@@ -105,3 +105,29 @@ func TestConfigCodec(t *testing.T) {
 		t.Fatalf("unexpected parsed config: %+v", parsed)
 	}
 }
+
+func TestCheckChat(t *testing.T) {
+	t.Parallel()
+	const (
+		token  = "token123"
+		chatID = "-100123"
+	)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/bot"+token+"/getChat", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		if got := r.FormValue("chat_id"); got != chatID {
+			t.Fatalf("unexpected chat_id: %s", got)
+		}
+		_, _ = w.Write([]byte(`{"ok":true,"result":{"id":-100123}}`))
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	cli, err := NewClientWithBaseURL(Config{Token: token, ChatID: chatID}, ts.URL)
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	if err := cli.CheckChat(context.Background()); err != nil {
+		t.Fatalf("check chat: %v", err)
+	}
+}

--- a/webui/src/pages/sources/ui/sources-page.tsx
+++ b/webui/src/pages/sources/ui/sources-page.tsx
@@ -1,17 +1,40 @@
-import {Button, Card, CardBody, CardHeader, Spinner, useDisclosure} from "@heroui/react";
+import {Button, Card, CardBody, CardHeader, Chip, Spinner, Tooltip, useDisclosure} from "@heroui/react";
 import {addToast} from "@heroui/toast";
 import {useNavigate} from "react-router-dom";
 import {useEffect, useState} from "react";
 import {CreateSourceDialog} from "../../../features/source";
-import {deleteSource, listSources} from "../../../shared/api/sources";
-import type {Source} from "../../../shared/api/sources";
+import {deleteSource, getSourceHealth, listSources} from "../../../shared/api/sources";
+import type {Source, SourceHealth, SourceHealthStatus} from "../../../shared/api/sources";
 import {SourceTypeChip} from "../../../entities/source";
 import {DeleteIcon} from "@heroui/shared-icons";
 import {ConfirmDialog, EmptyState} from "../../../shared/ui";
 import {showErrorToast} from "../../../shared/api/error";
 
+type HealthState =
+  | {state: "checking"}
+  | {state: "ready"; health: SourceHealth}
+  | {state: "error"; message: string};
+
+const healthColor: Record<SourceHealthStatus, "success" | "warning" | "danger"> = {
+  healthy: "success",
+  degraded: "warning",
+  unhealthy: "danger",
+};
+
+function RefreshIcon(props: {className?: string}) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" {...props}>
+      <path d="M20 6v5h-5" />
+      <path d="M4 18v-5h5" />
+      <path d="M18.5 9A7 7 0 0 0 6.2 6.2L4 8.3" />
+      <path d="M5.5 15a7 7 0 0 0 12.3 2.8L20 15.7" />
+    </svg>
+  );
+}
+
 export function SourcesPage() {
   const [sources, setSources] = useState<Source[]>([]);
+  const [healthBySource, setHealthBySource] = useState<Record<string, HealthState>>({});
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const navigate = useNavigate();
@@ -35,11 +58,43 @@ export function SourcesPage() {
     }
   }
 
+  async function refreshHealth(sourceId: string) {
+    setHealthBySource((current) => ({
+      ...current,
+      [sourceId]: {state: "checking"},
+    }));
+    try {
+      const health = await getSourceHealth(sourceId);
+      setHealthBySource((current) => ({
+        ...current,
+        [sourceId]: {state: "ready", health},
+      }));
+    } catch (err) {
+      setHealthBySource((current) => ({
+        ...current,
+        [sourceId]: {
+          state: "error",
+          message: err instanceof Error ? err.message : "Health check failed",
+        },
+      }));
+    }
+  }
+
+  function refreshAllHealth(nextSources: Source[]) {
+    const checking = Object.fromEntries(nextSources.map((s) => [s.id, {state: "checking"} as HealthState]));
+    setHealthBySource(checking);
+    nextSources.forEach((source) => {
+      void refreshHealth(source.id);
+    });
+  }
+
   async function load() {
     setIsLoading(true);
     setError(null);
     try {
-      setSources(await listSources());
+      const nextSources = await listSources();
+      setSources(nextSources);
+      refreshAllHealth(nextSources);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to load sources");
     } finally {
@@ -50,6 +105,27 @@ export function SourcesPage() {
   useEffect(() => {
     load();
   }, []);
+
+  function renderHealth(source: Source) {
+    const health = healthBySource[source.id];
+    if (!health || health.state === "checking") {
+      return <Chip size="sm" variant="flat" color="default">Checking</Chip>;
+    }
+    if (health.state === "error") {
+      return (
+        <Tooltip content={health.message}>
+          <Chip size="sm" variant="flat" color="danger">Check failed</Chip>
+        </Tooltip>
+      );
+    }
+    return (
+      <Tooltip content={health.health.message}>
+        <Chip size="sm" variant="flat" color={healthColor[health.health.status]}>
+          {health.health.status}
+        </Chip>
+      </Tooltip>
+    );
+  }
 
   return (
     <div className="p-8 flex flex-col gap-6">
@@ -88,22 +164,44 @@ export function SourcesPage() {
             >
               <CardHeader className="flex justify-between items-center font-bold">
                 {s.name}
-                <Button
-                  isIconOnly
-                  variant="light"
-                  color="danger"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    setDeleteId(s.id);
-                    confirm.onOpen();
-                  }}
-                >
-                  <DeleteIcon className="w-4 h-4" />
-                </Button>
+                <div className="flex items-center gap-1">
+                  <Tooltip content="Refresh health">
+                    <Button
+                      isIconOnly
+                      variant="light"
+                      aria-label="Refresh health"
+                      isLoading={healthBySource[s.id]?.state === "checking"}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        void refreshHealth(s.id);
+                      }}
+                    >
+                      <RefreshIcon className="w-4 h-4" />
+                    </Button>
+                  </Tooltip>
+                  <Button
+                    isIconOnly
+                    variant="light"
+                    color="danger"
+                    aria-label="Delete source"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setDeleteId(s.id);
+                      confirm.onOpen();
+                    }}
+                  >
+                    <DeleteIcon className="w-4 h-4" />
+                  </Button>
+                </div>
               </CardHeader>
-              <CardBody className="flex justify-between items-center">
-                <SourceTypeChip type={s.type} />
-                {new Date(s.created_at).toLocaleString()}
+              <CardBody className="flex flex-col gap-3">
+                <div className="flex justify-between items-center">
+                  <SourceTypeChip type={s.type} />
+                  {renderHealth(s)}
+                </div>
+                <div className="text-small text-default-500">
+                  {new Date(s.created_at).toLocaleString()}
+                </div>
               </CardBody>
             </Card>
           ))}

--- a/webui/src/shared/api/sources.ts
+++ b/webui/src/shared/api/sources.ts
@@ -4,6 +4,21 @@ export type Source = {id: string; name: string; type: string; created_at: string
 
 export type SourceFile = {id: string; name: string; size: number};
 
+export type SourceHealthStatus = "healthy" | "degraded" | "unhealthy";
+
+export type SourceHealth = {
+  id: string;
+  type: string;
+  status: SourceHealthStatus;
+  checked_at: string;
+  latency_ms: number;
+  reason_code: string;
+  message: string;
+  quota_total_bytes: number | null;
+  quota_used_bytes: number | null;
+  quota_free_bytes: number | null;
+};
+
 export type SourceInfo = {
   id: string;
   name: string;
@@ -62,6 +77,13 @@ export async function getSourceInfo(id: string): Promise<SourceInfo> {
   return apiJson<SourceInfo>(
     `/sources/${id}/info`,
     "Failed to get source info",
+  );
+}
+
+export async function getSourceHealth(id: string): Promise<SourceHealth> {
+  return apiJson<SourceHealth>(
+    `/sources/${id}/health`,
+    "Failed to check source health",
   );
 }
 


### PR DESCRIPTION
## Summary
- add authenticated `GET /api/v1/sources/:id/health` with source ownership checks and on-demand provider probes
- use lightweight checks only: Google Drive about/quota metadata, S3 `HeadBucket`, Telegram `getChat`
- add source list health indicators with manual refresh/retry and null quota fields for S3/Telegram
- document the endpoint in the maintained OpenAPI spec

## Validation
- `gofmt` on touched Go files
- `git diff --check`
- parsed `api-go/internal/docs/openapi.go` embedded OpenAPI JSON
- local test suites were not run due the limited-machine policy; Woodpecker should run the heavier validation

Refs #163
