### PR TITLE
THE-504: Route REST file lifecycle through object service

### DIFF
--- a/api-go/internal/handlers/bucket.go
+++ b/api-go/internal/handlers/bucket.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -403,6 +404,7 @@ type uploadFileResponse struct {
 // @Security BasicAuth
 // @Router /api/v1/buckets/{id}/upload [post]
 func UploadFile(bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository, grantRepo *repository.BucketGrantRepository, chunkSize int) gin.HandlerFunc {
+	objectSvc := manager.NewObjectService(sourceRepo, fileRepo, nil)
 	return func(c *gin.Context) {
 		ctx := c.Request.Context()
 		if bucketRepo == nil || sourceRepo == nil || fileRepo == nil {
@@ -416,16 +418,6 @@ func UploadFile(bucketRepo *repository.BucketRepository, sourceRepo *repository.
 			return
 		}
 		bucketDoc := acc.Bucket
-		sources, err := sourceRepo.ListByIDs(c.Request.Context(), bucketDoc.SourceIDs)
-		if err != nil {
-			slog.ErrorContext(ctx, "upload file: list sources", slog.String("error", err.Error()))
-			c.Status(http.StatusInternalServerError)
-			return
-		}
-		if len(sources) == 0 {
-			c.Status(http.StatusBadRequest)
-			return
-		}
 		fh, err := c.FormFile("file")
 		if err != nil {
 			slog.WarnContext(ctx, "upload file: get file", slog.String("error", err.Error()))
@@ -440,36 +432,23 @@ func UploadFile(bucketRepo *repository.BucketRepository, sourceRepo *repository.
 		}
 		defer func() { _ = f.Close() }()
 
-		selector := manager.SelectorForBucket(bucketDoc, sources)
-		chunks, err := manager.UploadFileChunksWithStrategy(ctx, f, sources, chunkSize, nil, selector)
+		result, err := objectSvc.PutObject(ctx, bucketDoc, fh.Filename, f, chunkSize)
 		if err != nil {
-			slog.ErrorContext(ctx, "upload file: upload chunks", slog.String("error", err.Error()))
-			c.Status(http.StatusInternalServerError)
-			return
-		}
-
-		fileDoc := repository.File{
-			BucketID:  bucketDoc.ID,
-			Name:      fh.Filename,
-			CreatedAt: time.Now().UTC(),
-			Chunks:    chunks,
-		}
-		created, previousFile, err := fileRepo.ReplaceByName(ctx, fileDoc)
-		if err != nil {
-			_ = manager.DeleteFileChunks(ctx, sourceRepo, chunks)
-			slog.ErrorContext(ctx, "upload file: save file", slog.String("error", err.Error()))
-			c.Status(http.StatusInternalServerError)
-			return
-		}
-		if previousFile != nil {
-			if err := manager.DeleteFileChunksIfUnreferenced(ctx, sourceRepo, fileRepo, previousFile.Chunks); err != nil {
-				slog.WarnContext(ctx, "upload file: delete old chunks", slog.String("error", err.Error()))
+			if errors.Is(err, manager.ErrNoSources) {
+				c.Status(http.StatusBadRequest)
+				return
 			}
+			slog.ErrorContext(ctx, "upload file: mutate file", slog.String("error", err.Error()))
+			c.Status(http.StatusInternalServerError)
+			return
+		}
+		if result.CleanupErr != nil {
+			slog.WarnContext(ctx, "upload file: delete old chunks", slog.String("error", result.CleanupErr.Error()))
 		}
 		c.JSON(http.StatusOK, uploadFileResponse{
-			ID:        created.ID.Hex(),
-			Name:      created.Name,
-			CreatedAt: created.CreatedAt,
+			ID:        result.File.ID.Hex(),
+			Name:      result.File.Name,
+			CreatedAt: result.File.CreatedAt,
 		})
 	}
 }
@@ -597,6 +576,7 @@ func DownloadFile(bucketRepo *repository.BucketRepository, sourceRepo *repositor
 // @Security BasicAuth
 // @Router /api/v1/buckets/{id}/files/{file_id} [delete]
 func DeleteFile(bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository, grantRepo *repository.BucketGrantRepository) gin.HandlerFunc {
+	objectSvc := manager.NewObjectService(sourceRepo, fileRepo, nil)
 	return func(c *gin.Context) {
 		ctx := c.Request.Context()
 		if bucketRepo == nil || sourceRepo == nil || fileRepo == nil {
@@ -615,27 +595,18 @@ func DeleteFile(bucketRepo *repository.BucketRepository, sourceRepo *repository.
 		if !ok {
 			return
 		}
-		fileDoc, err := fileRepo.GetByID(c.Request.Context(), fileID)
+		result, err := objectSvc.DeleteFile(ctx, bucketID, fileID)
 		if err != nil {
-			if err == mongo.ErrNoDocuments {
+			if errors.Is(err, manager.ErrObjectNotFound) {
 				c.Status(http.StatusNotFound)
 				return
 			}
-			slog.ErrorContext(ctx, "delete file: get file", slog.String("error", err.Error()))
+			slog.ErrorContext(ctx, "delete file: mutate file", slog.String("error", err.Error()))
 			c.Status(http.StatusInternalServerError)
 			return
 		}
-		if fileDoc.BucketID != bucketID {
-			c.Status(http.StatusNotFound)
-			return
-		}
-		if err := fileRepo.Delete(ctx, fileID); err != nil {
-			slog.ErrorContext(ctx, "delete file: delete metadata", slog.String("error", err.Error()))
-			c.Status(http.StatusInternalServerError)
-			return
-		}
-		if err := manager.DeleteFileChunksIfUnreferenced(ctx, sourceRepo, fileRepo, fileDoc.Chunks); err != nil {
-			slog.ErrorContext(ctx, "delete file: delete chunk", slog.String("error", err.Error()))
+		if result.CleanupErr != nil {
+			slog.ErrorContext(ctx, "delete file: delete chunk", slog.String("error", result.CleanupErr.Error()))
 			c.Status(http.StatusInternalServerError)
 			return
 		}

--- a/api-go/internal/manager/s3_object.go
+++ b/api-go/internal/manager/s3_object.go
@@ -87,6 +87,7 @@ type BucketScopedChunkReferenceCounter interface {
 
 type objectFileStore interface {
 	BucketScopedChunkReferenceCounter
+	GetByID(ctx context.Context, id primitive.ObjectID) (*repository.File, error)
 	GetByName(ctx context.Context, bucketID primitive.ObjectID, name string) (*repository.File, error)
 	ListByBucket(ctx context.Context, bucketID primitive.ObjectID) ([]repository.File, error)
 	ReplaceByName(ctx context.Context, f repository.File) (*repository.File, *repository.File, error)
@@ -199,6 +200,29 @@ func (s *ObjectService) DeleteObject(ctx context.Context, bucketID primitive.Obj
 	if err := s.files.Delete(ctx, fileDoc.ID); err != nil {
 		if err == mongo.ErrNoDocuments {
 			return DeleteObjectResult{}, nil
+		}
+		return DeleteObjectResult{}, err
+	}
+	return DeleteObjectResult{
+		Deleted:    true,
+		CleanupErr: s.deleteFileChunksIfUnreferenced(ctx, fileDoc.Chunks),
+	}, nil
+}
+
+func (s *ObjectService) DeleteFile(ctx context.Context, bucketID, fileID primitive.ObjectID) (DeleteObjectResult, error) {
+	fileDoc, err := s.files.GetByID(ctx, fileID)
+	if err != nil {
+		if err == mongo.ErrNoDocuments {
+			return DeleteObjectResult{}, ErrObjectNotFound
+		}
+		return DeleteObjectResult{}, err
+	}
+	if fileDoc.BucketID != bucketID {
+		return DeleteObjectResult{}, ErrObjectNotFound
+	}
+	if err := s.files.Delete(ctx, fileDoc.ID); err != nil {
+		if err == mongo.ErrNoDocuments {
+			return DeleteObjectResult{}, ErrObjectNotFound
 		}
 		return DeleteObjectResult{}, err
 	}

--- a/api-go/internal/manager/s3_object_test.go
+++ b/api-go/internal/manager/s3_object_test.go
@@ -71,6 +71,15 @@ func (f *fakeObjectFiles) GetByName(_ context.Context, bucketID primitive.Object
 	return &file, nil
 }
 
+func (f *fakeObjectFiles) GetByID(_ context.Context, id primitive.ObjectID) (*repository.File, error) {
+	for _, file := range f.byName {
+		if file.ID == id {
+			return &file, nil
+		}
+	}
+	return nil, mongo.ErrNoDocuments
+}
+
 func (f *fakeObjectFiles) Delete(_ context.Context, id primitive.ObjectID) error {
 	if f.deleteErr != nil {
 		return f.deleteErr
@@ -384,6 +393,47 @@ func TestObjectServiceDeleteObjectRemovesMetadataAndUnreferencedChunks(t *testin
 	}
 	if _, err := files.GetByName(context.Background(), bucketID, "object.txt"); !errors.Is(err, mongo.ErrNoDocuments) {
 		t.Fatalf("expected metadata delete, got %v", err)
+	}
+}
+
+func TestObjectServiceDeleteFileRemovesMetadataAndUnreferencedChunks(t *testing.T) {
+	bucketID := primitive.NewObjectID()
+	fileID := primitive.NewObjectID()
+	chunk := repository.FileChunk{SourceID: primitive.NewObjectID(), Name: "delete-me", Size: 3}
+	files := newFakeObjectFiles(repository.File{ID: fileID, BucketID: bucketID, Name: "object.txt", Chunks: []repository.FileChunk{chunk}})
+	var deleted []repository.FileChunk
+	svc := testObjectService(files, &deleted)
+
+	result, err := svc.DeleteFile(context.Background(), bucketID, fileID)
+	if err != nil {
+		t.Fatalf("DeleteFile returned error: %v", err)
+	}
+	if !result.Deleted {
+		t.Fatalf("expected DeleteFile to report deletion")
+	}
+	if len(deleted) != 1 || deleted[0].Name != chunk.Name {
+		t.Fatalf("expected deleted chunk cleanup, got %#v", deleted)
+	}
+	if _, err := files.GetByID(context.Background(), fileID); !errors.Is(err, mongo.ErrNoDocuments) {
+		t.Fatalf("expected metadata delete, got %v", err)
+	}
+}
+
+func TestObjectServiceDeleteFileRejectsWrongBucket(t *testing.T) {
+	fileID := primitive.NewObjectID()
+	files := newFakeObjectFiles(repository.File{ID: fileID, BucketID: primitive.NewObjectID(), Name: "object.txt"})
+	var deleted []repository.FileChunk
+	svc := testObjectService(files, &deleted)
+
+	_, err := svc.DeleteFile(context.Background(), primitive.NewObjectID(), fileID)
+	if !errors.Is(err, ErrObjectNotFound) {
+		t.Fatalf("expected object not found, got %v", err)
+	}
+	if len(deleted) != 0 {
+		t.Fatalf("expected no chunk cleanup, got %#v", deleted)
+	}
+	if _, err := files.GetByID(context.Background(), fileID); err != nil {
+		t.Fatalf("expected metadata to remain, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Route REST bucket uploads through `manager.ObjectService.PutObject`
- Add `ObjectService.DeleteFile` for REST file-id deletion lifecycle handling
- Add focused manager coverage for file-id deletion and wrong-bucket rejection

## Validation

- `gofmt -w api-go/internal/manager/s3_object.go api-go/internal/manager/s3_object_test.go api-go/internal/handlers/bucket.go`
- `git diff --check`

Local Go tests were not run because this agent is constrained from CPU-bound validation; Woodpecker should run backend validation in CI.