### PR TITLE
THE-561 Assert CopyObject REPLACE XML error

### DIFF
--- a/api-go/internal/e2e/s3_compat_object_test.go
+++ b/api-go/internal/e2e/s3_compat_object_test.go
@@ -203,6 +203,7 @@ func TestS3CompatCopyObject(t *testing.T) {
 	if status != http.StatusNotImplemented {
 		t.Fatalf("CopyObject REPLACE: expected 501, got %d: %s", status, body)
 	}
+	assertS3Error(t, body, "NotImplemented")
 
 	status, body = s3Do(t, http.MethodDelete, s3URL(sourceBucket, sourceKey), sourceBucket.AccessKey, sourceBucket.AccessSecret, env.Region, nil)
 	if status != http.StatusNoContent {


### PR DESCRIPTION
## Summary

- Tightens the CopyObject `x-amz-metadata-directive: REPLACE` E2E assertion to decode the S3 XML error body.
- Verifies the response code remains `NotImplemented`, matching the focused QA slice from [THE-561](/THE/issues/THE-561).

## Context

This follows the S3/API testing-plan slice from [THE-396](/THE/issues/THE-396) and the coverage gap noted in GitHub PR #229.

## Validation

- `git diff --check`

Runtime validation is intentionally left to Woodpecker per task instructions; no local E2E/full Go suite was run.