### PR TITLE
THE-583 Keep download contexts alive through body close

### DIFF
--- a/api-go/internal/resilience/wrapper.go
+++ b/api-go/internal/resilience/wrapper.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"io"
 	"log/slog"
-	"sync/atomic"
 	"time"
 
 	"github.com/example/sfree/api-go/internal/gdrive"
@@ -307,16 +306,15 @@ func (r *cancelOnCloseReadCloser) Close() error {
 
 func downloadAttemptContext(parent context.Context, timeout time.Duration) (context.Context, context.CancelFunc, func() error) {
 	ctx, cancel := context.WithCancel(parent)
-	var timedOut atomic.Bool
 	timer := time.AfterFunc(timeout, func() {
-		timedOut.Store(true)
 		cancel()
 	})
 	timeoutErr := func() error {
-		if !timer.Stop() && timedOut.Load() {
-			return context.DeadlineExceeded
+		if timer.Stop() {
+			return nil
 		}
-		return nil
+		cancel()
+		return context.DeadlineExceeded
 	}
 	return ctx, cancel, timeoutErr
 }

--- a/api-go/internal/resilience/wrapper.go
+++ b/api-go/internal/resilience/wrapper.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"sync/atomic"
 	"time"
 
 	"github.com/example/sfree/api-go/internal/gdrive"
@@ -223,13 +224,56 @@ func (w *wrapper) Upload(ctx context.Context, name string, r io.Reader) (string,
 }
 
 func (w *wrapper) Download(ctx context.Context, name string) (io.ReadCloser, error) {
-	var rc io.ReadCloser
-	err := w.withRetry(ctx, "retrying download", []any{slog.String("name", name)}, timeoutRetryContext(w.cfg.Timeout), true, nil, func(reqCtx context.Context, cancel context.CancelFunc) error {
-		var err error
-		rc, err = w.inner.Download(reqCtx, name)
-		return err
-	})
-	return rc, err
+	if err := w.cb.Allow(); err != nil {
+		return nil, err
+	}
+
+	var lastErr error
+	for attempt := 0; attempt <= w.retryCfg.MaxRetries; attempt++ {
+		if attempt > 0 {
+			delay := Backoff(attempt-1, w.retryCfg)
+			slog.WarnContext(ctx, "retrying download",
+				slog.String("name", name),
+				slog.Int("attempt", attempt),
+				slog.Duration("backoff", delay),
+				slog.String("last_error", lastErr.Error()),
+			)
+			select {
+			case <-time.After(delay):
+			case <-ctx.Done():
+				w.cb.RecordFailure()
+				return nil, ctx.Err()
+			}
+			if err := w.cb.Allow(); err != nil {
+				return nil, err
+			}
+		}
+
+		reqCtx, cancel, timeoutErr := downloadAttemptContext(ctx, w.cfg.Timeout)
+		rc, err := w.inner.Download(reqCtx, name)
+
+		if err == nil {
+			if err := timeoutErr(); err != nil {
+				cancel()
+				_ = rc.Close()
+				lastErr = err
+				break
+			}
+			w.cb.RecordSuccess()
+			return &cancelOnCloseReadCloser{ReadCloser: rc, cancel: cancel}, nil
+		}
+		cancel()
+		if timeoutErr() != nil && errors.Is(err, context.Canceled) {
+			err = context.DeadlineExceeded
+		}
+		lastErr = err
+		if !isRetryable(err) {
+			break
+		}
+	}
+
+	w.cb.RecordFailure()
+	return nil, lastErr
 }
 
 func (w *wrapper) DownloadStream(ctx context.Context, name string) (io.ReadCloser, error) {
@@ -259,6 +303,22 @@ func (r *cancelOnCloseReadCloser) Close() error {
 	err := r.ReadCloser.Close()
 	r.cancel()
 	return err
+}
+
+func downloadAttemptContext(parent context.Context, timeout time.Duration) (context.Context, context.CancelFunc, func() error) {
+	ctx, cancel := context.WithCancel(parent)
+	var timedOut atomic.Bool
+	timer := time.AfterFunc(timeout, func() {
+		timedOut.Store(true)
+		cancel()
+	})
+	timeoutErr := func() error {
+		if !timer.Stop() && timedOut.Load() {
+			return context.DeadlineExceeded
+		}
+		return nil
+	}
+	return ctx, cancel, timeoutErr
 }
 
 func (w *wrapper) ListFiles(ctx context.Context) ([]gdrive.File, error) {

--- a/api-go/internal/resilience/wrapper_test.go
+++ b/api-go/internal/resilience/wrapper_test.go
@@ -350,6 +350,109 @@ func TestWrapperRetryDownloadSucceeds(t *testing.T) {
 	}
 }
 
+type contextBoundDownloadClient struct {
+	ctx context.Context
+}
+
+func (c *contextBoundDownloadClient) Upload(ctx context.Context, name string, r io.Reader) (string, error) {
+	return "", errors.New("not implemented")
+}
+
+func (c *contextBoundDownloadClient) Download(ctx context.Context, name string) (io.ReadCloser, error) {
+	c.ctx = ctx
+	return &contextBoundBody{ctx: ctx, r: strings.NewReader("data")}, nil
+}
+
+func (c *contextBoundDownloadClient) Delete(ctx context.Context, name string) error {
+	return errors.New("not implemented")
+}
+
+type contextBoundBody struct {
+	ctx context.Context
+	r   io.Reader
+}
+
+func (b *contextBoundBody) Read(p []byte) (int, error) {
+	select {
+	case <-b.ctx.Done():
+		return 0, b.ctx.Err()
+	default:
+		return b.r.Read(p)
+	}
+}
+
+func (b *contextBoundBody) Close() error {
+	return nil
+}
+
+func TestWrapperDownloadKeepsContextAliveUntilBodyClose(t *testing.T) {
+	inner := &contextBoundDownloadClient{}
+	cfg := WrapperConfig{
+		Timeout:          time.Second,
+		FailureThreshold: 10,
+		RecoveryTimeout:  time.Second,
+		MaxRetries:       0,
+	}
+	w := Wrap(inner, cfg)
+
+	rc, err := w.Download(context.Background(), "file.txt")
+	if err != nil {
+		t.Fatalf("download: %v", err)
+	}
+	select {
+	case <-inner.ctx.Done():
+		t.Fatal("download context canceled before body close")
+	default:
+	}
+
+	got, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if string(got) != "data" {
+		t.Fatalf("expected data, got %q", string(got))
+	}
+	if err := rc.Close(); err != nil {
+		t.Fatalf("close body: %v", err)
+	}
+	select {
+	case <-inner.ctx.Done():
+	default:
+		t.Fatal("download context was not canceled on body close")
+	}
+}
+
+type blockingDownloadClient struct{}
+
+func (c *blockingDownloadClient) Upload(ctx context.Context, name string, r io.Reader) (string, error) {
+	return "", errors.New("not implemented")
+}
+
+func (c *blockingDownloadClient) Download(ctx context.Context, name string) (io.ReadCloser, error) {
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+func (c *blockingDownloadClient) Delete(ctx context.Context, name string) error {
+	return errors.New("not implemented")
+}
+
+func TestWrapperDownloadTimeoutBeforeBodyReturned(t *testing.T) {
+	inner := &blockingDownloadClient{}
+	cfg := WrapperConfig{
+		Timeout:          10 * time.Millisecond,
+		FailureThreshold: 10,
+		RecoveryTimeout:  time.Second,
+		MaxRetries:       0,
+	}
+	w := Wrap(inner, cfg)
+
+	_, err := w.Download(context.Background(), "slow.txt")
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected DeadlineExceeded, got %v", err)
+	}
+}
+
 type streamContextClient struct {
 	ctxCh chan context.Context
 }


### PR DESCRIPTION
## Summary
- keep resilience-wrapped `Download` contexts alive until the returned body is closed
- preserve initial download timeout behavior before a body is returned
- add focused unit coverage for context lifetime and pre-body timeout behavior
- address review feedback by making expired download timers return `context.DeadlineExceeded` even if the timer callback has not run yet
- rebase onto current `main` after THE-637 landed and preserve existing `DownloadStream` cancel-on-close coverage from main

## Validation
- Earlier branch validation before the latest review fix: `gofmt -w api-go/internal/resilience/wrapper.go api-go/internal/resilience/wrapper_test.go`
- Earlier branch validation before the latest review fix: `git diff --check`
- Local Go tests, formatting, and diff checks were not run after the latest review fix/rebase per task/resource policy; Woodpecker should validate the branch.
- Woodpecker pipeline 519 is pending for commit `cc1c82e` (`ci/woodpecker/pr/api-go`, `ci/woodpecker/pr/smoke`).

Closes THE-583