### PR TITLE
THE-592: Route REST bucket uploads through ObjectService

### DIFF
--- a/api-go/internal/handlers/bucket.go
+++ b/api-go/internal/handlers/bucket.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -403,6 +404,7 @@ type uploadFileResponse struct {
 // @Security BasicAuth
 // @Router /api/v1/buckets/{id}/upload [post]
 func UploadFile(bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository, grantRepo *repository.BucketGrantRepository, chunkSize int) gin.HandlerFunc {
+	objectSvc := manager.NewObjectService(sourceRepo, fileRepo, nil)
 	return func(c *gin.Context) {
 		ctx := c.Request.Context()
 		if bucketRepo == nil || sourceRepo == nil || fileRepo == nil {
@@ -416,16 +418,6 @@ func UploadFile(bucketRepo *repository.BucketRepository, sourceRepo *repository.
 			return
 		}
 		bucketDoc := acc.Bucket
-		sources, err := sourceRepo.ListByIDs(c.Request.Context(), bucketDoc.SourceIDs)
-		if err != nil {
-			slog.ErrorContext(ctx, "upload file: list sources", slog.String("error", err.Error()))
-			c.Status(http.StatusInternalServerError)
-			return
-		}
-		if len(sources) == 0 {
-			c.Status(http.StatusBadRequest)
-			return
-		}
 		fh, err := c.FormFile("file")
 		if err != nil {
 			slog.WarnContext(ctx, "upload file: get file", slog.String("error", err.Error()))
@@ -440,36 +432,23 @@ func UploadFile(bucketRepo *repository.BucketRepository, sourceRepo *repository.
 		}
 		defer func() { _ = f.Close() }()
 
-		selector := manager.SelectorForBucket(bucketDoc, sources)
-		chunks, err := manager.UploadFileChunksWithStrategy(ctx, f, sources, chunkSize, nil, selector)
+		result, err := objectSvc.PutObject(ctx, bucketDoc, fh.Filename, f, chunkSize)
 		if err != nil {
-			slog.ErrorContext(ctx, "upload file: upload chunks", slog.String("error", err.Error()))
-			c.Status(http.StatusInternalServerError)
-			return
-		}
-
-		fileDoc := repository.File{
-			BucketID:  bucketDoc.ID,
-			Name:      fh.Filename,
-			CreatedAt: time.Now().UTC(),
-			Chunks:    chunks,
-		}
-		created, previousFile, err := fileRepo.ReplaceByName(ctx, fileDoc)
-		if err != nil {
-			_ = manager.DeleteFileChunks(ctx, sourceRepo, chunks)
-			slog.ErrorContext(ctx, "upload file: save file", slog.String("error", err.Error()))
-			c.Status(http.StatusInternalServerError)
-			return
-		}
-		if previousFile != nil {
-			if err := manager.DeleteFileChunksIfUnreferenced(ctx, sourceRepo, fileRepo, previousFile.Chunks); err != nil {
-				slog.WarnContext(ctx, "upload file: delete old chunks", slog.String("error", err.Error()))
+			if errors.Is(err, manager.ErrNoSources) {
+				c.Status(http.StatusBadRequest)
+				return
 			}
+			slog.ErrorContext(ctx, "upload file: mutate object", slog.String("error", err.Error()))
+			c.Status(http.StatusInternalServerError)
+			return
+		}
+		if result.CleanupErr != nil {
+			slog.WarnContext(ctx, "upload file: delete old chunks", slog.String("error", result.CleanupErr.Error()))
 		}
 		c.JSON(http.StatusOK, uploadFileResponse{
-			ID:        created.ID.Hex(),
-			Name:      created.Name,
-			CreatedAt: created.CreatedAt,
+			ID:        result.File.ID.Hex(),
+			Name:      result.File.Name,
+			CreatedAt: result.File.CreatedAt,
 		})
 	}
 }

--- a/api-go/internal/handlers/bucket.go
+++ b/api-go/internal/handlers/bucket.go
@@ -418,6 +418,15 @@ func UploadFile(bucketRepo *repository.BucketRepository, sourceRepo *repository.
 			return
 		}
 		bucketDoc := acc.Bucket
+		if err := objectSvc.ValidateObjectSources(ctx, bucketDoc); err != nil {
+			if errors.Is(err, manager.ErrNoSources) {
+				c.Status(http.StatusBadRequest)
+				return
+			}
+			slog.ErrorContext(ctx, "upload file: validate object sources", slog.String("error", err.Error()))
+			c.Status(http.StatusInternalServerError)
+			return
+		}
 		fh, err := c.FormFile("file")
 		if err != nil {
 			slog.WarnContext(ctx, "upload file: get file", slog.String("error", err.Error()))

--- a/api-go/internal/manager/s3_object.go
+++ b/api-go/internal/manager/s3_object.go
@@ -135,6 +135,17 @@ func NewObjectService(sourceRepo *repository.SourceRepository, fileRepo *reposit
 	return svc
 }
 
+func (s *ObjectService) ValidateObjectSources(ctx context.Context, bucket *repository.Bucket) error {
+	sources, err := s.sources.ListByIDs(ctx, bucket.SourceIDs)
+	if err != nil {
+		return err
+	}
+	if len(sources) == 0 {
+		return ErrNoSources
+	}
+	return nil
+}
+
 func (s *ObjectService) PutObject(ctx context.Context, bucket *repository.Bucket, name string, body io.Reader, chunkSize int) (PutObjectResult, error) {
 	sources, err := s.sources.ListByIDs(ctx, bucket.SourceIDs)
 	if err != nil {

--- a/api-go/internal/manager/s3_object_test.go
+++ b/api-go/internal/manager/s3_object_test.go
@@ -253,6 +253,7 @@ func testObjectService(files *fakeObjectFiles, deleted *[]repository.FileChunk) 
 }
 
 func TestObjectServicePutObjectUpdatesFileAndDeletesOldChunks(t *testing.T) {
+	now := time.Date(2026, 4, 21, 12, 0, 0, 0, time.UTC)
 	bucketID := primitive.NewObjectID()
 	oldSourceID := primitive.NewObjectID()
 	existing := repository.File{
@@ -273,11 +274,90 @@ func TestObjectServicePutObjectUpdatesFileAndDeletesOldChunks(t *testing.T) {
 	if result.File.ID != existing.ID {
 		t.Fatalf("expected update to preserve file id")
 	}
+	if result.File.Name != "object.txt" || !result.File.CreatedAt.Equal(now) {
+		t.Fatalf("expected saved file metadata to match upload, got %#v", result.File)
+	}
 	if len(result.File.Chunks) != 1 || result.File.Chunks[0].Name != "new-chunk" {
 		t.Fatalf("expected saved file to use uploaded chunk, got %#v", result.File.Chunks)
 	}
 	if len(deleted) != 1 || deleted[0].Name != "old-chunk" {
 		t.Fatalf("expected old chunk cleanup, got %#v", deleted)
+	}
+}
+
+func TestObjectServicePutObjectReturnsNoSourcesBeforeUpload(t *testing.T) {
+	files := newFakeObjectFiles()
+	uploadCalled := false
+	svc := &ObjectService{
+		sources: &fakeObjectSources{},
+		files:   files,
+		uploadChunks: func(context.Context, io.Reader, []repository.Source, int, SourceSelector) ([]repository.FileChunk, error) {
+			uploadCalled = true
+			return nil, nil
+		},
+		deleteChunks: func(context.Context, []repository.FileChunk) error {
+			t.Fatal("deleteChunks should not be called")
+			return nil
+		},
+		now: func() time.Time {
+			return time.Now().UTC()
+		},
+	}
+
+	_, err := svc.PutObject(context.Background(), &repository.Bucket{ID: primitive.NewObjectID()}, "object.txt", bytes.NewBufferString("data"), 5)
+	if !errors.Is(err, ErrNoSources) {
+		t.Fatalf("expected ErrNoSources, got %v", err)
+	}
+	if uploadCalled {
+		t.Fatal("expected no upload attempt without sources")
+	}
+	if len(files.byName) != 0 {
+		t.Fatalf("expected no file metadata to be saved, got %#v", files.byName)
+	}
+}
+
+func TestObjectServicePutObjectUsesBucketDistributionStrategy(t *testing.T) {
+	sourceA := repository.Source{ID: primitive.NewObjectID()}
+	sourceB := repository.Source{ID: primitive.NewObjectID()}
+	files := newFakeObjectFiles()
+	var capturedSelector SourceSelector
+	var capturedSources []repository.Source
+	svc := &ObjectService{
+		sources: &fakeObjectSources{sources: []repository.Source{sourceA, sourceB}},
+		files:   files,
+		uploadChunks: func(_ context.Context, r io.Reader, sources []repository.Source, _ int, selector SourceSelector) ([]repository.FileChunk, error) {
+			if _, err := io.Copy(io.Discard, r); err != nil {
+				return nil, err
+			}
+			capturedSelector = selector
+			capturedSources = append([]repository.Source(nil), sources...)
+			return []repository.FileChunk{{SourceID: sourceA.ID, Name: "new-chunk", Size: 4}}, nil
+		},
+		deleteChunks: func(context.Context, []repository.FileChunk) error {
+			return nil
+		},
+		now: func() time.Time {
+			return time.Now().UTC()
+		},
+	}
+	bucket := &repository.Bucket{
+		ID:                   primitive.NewObjectID(),
+		SourceIDs:            []primitive.ObjectID{sourceA.ID, sourceB.ID},
+		DistributionStrategy: repository.StrategyWeighted,
+		SourceWeights: map[string]int{
+			sourceA.ID.Hex(): 2,
+			sourceB.ID.Hex(): 1,
+		},
+	}
+
+	if _, err := svc.PutObject(context.Background(), bucket, "object.txt", bytes.NewBufferString("data"), 5); err != nil {
+		t.Fatalf("PutObject returned error: %v", err)
+	}
+	if _, ok := capturedSelector.(*WeightedSelector); !ok {
+		t.Fatalf("expected weighted selector, got %T", capturedSelector)
+	}
+	if len(capturedSources) != 2 || capturedSources[0].ID != sourceA.ID || capturedSources[1].ID != sourceB.ID {
+		t.Fatalf("expected source order to be preserved, got %#v", capturedSources)
 	}
 }
 

--- a/api-go/internal/manager/s3_object_test.go
+++ b/api-go/internal/manager/s3_object_test.go
@@ -285,6 +285,15 @@ func TestObjectServicePutObjectUpdatesFileAndDeletesOldChunks(t *testing.T) {
 	}
 }
 
+func TestObjectServiceValidateObjectSourcesRejectsNoSources(t *testing.T) {
+	svc := &ObjectService{sources: &fakeObjectSources{}}
+
+	err := svc.ValidateObjectSources(context.Background(), &repository.Bucket{ID: primitive.NewObjectID()})
+	if !errors.Is(err, ErrNoSources) {
+		t.Fatalf("expected ErrNoSources, got %v", err)
+	}
+}
+
 func TestObjectServicePutObjectReturnsNoSourcesBeforeUpload(t *testing.T) {
 	files := newFakeObjectFiles()
 	uploadCalled := false


### PR DESCRIPTION
## Summary
- Route REST bucket uploads through `ObjectService.PutObject` instead of duplicating chunk upload, metadata replace, and old chunk cleanup in the handler.
- Preserve REST upload response shape `{id, name, created_at}` and no-source `400` behavior.
- Add focused `ObjectService.PutObject` coverage for no-source short-circuiting and bucket distribution strategy selection; strengthen existing success metadata assertions.

## Validation
- `gofmt -w api-go/internal/handlers/bucket.go api-go/internal/manager/s3_object_test.go`
- `git diff --check`
- Local Go tests not run per task instruction to keep CPU-heavy validation in Woodpecker.