### PR TITLE
Respect bucket roles in webui bucket actions

### DIFF
--- a/webui/e2e/buckets.spec.ts
+++ b/webui/e2e/buckets.spec.ts
@@ -24,6 +24,14 @@ const MOCK_BUCKET = {
   key: "my-bucket",
   access_key: "AK123",
   created_at: "2024-01-15T11:00:00Z",
+  role: "owner",
+  shared: false,
+};
+
+const MOCK_VIEWER_BUCKET = {
+  ...MOCK_BUCKET,
+  role: "viewer",
+  shared: true,
 };
 
 const MOCK_BUCKET_CREDS = {
@@ -108,13 +116,28 @@ test.describe("Bucket creation flow", () => {
     await expect(page.getByRole("dialog")).not.toBeVisible();
   });
 
-  test("Upload File button is present on bucket detail page", async ({
+  test("owner bucket detail shows owner actions", async ({
     page,
   }) => {
     await injectAuth(page);
     await mockGet(page, "/buckets", [MOCK_BUCKET]);
     await mockGet(page, "/buckets/bkt-1/files", []);
     await page.goto("/buckets/bkt-1");
-    await expect(page.getByRole("button", { name: "Upload File" })).toBeVisible();
+
+    await expect(page.getByRole("button", { name: "Upload File" })).toHaveCount(2);
+    await expect(page.getByRole("button", { name: "Share Bucket" })).toBeVisible();
+    await expect(page.getByText("Drag and drop a file here")).toBeVisible();
+  });
+
+  test("viewer bucket detail hides write actions", async ({ page }) => {
+    await injectAuth(page);
+    await mockGet(page, "/buckets", [MOCK_VIEWER_BUCKET]);
+    await mockGet(page, "/buckets/bkt-1/files", []);
+    await page.goto("/buckets/bkt-1");
+
+    await expect(page.getByRole("button", { name: "Upload File" })).not.toBeVisible();
+    await expect(page.getByRole("button", { name: "Share Bucket" })).not.toBeVisible();
+    await expect(page.getByText("Drag and drop a file here")).not.toBeVisible();
+    await expect(page.getByText("Files shared in this bucket will appear here.")).toBeVisible();
   });
 });

--- a/webui/e2e/files.spec.ts
+++ b/webui/e2e/files.spec.ts
@@ -16,6 +16,20 @@ const MOCK_BUCKET = {
   key: "my-bucket",
   access_key: "AK123",
   created_at: "2024-01-15T11:00:00Z",
+  role: "owner",
+  shared: false,
+};
+
+const MOCK_VIEWER_BUCKET = {
+  ...MOCK_BUCKET,
+  role: "viewer",
+  shared: true,
+};
+
+const MOCK_EDITOR_BUCKET = {
+  ...MOCK_BUCKET,
+  role: "editor",
+  shared: true,
 };
 
 const MOCK_FILES = [
@@ -90,9 +104,45 @@ test.describe("File listing and download", () => {
     const fileRows = page.locator("tbody tr");
     await expect(fileRows).toHaveCount(2);
 
-    // Each row should have exactly 2 icon buttons (download + delete)
-    const firstRowButtons = fileRows.first().getByRole("button");
-    await expect(firstRowButtons).toHaveCount(2);
+    const firstRowActionButtons = fileRows
+      .first()
+      .locator("td")
+      .last()
+      .getByRole("button");
+    await expect(firstRowActionButtons).toHaveCount(3);
+    await expect(fileRows.first().getByRole("button", { name: "Share report.pdf" })).toBeVisible();
+    await expect(fileRows.first().getByRole("button", { name: "Download report.pdf" })).toBeVisible();
+    await expect(fileRows.first().getByRole("button", { name: "Delete report.pdf" })).toBeVisible();
+  });
+
+  test("viewer file rows only expose download actions", async ({ page }) => {
+    await injectAuth(page);
+    await mockGet(page, "/buckets", [MOCK_VIEWER_BUCKET]);
+    await mockGet(page, "/buckets/bkt-1/files", MOCK_FILES);
+    await page.goto("/buckets/bkt-1");
+
+    const firstRowActions = page.locator("tbody tr").first().locator("td").last();
+    await expect(firstRowActions.getByRole("button")).toHaveCount(1);
+    await expect(
+      firstRowActions.getByRole("button", { name: "Download report.pdf" }),
+    ).toBeVisible();
+    await expect(page.getByRole("button", { name: "Upload File" })).not.toBeVisible();
+    await expect(page.getByRole("button", { name: "Share Bucket" })).not.toBeVisible();
+    await expect(page.getByRole("button", { name: "Share report.pdf" })).not.toBeVisible();
+    await expect(page.getByRole("button", { name: "Delete report.pdf" })).not.toBeVisible();
+  });
+
+  test("editor file rows expose file actions without bucket sharing", async ({ page }) => {
+    await injectAuth(page);
+    await mockGet(page, "/buckets", [MOCK_EDITOR_BUCKET]);
+    await mockGet(page, "/buckets/bkt-1/files", [MOCK_FILES[0]]);
+    await page.goto("/buckets/bkt-1");
+
+    await expect(page.getByRole("button", { name: "Upload File" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Share Bucket" })).not.toBeVisible();
+    await expect(page.getByRole("button", { name: "Share report.pdf" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Download report.pdf" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Delete report.pdf" })).toBeVisible();
   });
 
   test("clicking download triggers a fetch to the download endpoint", async ({
@@ -116,12 +166,7 @@ test.describe("File listing and download", () => {
     await page.goto("/buckets/bkt-1");
     await expect(page.getByText("report.pdf")).toBeVisible();
 
-    // Click the first icon button in the first file row (download)
-    const firstRow = page.locator("tbody tr").first();
-    const actionCell = firstRow.locator("td").last();
-    const actionButtons = actionCell.getByRole("button");
-    const actionButtonCount = await actionButtons.count();
-    await actionButtons.nth(actionButtonCount === 1 ? 0 : 1).click();
+    await page.getByRole("button", { name: "Download report.pdf" }).click();
 
     await expect.poll(() => downloadCalled).toBe(true);
   });

--- a/webui/src/pages/bucket/ui/bucket-page.tsx
+++ b/webui/src/pages/bucket/ui/bucket-page.tsx
@@ -59,7 +59,7 @@ export function BucketPage() {
   }, [load]);
 
   async function handleUpload(file: File) {
-    if (!id) return;
+    if (!id || !bucket || !canWriteFiles(bucket)) return;
     try {
       await uploadFile(id, file);
       addToast({title: "File uploaded", description: `${file.name} added to bucket`, color: "success", timeout: 4000});
@@ -76,6 +76,7 @@ export function BucketPage() {
 
   function onDrop(e: React.DragEvent<HTMLDivElement>) {
     e.preventDefault();
+    if (!bucket || !canWriteFiles(bucket)) return;
     const f = e.dataTransfer.files?.[0];
     if (f) handleUpload(f);
   }
@@ -140,9 +141,17 @@ export function BucketPage() {
     );
   }
 
+  const canManage = canManageBucket(bucket);
+  const canWrite = canWriteFiles(bucket);
+
   return (
     <div className="p-8 flex flex-col gap-6">
-      <Button isIconOnly variant="light" onPress={() => navigate(-1)}>
+      <Button
+        isIconOnly
+        aria-label="Back"
+        variant="light"
+        onPress={() => navigate(-1)}
+      >
         <ArrowLeftIcon className="w-5 h-5" />
       </Button>
       <div className="flex flex-col gap-1">
@@ -152,12 +161,12 @@ export function BucketPage() {
         <p>Created: {new Date(bucket.created_at).toLocaleString()}</p>
       </div>
       <div className="flex justify-end gap-2">
-        {bucket.role === "owner" && (
+        {canManage && (
           <Button variant="flat" onPress={shareBucket.onOpen}>
             Share Bucket
           </Button>
         )}
-        {(bucket.role === "owner" || bucket.role === "editor") && (
+        {canWrite && (
           <>
             <input
               type="file"
@@ -172,16 +181,22 @@ export function BucketPage() {
         )}
       </div>
       <div
-        className="border-2 border-dashed rounded p-4"
+        className={
+          canWrite ? "border-2 border-dashed rounded p-4" : "border rounded p-4"
+        }
         onDragOver={(e) => e.preventDefault()}
         onDrop={onDrop}
       >
         {files.length === 0 ? (
           <EmptyState
             title="No files yet"
-            description="Drag and drop a file here, or use the Upload button."
-            ctaLabel="Upload File"
-            onCtaPress={() => fileInput.current?.click()}
+            description={
+              canWrite
+                ? "Drag and drop a file here, or use the Upload button."
+                : "Files shared in this bucket will appear here."
+            }
+            ctaLabel={canWrite ? "Upload File" : undefined}
+            onCtaPress={canWrite ? () => fileInput.current?.click() : undefined}
           />
         ) : (
           <table className="w-full text-left">
@@ -211,9 +226,10 @@ export function BucketPage() {
                   </td>
                   <td className="py-2">
                     <div className="flex gap-2">
-                      {(bucket.role === "owner" || bucket.role === "editor") && (
+                      {canWrite && (
                         <Button
                           isIconOnly
+                          aria-label={`Share ${f.name}`}
                           variant="light"
                           onPress={() => openShareModal(f)}
                         >
@@ -222,14 +238,16 @@ export function BucketPage() {
                       )}
                       <Button
                         isIconOnly
+                        aria-label={`Download ${f.name}`}
                         variant="light"
                         onPress={() => downloadFile(id!, f)}
                       >
                         <DownloadIcon className="w-5 h-5" />
                       </Button>
-                      {(bucket.role === "owner" || bucket.role === "editor") && (
+                      {canWrite && (
                         <Button
                           isIconOnly
+                          aria-label={`Delete ${f.name}`}
                           variant="light"
                           color="danger"
                           onPress={() => {
@@ -278,4 +296,12 @@ export function BucketPage() {
       />
     </div>
   );
+}
+
+function canManageBucket(bucket: Bucket) {
+  return bucket.role === "owner";
+}
+
+function canWriteFiles(bucket: Bucket) {
+  return bucket.role === "owner" || bucket.role === "editor";
 }


### PR DESCRIPTION
## Summary
- Gate bucket upload affordances, empty-state CTA, and drag/drop handling by bucket role.
- Keep bucket sharing owner-only while allowing editor file actions.
- Update Web UI E2E bucket fixtures with `role` and `shared`, plus owner/editor/viewer action visibility coverage.

## Validation
- `git diff --check`
- Playwright not run locally per THE-593; browser E2E should run in Woodpecker.