### PR TITLE
THE-565 Consolidate docs routes onto OpenAPI surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ Run `sfree --help` or `sfree <command> --help` for full usage details.
 
 | Directory | Purpose |
 | --- | --- |
-| `api-go/` | **Primary backend** — Go HTTP API, S3-compatible routes, Swagger docs, MongoDB metadata |
+| `api-go/` | **Primary backend** — Go HTTP API, S3-compatible routes, OpenAPI docs, MongoDB metadata |
 | `webui/` | React 19 + Vite frontend — signup, source management, bucket operations, file upload/download |
 | `api-python-archived/` | Archived Python backend (historical reference only — not maintained) |
 | `docs/` | Architecture notes, quickstart walkthrough, CI docs |

--- a/api-go/internal/app/router_routes.go
+++ b/api-go/internal/app/router_routes.go
@@ -115,7 +115,13 @@ func registerDocsMetricsRoutes(router *gin.Engine) {
 		c.Redirect(http.StatusMovedPermanently, "/api/docs/index.html")
 	})
 	router.GET("/api/docs/*any", ginSwagger.WrapHandler(swaggerFiles.Handler, ginSwagger.URL("/api/openapi.json")))
-	router.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
+	router.GET("/swagger/*any", func(c *gin.Context) {
+		if c.Param("any") == "/doc.json" {
+			c.Redirect(http.StatusMovedPermanently, "/api/openapi.json")
+			return
+		}
+		c.Redirect(http.StatusMovedPermanently, "/api/docs")
+	})
 	router.GET("/metrics", gin.WrapH(promhttp.Handler()))
 }
 

--- a/api-go/internal/app/router_test.go
+++ b/api-go/internal/app/router_test.go
@@ -122,6 +122,42 @@ func TestOpenAPIDocsRouteRedirectsToIndex(t *testing.T) {
 	}
 }
 
+func TestLegacySwaggerRouteRedirectsToCanonicalDocs(t *testing.T) {
+	r, err := SetupRouter(nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req, _ := http.NewRequest(http.MethodGet, "/swagger/index.html", nil)
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusMovedPermanently {
+		t.Fatalf("expected 301, got %d", w.Code)
+	}
+	if got := w.Header().Get("Location"); got != "/api/docs" {
+		t.Fatalf("expected redirect to /api/docs, got %q", got)
+	}
+}
+
+func TestLegacySwaggerDocJSONRouteRedirectsToOpenAPIJSON(t *testing.T) {
+	r, err := SetupRouter(nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req, _ := http.NewRequest(http.MethodGet, "/swagger/doc.json", nil)
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusMovedPermanently {
+		t.Fatalf("expected 301, got %d", w.Code)
+	}
+	if got := w.Header().Get("Location"); got != "/api/openapi.json" {
+		t.Fatalf("expected redirect to /api/openapi.json, got %q", got)
+	}
+}
+
 func TestNewRouterDependenciesReturnsRepositoryErrors(t *testing.T) {
 	tests := []struct {
 		name string

--- a/api-go/internal/docs/docs.go
+++ b/api-go/internal/docs/docs.go
@@ -1470,6 +1470,61 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/sources/{id}/health": {
+            "get": {
+                "security": [
+                    {
+                        "BasicAuth": []
+                    }
+                ],
+                "description": "Runs a lightweight on-demand provider probe. Google Drive returns native quota when available; S3-compatible and Telegram quota fields are null because no cheap native capacity is available.",
+                "tags": [
+                    "sources"
+                ],
+                "summary": "Check source health",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Source ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.sourceHealthResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/sources/{id}/info": {
             "get": {
                 "security": [
@@ -1936,6 +1991,41 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "url": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.sourceHealthResponse": {
+            "type": "object",
+            "properties": {
+                "checked_at": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "latency_ms": {
+                    "type": "integer"
+                },
+                "message": {
+                    "type": "string"
+                },
+                "quota_free_bytes": {
+                    "type": "integer"
+                },
+                "quota_total_bytes": {
+                    "type": "integer"
+                },
+                "quota_used_bytes": {
+                    "type": "integer"
+                },
+                "reason_code": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "type": {
                     "type": "string"
                 }
             }


### PR DESCRIPTION
## Summary

- Redirect legacy `/swagger/*any` requests to canonical `/api/docs`
- Keep `/api/docs` backed by `/api/openapi.json` as the single public docs surface
- Update focused router coverage and public docs references away from `/swagger/index.html`

## Validation

- Not run locally per agent resource policy against CPU-bound validation; Woodpecker should run the focused Go test suite and docs checks.

Closes THE-565.