### PR TITLE
THE-495: Collapse resilience retry loops

### DIFF
--- a/api-go/internal/resilience/wrapper.go
+++ b/api-go/internal/resilience/wrapper.go
@@ -72,6 +72,88 @@ type wrapper struct {
 	retryCfg RetryConfig
 }
 
+type retryContextFactory func(context.Context) (context.Context, context.CancelFunc)
+
+type abortRetryError struct {
+	err error
+}
+
+func (e abortRetryError) Error() string {
+	return e.err.Error()
+}
+
+func (e abortRetryError) Unwrap() error {
+	return e.err
+}
+
+func timeoutRetryContext(timeout time.Duration) retryContextFactory {
+	return func(ctx context.Context) (context.Context, context.CancelFunc) {
+		return context.WithTimeout(ctx, timeout)
+	}
+}
+
+func cancelRetryContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithCancel(ctx)
+}
+
+func (w *wrapper) withRetry(ctx context.Context, logMessage string, logAttrs []any, newContext retryContextFactory, cancelOnSuccess bool, prepare func() error, fn func(context.Context, context.CancelFunc) error) error {
+	if err := w.cb.Allow(); err != nil {
+		return err
+	}
+	if prepare != nil {
+		if err := prepare(); err != nil {
+			w.cb.RecordFailure()
+			return err
+		}
+	}
+
+	var lastErr error
+	for attempt := 0; attempt <= w.retryCfg.MaxRetries; attempt++ {
+		if attempt > 0 {
+			delay := Backoff(attempt-1, w.retryCfg)
+			attrs := append([]any{}, logAttrs...)
+			attrs = append(attrs,
+				slog.Int("attempt", attempt),
+				slog.Duration("backoff", delay),
+				slog.String("last_error", lastErr.Error()),
+			)
+			slog.WarnContext(ctx, logMessage, attrs...)
+			select {
+			case <-time.After(delay):
+			case <-ctx.Done():
+				w.cb.RecordFailure()
+				return ctx.Err()
+			}
+			if err := w.cb.Allow(); err != nil {
+				return err
+			}
+		}
+
+		reqCtx, cancel := newContext(ctx)
+		err := fn(reqCtx, cancel)
+		if err == nil {
+			if cancelOnSuccess {
+				cancel()
+			}
+			w.cb.RecordSuccess()
+			return nil
+		}
+		cancel()
+		var abortErr abortRetryError
+		if errors.As(err, &abortErr) {
+			lastErr = abortErr.err
+			break
+		}
+		lastErr = err
+		if !isRetryable(err) {
+			break
+		}
+	}
+
+	w.cb.RecordFailure()
+	return lastErr
+}
+
 type uploadBodyReplay interface {
 	Reader() (io.Reader, error)
 }
@@ -111,198 +193,61 @@ func newUploadBodyReplay(r io.Reader) (uploadBodyReplay, error) {
 }
 
 func (w *wrapper) Upload(ctx context.Context, name string, r io.Reader) (string, error) {
-	if err := w.cb.Allow(); err != nil {
-		return "", err
-	}
-
 	var replay uploadBodyReplay
-	if w.retryCfg.MaxRetries > 0 {
-		var err error
-		replay, err = newUploadBodyReplay(r)
-		if err != nil {
-			w.cb.RecordFailure()
-			return "", err
+	prepare := func() error {
+		if w.retryCfg.MaxRetries > 0 {
+			var err error
+			replay, err = newUploadBodyReplay(r)
+			if err != nil {
+				return err
+			}
 		}
+		return nil
 	}
 
-	var lastErr error
-	for attempt := 0; attempt <= w.retryCfg.MaxRetries; attempt++ {
-		if attempt > 0 {
-			delay := Backoff(attempt-1, w.retryCfg)
-			slog.WarnContext(ctx, "retrying upload",
-				slog.String("name", name),
-				slog.Int("attempt", attempt),
-				slog.Duration("backoff", delay),
-				slog.String("last_error", lastErr.Error()),
-			)
-			select {
-			case <-time.After(delay):
-			case <-ctx.Done():
-				w.cb.RecordFailure()
-				return "", ctx.Err()
-			}
-			// Re-check circuit before retry.
-			if err := w.cb.Allow(); err != nil {
-				return "", err
-			}
-		}
-
+	var result string
+	err := w.withRetry(ctx, "retrying upload", []any{slog.String("name", name)}, timeoutRetryContext(w.cfg.Timeout), true, prepare, func(reqCtx context.Context, cancel context.CancelFunc) error {
 		body := r
 		if replay != nil {
 			var err error
 			body, err = replay.Reader()
 			if err != nil {
-				w.cb.RecordFailure()
-				return "", err
+				return abortRetryError{err: err}
 			}
 		}
-		reqCtx, cancel := context.WithTimeout(ctx, w.cfg.Timeout)
-		result, err := w.inner.Upload(reqCtx, name, body)
-		cancel()
-
-		if err == nil {
-			w.cb.RecordSuccess()
-			return result, nil
-		}
-		lastErr = err
-		if !isRetryable(err) {
-			break
-		}
-	}
-
-	w.cb.RecordFailure()
-	return "", lastErr
+		var err error
+		result, err = w.inner.Upload(reqCtx, name, body)
+		return err
+	})
+	return result, err
 }
 
 func (w *wrapper) Download(ctx context.Context, name string) (io.ReadCloser, error) {
-	if err := w.cb.Allow(); err != nil {
-		return nil, err
-	}
-
-	var lastErr error
-	for attempt := 0; attempt <= w.retryCfg.MaxRetries; attempt++ {
-		if attempt > 0 {
-			delay := Backoff(attempt-1, w.retryCfg)
-			slog.WarnContext(ctx, "retrying download",
-				slog.String("name", name),
-				slog.Int("attempt", attempt),
-				slog.Duration("backoff", delay),
-				slog.String("last_error", lastErr.Error()),
-			)
-			select {
-			case <-time.After(delay):
-			case <-ctx.Done():
-				w.cb.RecordFailure()
-				return nil, ctx.Err()
-			}
-			if err := w.cb.Allow(); err != nil {
-				return nil, err
-			}
-		}
-
-		reqCtx, cancel := context.WithTimeout(ctx, w.cfg.Timeout)
-		rc, err := w.inner.Download(reqCtx, name)
-		cancel()
-
-		if err == nil {
-			w.cb.RecordSuccess()
-			return rc, nil
-		}
-		lastErr = err
-		if !isRetryable(err) {
-			break
-		}
-	}
-
-	w.cb.RecordFailure()
-	return nil, lastErr
+	var rc io.ReadCloser
+	err := w.withRetry(ctx, "retrying download", []any{slog.String("name", name)}, timeoutRetryContext(w.cfg.Timeout), true, nil, func(reqCtx context.Context, cancel context.CancelFunc) error {
+		var err error
+		rc, err = w.inner.Download(reqCtx, name)
+		return err
+	})
+	return rc, err
 }
 
 func (w *wrapper) DownloadStream(ctx context.Context, name string) (io.ReadCloser, error) {
-	if err := w.cb.Allow(); err != nil {
-		return nil, err
-	}
-
-	var lastErr error
-	for attempt := 0; attempt <= w.retryCfg.MaxRetries; attempt++ {
-		if attempt > 0 {
-			delay := Backoff(attempt-1, w.retryCfg)
-			slog.WarnContext(ctx, "retrying streamed download",
-				slog.String("name", name),
-				slog.Int("attempt", attempt),
-				slog.Duration("backoff", delay),
-				slog.String("last_error", lastErr.Error()),
-			)
-			select {
-			case <-time.After(delay):
-			case <-ctx.Done():
-				w.cb.RecordFailure()
-				return nil, ctx.Err()
-			}
-			if err := w.cb.Allow(); err != nil {
-				return nil, err
-			}
-		}
-
-		reqCtx, cancel := context.WithCancel(ctx)
-		rc, err := w.inner.Download(reqCtx, name)
+	var rc io.ReadCloser
+	err := w.withRetry(ctx, "retrying streamed download", []any{slog.String("name", name)}, cancelRetryContext, false, nil, func(reqCtx context.Context, cancel context.CancelFunc) error {
+		stream, err := w.inner.Download(reqCtx, name)
 		if err == nil {
-			w.cb.RecordSuccess()
-			return &cancelOnCloseReadCloser{ReadCloser: rc, cancel: cancel}, nil
+			rc = &cancelOnCloseReadCloser{ReadCloser: stream, cancel: cancel}
 		}
-		cancel()
-		lastErr = err
-		if !isRetryable(err) {
-			break
-		}
-	}
-
-	w.cb.RecordFailure()
-	return nil, lastErr
+		return err
+	})
+	return rc, err
 }
 
 func (w *wrapper) Delete(ctx context.Context, name string) error {
-	if err := w.cb.Allow(); err != nil {
-		return err
-	}
-
-	var lastErr error
-	for attempt := 0; attempt <= w.retryCfg.MaxRetries; attempt++ {
-		if attempt > 0 {
-			delay := Backoff(attempt-1, w.retryCfg)
-			slog.WarnContext(ctx, "retrying delete",
-				slog.String("name", name),
-				slog.Int("attempt", attempt),
-				slog.Duration("backoff", delay),
-				slog.String("last_error", lastErr.Error()),
-			)
-			select {
-			case <-time.After(delay):
-			case <-ctx.Done():
-				w.cb.RecordFailure()
-				return ctx.Err()
-			}
-			if err := w.cb.Allow(); err != nil {
-				return err
-			}
-		}
-
-		reqCtx, cancel := context.WithTimeout(ctx, w.cfg.Timeout)
-		err := w.inner.Delete(reqCtx, name)
-		cancel()
-
-		if err == nil {
-			w.cb.RecordSuccess()
-			return nil
-		}
-		lastErr = err
-		if !isRetryable(err) {
-			break
-		}
-	}
-
-	w.cb.RecordFailure()
-	return lastErr
+	return w.withRetry(ctx, "retrying delete", []any{slog.String("name", name)}, timeoutRetryContext(w.cfg.Timeout), true, nil, func(reqCtx context.Context, cancel context.CancelFunc) error {
+		return w.inner.Delete(reqCtx, name)
+	})
 }
 
 type cancelOnCloseReadCloser struct {
@@ -323,45 +268,14 @@ func (w *wrapper) ListFiles(ctx context.Context) ([]gdrive.File, error) {
 	if !ok {
 		return nil, ErrUnsupportedOperation
 	}
-	if err := w.cb.Allow(); err != nil {
-		return nil, err
-	}
 
-	var lastErr error
-	for attempt := 0; attempt <= w.retryCfg.MaxRetries; attempt++ {
-		if attempt > 0 {
-			delay := Backoff(attempt-1, w.retryCfg)
-			slog.WarnContext(ctx, "retrying list files",
-				slog.Int("attempt", attempt),
-				slog.Duration("backoff", delay),
-				slog.String("last_error", lastErr.Error()),
-			)
-			select {
-			case <-time.After(delay):
-			case <-ctx.Done():
-				w.cb.RecordFailure()
-				return nil, ctx.Err()
-			}
-			if err := w.cb.Allow(); err != nil {
-				return nil, err
-			}
-		}
-
-		reqCtx, cancel := context.WithTimeout(ctx, w.cfg.Timeout)
-		files, err := inner.ListFiles(reqCtx)
-		cancel()
-		if err == nil {
-			w.cb.RecordSuccess()
-			return files, nil
-		}
-		lastErr = err
-		if !isRetryable(err) {
-			break
-		}
-	}
-
-	w.cb.RecordFailure()
-	return nil, lastErr
+	var files []gdrive.File
+	err := w.withRetry(ctx, "retrying list files", nil, timeoutRetryContext(w.cfg.Timeout), true, nil, func(reqCtx context.Context, cancel context.CancelFunc) error {
+		var err error
+		files, err = inner.ListFiles(reqCtx)
+		return err
+	})
+	return files, err
 }
 
 func (w *wrapper) StorageInfo(ctx context.Context) (int64, int64, int64, error) {
@@ -371,45 +285,14 @@ func (w *wrapper) StorageInfo(ctx context.Context) (int64, int64, int64, error) 
 	if !ok {
 		return 0, 0, 0, ErrUnsupportedOperation
 	}
-	if err := w.cb.Allow(); err != nil {
-		return 0, 0, 0, err
-	}
 
-	var lastErr error
-	for attempt := 0; attempt <= w.retryCfg.MaxRetries; attempt++ {
-		if attempt > 0 {
-			delay := Backoff(attempt-1, w.retryCfg)
-			slog.WarnContext(ctx, "retrying storage info",
-				slog.Int("attempt", attempt),
-				slog.Duration("backoff", delay),
-				slog.String("last_error", lastErr.Error()),
-			)
-			select {
-			case <-time.After(delay):
-			case <-ctx.Done():
-				w.cb.RecordFailure()
-				return 0, 0, 0, ctx.Err()
-			}
-			if err := w.cb.Allow(); err != nil {
-				return 0, 0, 0, err
-			}
-		}
-
-		reqCtx, cancel := context.WithTimeout(ctx, w.cfg.Timeout)
-		total, used, free, err := inner.StorageInfo(reqCtx)
-		cancel()
-		if err == nil {
-			w.cb.RecordSuccess()
-			return total, used, free, nil
-		}
-		lastErr = err
-		if !isRetryable(err) {
-			break
-		}
-	}
-
-	w.cb.RecordFailure()
-	return 0, 0, 0, lastErr
+	var total, used, free int64
+	err := w.withRetry(ctx, "retrying storage info", nil, timeoutRetryContext(w.cfg.Timeout), true, nil, func(reqCtx context.Context, cancel context.CancelFunc) error {
+		var err error
+		total, used, free, err = inner.StorageInfo(reqCtx)
+		return err
+	})
+	return total, used, free, err
 }
 
 func (w *wrapper) ListObjects(ctx context.Context) ([]s3compat.ObjectInfo, int64, error) {
@@ -419,45 +302,15 @@ func (w *wrapper) ListObjects(ctx context.Context) ([]s3compat.ObjectInfo, int64
 	if !ok {
 		return nil, 0, ErrUnsupportedOperation
 	}
-	if err := w.cb.Allow(); err != nil {
-		return nil, 0, err
-	}
 
-	var lastErr error
-	for attempt := 0; attempt <= w.retryCfg.MaxRetries; attempt++ {
-		if attempt > 0 {
-			delay := Backoff(attempt-1, w.retryCfg)
-			slog.WarnContext(ctx, "retrying list objects",
-				slog.Int("attempt", attempt),
-				slog.Duration("backoff", delay),
-				slog.String("last_error", lastErr.Error()),
-			)
-			select {
-			case <-time.After(delay):
-			case <-ctx.Done():
-				w.cb.RecordFailure()
-				return nil, 0, ctx.Err()
-			}
-			if err := w.cb.Allow(); err != nil {
-				return nil, 0, err
-			}
-		}
-
-		reqCtx, cancel := context.WithTimeout(ctx, w.cfg.Timeout)
-		objects, used, err := inner.ListObjects(reqCtx)
-		cancel()
-		if err == nil {
-			w.cb.RecordSuccess()
-			return objects, used, nil
-		}
-		lastErr = err
-		if !isRetryable(err) {
-			break
-		}
-	}
-
-	w.cb.RecordFailure()
-	return nil, 0, lastErr
+	var objects []s3compat.ObjectInfo
+	var used int64
+	err := w.withRetry(ctx, "retrying list objects", nil, timeoutRetryContext(w.cfg.Timeout), true, nil, func(reqCtx context.Context, cancel context.CancelFunc) error {
+		var err error
+		objects, used, err = inner.ListObjects(reqCtx)
+		return err
+	})
+	return objects, used, err
 }
 
 func (w *wrapper) HeadBucket(ctx context.Context) error {
@@ -467,45 +320,10 @@ func (w *wrapper) HeadBucket(ctx context.Context) error {
 	if !ok {
 		return ErrUnsupportedOperation
 	}
-	if err := w.cb.Allow(); err != nil {
-		return err
-	}
 
-	var lastErr error
-	for attempt := 0; attempt <= w.retryCfg.MaxRetries; attempt++ {
-		if attempt > 0 {
-			delay := Backoff(attempt-1, w.retryCfg)
-			slog.WarnContext(ctx, "retrying head bucket",
-				slog.Int("attempt", attempt),
-				slog.Duration("backoff", delay),
-				slog.String("last_error", lastErr.Error()),
-			)
-			select {
-			case <-time.After(delay):
-			case <-ctx.Done():
-				w.cb.RecordFailure()
-				return ctx.Err()
-			}
-			if err := w.cb.Allow(); err != nil {
-				return err
-			}
-		}
-
-		reqCtx, cancel := context.WithTimeout(ctx, w.cfg.Timeout)
-		err := inner.HeadBucket(reqCtx)
-		cancel()
-		if err == nil {
-			w.cb.RecordSuccess()
-			return nil
-		}
-		lastErr = err
-		if !isRetryable(err) {
-			break
-		}
-	}
-
-	w.cb.RecordFailure()
-	return lastErr
+	return w.withRetry(ctx, "retrying head bucket", nil, timeoutRetryContext(w.cfg.Timeout), true, nil, func(reqCtx context.Context, cancel context.CancelFunc) error {
+		return inner.HeadBucket(reqCtx)
+	})
 }
 
 func (w *wrapper) CheckChat(ctx context.Context) error {
@@ -515,43 +333,8 @@ func (w *wrapper) CheckChat(ctx context.Context) error {
 	if !ok {
 		return ErrUnsupportedOperation
 	}
-	if err := w.cb.Allow(); err != nil {
-		return err
-	}
 
-	var lastErr error
-	for attempt := 0; attempt <= w.retryCfg.MaxRetries; attempt++ {
-		if attempt > 0 {
-			delay := Backoff(attempt-1, w.retryCfg)
-			slog.WarnContext(ctx, "retrying telegram chat check",
-				slog.Int("attempt", attempt),
-				slog.Duration("backoff", delay),
-				slog.String("last_error", lastErr.Error()),
-			)
-			select {
-			case <-time.After(delay):
-			case <-ctx.Done():
-				w.cb.RecordFailure()
-				return ctx.Err()
-			}
-			if err := w.cb.Allow(); err != nil {
-				return err
-			}
-		}
-
-		reqCtx, cancel := context.WithTimeout(ctx, w.cfg.Timeout)
-		err := inner.CheckChat(reqCtx)
-		cancel()
-		if err == nil {
-			w.cb.RecordSuccess()
-			return nil
-		}
-		lastErr = err
-		if !isRetryable(err) {
-			break
-		}
-	}
-
-	w.cb.RecordFailure()
-	return lastErr
+	return w.withRetry(ctx, "retrying telegram chat check", nil, timeoutRetryContext(w.cfg.Timeout), true, nil, func(reqCtx context.Context, cancel context.CancelFunc) error {
+		return inner.CheckChat(reqCtx)
+	})
 }

--- a/api-go/internal/resilience/wrapper_test.go
+++ b/api-go/internal/resilience/wrapper_test.go
@@ -350,6 +350,57 @@ func TestWrapperRetryDownloadSucceeds(t *testing.T) {
 	}
 }
 
+type streamContextClient struct {
+	ctxCh chan context.Context
+}
+
+func (c *streamContextClient) Upload(ctx context.Context, name string, r io.Reader) (string, error) {
+	return "", errors.New("not implemented")
+}
+
+func (c *streamContextClient) Download(ctx context.Context, name string) (io.ReadCloser, error) {
+	c.ctxCh <- ctx
+	return io.NopCloser(strings.NewReader("data")), nil
+}
+
+func (c *streamContextClient) Delete(ctx context.Context, name string) error {
+	return errors.New("not implemented")
+}
+
+func TestWrapperDownloadStreamCancelsOnClose(t *testing.T) {
+	inner := &streamContextClient{ctxCh: make(chan context.Context, 1)}
+	cfg := WrapperConfig{
+		Timeout:          time.Second,
+		FailureThreshold: 10,
+		RecoveryTimeout:  time.Second,
+		MaxRetries:       0,
+	}
+	w := Wrap(inner, cfg).(interface {
+		DownloadStream(context.Context, string) (io.ReadCloser, error)
+	})
+
+	rc, err := w.DownloadStream(context.Background(), "file.txt")
+	if err != nil {
+		t.Fatalf("download stream: %v", err)
+	}
+
+	reqCtx := <-inner.ctxCh
+	select {
+	case <-reqCtx.Done():
+		t.Fatal("stream context was canceled before close")
+	default:
+	}
+
+	if err := rc.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	select {
+	case <-reqCtx.Done():
+	case <-time.After(50 * time.Millisecond):
+		t.Fatal("stream context was not canceled after close")
+	}
+}
+
 func TestWrapperRetryDeleteSucceeds(t *testing.T) {
 	inner := &flakeyClient{failCount: 1}
 	cfg := WrapperConfig{


### PR DESCRIPTION
## Summary
- Extract shared retry, circuit-breaker, backoff, timeout, and logging flow in the source resilience wrapper.
- Keep operation-specific result handling in each wrapper method.
- Preserve `DownloadStream` context lifetime by keeping its context open until the returned stream is closed.

## Tests
- Added focused unit coverage for `DownloadStream` cancel-on-close behavior.
- Not run locally per agent resource policy; Woodpecker should run validation.
