### PR TITLE
THE-563 Preflight direct source downloads

### DIFF
--- a/api-go/internal/docs/docs.go
+++ b/api-go/internal/docs/docs.go
@@ -1470,6 +1470,61 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/sources/{id}/health": {
+            "get": {
+                "security": [
+                    {
+                        "BasicAuth": []
+                    }
+                ],
+                "description": "Runs a lightweight on-demand provider probe. Google Drive returns native quota when available; S3-compatible and Telegram quota fields are null because no cheap native capacity is available.",
+                "tags": [
+                    "sources"
+                ],
+                "summary": "Check source health",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Source ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.sourceHealthResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/sources/{id}/info": {
             "get": {
                 "security": [
@@ -1936,6 +1991,41 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "url": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.sourceHealthResponse": {
+            "type": "object",
+            "properties": {
+                "checked_at": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "latency_ms": {
+                    "type": "integer"
+                },
+                "message": {
+                    "type": "string"
+                },
+                "quota_free_bytes": {
+                    "type": "integer"
+                },
+                "quota_total_bytes": {
+                    "type": "integer"
+                },
+                "quota_used_bytes": {
+                    "type": "integer"
+                },
+                "reason_code": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "type": {
                     "type": "string"
                 }
             }

--- a/api-go/internal/handlers/source.go
+++ b/api-go/internal/handlers/source.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -447,10 +448,13 @@ func getSourceHealth(repo sourceGetter, factory manager.SourceClientFactory) gin
 // @Security BasicAuth
 // @Router /api/v1/sources/{id}/files/{file_id}/download [get]
 func DownloadSourceFile(sourceRepo *repository.SourceRepository) gin.HandlerFunc {
+	if sourceRepo == nil {
+		return downloadSourceFile(nil, nil)
+	}
 	return downloadSourceFile(sourceRepo, nil)
 }
 
-func downloadSourceFile(sourceRepo *repository.SourceRepository, factory manager.SourceClientFactory) gin.HandlerFunc {
+func downloadSourceFile(sourceRepo sourceGetter, factory manager.SourceClientFactory) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		if sourceRepo == nil {
 			slog.ErrorContext(c.Request.Context(), "download source file: repository is nil")
@@ -502,10 +506,22 @@ func downloadSourceFile(sourceRepo *repository.SourceRepository, factory manager
 		}
 		defer func() { _ = body.Close() }()
 
+		prefix := make([]byte, 1)
+		n, err := io.ReadFull(body, prefix)
+		if err != nil && err != io.EOF && err != io.ErrUnexpectedEOF {
+			slog.ErrorContext(c.Request.Context(), "download source file: preflight", slog.String("error", err.Error()))
+			c.Status(http.StatusInternalServerError)
+			return
+		}
+		stream := io.Reader(body)
+		if n > 0 {
+			stream = io.MultiReader(bytes.NewReader(prefix[:n]), body)
+		}
+
 		c.Header("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s\"", sanitizeFilename(filename)))
 		c.Header("Content-Type", "application/octet-stream")
 		c.Status(http.StatusOK)
-		if _, err := io.Copy(c.Writer, body); err != nil {
+		if _, err := io.Copy(c.Writer, stream); err != nil {
 			slog.ErrorContext(c.Request.Context(), "download source file: stream", slog.String("error", err.Error()))
 		}
 	}

--- a/api-go/internal/handlers/source_download_test.go
+++ b/api-go/internal/handlers/source_download_test.go
@@ -1,0 +1,117 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/example/sfree/api-go/internal/manager"
+	"github.com/example/sfree/api-go/internal/repository"
+	"github.com/gin-gonic/gin"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+type sourceDownloadHandlerClient struct {
+	body io.ReadCloser
+}
+
+func (c sourceDownloadHandlerClient) Upload(context.Context, string, io.Reader) (string, error) {
+	return "", nil
+}
+
+func (c sourceDownloadHandlerClient) Download(context.Context, string) (io.ReadCloser, error) {
+	return c.body, nil
+}
+
+func (c sourceDownloadHandlerClient) Delete(context.Context, string) error {
+	return nil
+}
+
+type failingReadCloser struct{}
+
+func (f failingReadCloser) Read([]byte) (int, error) {
+	return 0, errors.New("source stream failed")
+}
+
+func (f failingReadCloser) Close() error {
+	return nil
+}
+
+func TestDownloadSourceFilePreflightFailureBeforeHeaders(t *testing.T) {
+	t.Parallel()
+	userID := primitive.NewObjectID()
+	source := &repository.Source{
+		ID:     primitive.NewObjectID(),
+		UserID: userID,
+		Type:   repository.SourceTypeS3,
+	}
+	r := gin.New()
+	r.GET("/sources/:id/files/:file_id/download", setUserID(userID.Hex()), downloadSourceFile(fakeSourceGetter{source: source}, func(context.Context, *repository.Source) (manager.SourceClient, error) {
+		return sourceDownloadHandlerClient{body: failingReadCloser{}}, nil
+	}))
+
+	req, _ := http.NewRequest(http.MethodGet, "/sources/"+source.ID.Hex()+"/files/object-key/download", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", w.Code)
+	}
+	if got := w.Header().Get("Content-Disposition"); got != "" {
+		t.Fatalf("expected no success download headers, got Content-Disposition %q", got)
+	}
+}
+
+func TestDownloadSourceFileStreamsAfterPreflight(t *testing.T) {
+	t.Parallel()
+	userID := primitive.NewObjectID()
+	source := &repository.Source{
+		ID:     primitive.NewObjectID(),
+		UserID: userID,
+		Type:   repository.SourceTypeS3,
+	}
+	r := gin.New()
+	r.GET("/sources/:id/files/:file_id/download", setUserID(userID.Hex()), downloadSourceFile(fakeSourceGetter{source: source}, func(context.Context, *repository.Source) (manager.SourceClient, error) {
+		return sourceDownloadHandlerClient{body: io.NopCloser(strings.NewReader("streamed payload"))}, nil
+	}))
+
+	req, _ := http.NewRequest(http.MethodGet, "/sources/"+source.ID.Hex()+"/files/object-key/download", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if got := w.Header().Get("Content-Type"); got != "application/octet-stream" {
+		t.Fatalf("expected octet stream content type, got %q", got)
+	}
+	if got := w.Body.String(); got != "streamed payload" {
+		t.Fatalf("expected full streamed payload, got %q", got)
+	}
+}
+
+func TestDownloadSourceFileNilBodyRemainsBadRequest(t *testing.T) {
+	t.Parallel()
+	userID := primitive.NewObjectID()
+	source := &repository.Source{
+		ID:     primitive.NewObjectID(),
+		UserID: userID,
+		Type:   repository.SourceTypeS3,
+	}
+	r := gin.New()
+	r.GET("/sources/:id/files/:file_id/download", setUserID(userID.Hex()), downloadSourceFile(fakeSourceGetter{source: source}, func(context.Context, *repository.Source) (manager.SourceClient, error) {
+		return sourceDownloadHandlerClient{}, nil
+	}))
+
+	req, _ := http.NewRequest(http.MethodGet, "/sources/"+source.ID.Hex()+"/files/object-key/download", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}


### PR DESCRIPTION
## Summary
- preflight direct source download streams by reading one byte before committing success headers
- replay the preflight byte and continue streaming the original body on success
- add focused handler coverage for preflight failure, successful streaming, and existing nil-body bad request behavior

## Validation
- Not run locally per limited-resource task instructions; full backend validation should run in Woodpecker.

Refs [THE-563](/THE/issues/THE-563).