### PR TITLE
THE-600 proxy share downloads through frontend origin

### DIFF
--- a/scripts/woodpecker-smoke.sh
+++ b/scripts/woodpecker-smoke.sh
@@ -2,6 +2,7 @@
 set -eu
 
 base_url="${SFREE_SMOKE_BASE_URL:-http://docker:8080}"
+frontend_url="${SFREE_SMOKE_FRONTEND_URL:-http://docker:3000}"
 suffix="$(date +%s)-$$"
 tmpdir="$(mktemp -d)"
 export COMPOSE_PROJECT_NAME="sfree_smoke_$suffix"
@@ -87,6 +88,7 @@ bucket_key="smoke-bucket-$suffix"
 payload="$tmpdir/payload.txt"
 cli_download="$tmpdir/cli-download.txt"
 s3_download="$tmpdir/s3-download.txt"
+share_download="$tmpdir/share-download.txt"
 
 printf 'sfree smoke payload %s\n' "$suffix" > "$payload"
 
@@ -156,5 +158,16 @@ AWS_DEFAULT_REGION=us-east-1 \
 	"$s3_download" >/dev/null
 cmp "$payload" "$s3_download"
 pass "Downloaded bytes match through S3-compatible credentials"
+
+step "Frontend-origin public share download"
+share_json="$(curl -fsS -u "$username:$password" -H 'Content-Type: application/json' --data '{}' "$base_url/api/v1/buckets/$bucket_id/files/$file_id/share")"
+share_path="$(printf '%s' "$share_json" | jq -r '.url // empty')"
+case "$share_path" in
+	/share/*) ;;
+	*) fail "Share creation response did not include a /share/ URL" ;;
+esac
+curl -fsS "$frontend_url$share_path" -o "$share_download"
+cmp "$payload" "$share_download"
+pass "Downloaded bytes match through the frontend-origin public share URL"
 
 pass "Woodpecker smoke validation completed"

--- a/webui/nginx.conf
+++ b/webui/nginx.conf
@@ -11,6 +11,13 @@ server {
     client_max_body_size 100m;
   }
 
+  location /share/ {
+    proxy_pass http://${API_HOST}:${API_PORT};
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+  }
+
   location / {
     try_files $uri /index.html;
   }

--- a/webui/vite.config.ts
+++ b/webui/vite.config.ts
@@ -10,6 +10,10 @@ export default defineConfig({
         target: process.env.VITE_API_URL || 'http://localhost:8080',
         changeOrigin: true,
       },
+      '/share': {
+        target: process.env.VITE_API_URL || 'http://localhost:8080',
+        changeOrigin: true,
+      },
     },
   },
 })


### PR DESCRIPTION
## Summary
- proxy `/share/` through the production nginx frontend to the Go API
- align Vite dev proxying for standalone browser development
- extend the Woodpecker smoke script to create a public share link and verify bytes downloaded through the frontend-origin `/share/{token}` URL

## Validation
- `sh -n scripts/woodpecker-smoke.sh`
- `git diff --check`

Full Docker/Compose smoke validation is left to Woodpecker per the task constraints.