### PR TITLE
docs: refresh auth and launch caveats

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,8 @@ cd api-go
 ENV=local go run ./cmd/server
 ```
 
-Swagger is served from `http://localhost:8080/swagger/index.html`.
+API docs are served from `http://localhost:8080/api/docs`; the OpenAPI JSON is
+available at `http://localhost:8080/api/openapi.json`.
 
 ### Frontend (React / Vite)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,7 +8,7 @@ upstream sources, and exposes both REST and S3-compatible access paths.
 
 At a high level:
 
-1. A user signs up and authenticates with HTTP Basic Auth.
+1. A user signs up and authenticates with HTTP Basic Auth or GitHub OAuth.
 2. The user registers one or more storage sources.
 3. A bucket records the selected source set plus generated S3 credentials.
 4. Uploads are split into chunks and assigned to sources in round-robin order.
@@ -77,21 +77,25 @@ copy:
 
 - Do not claim redundancy, erasure coding, or durable multi-provider storage.
   The current design distributes chunks; it does not replicate them.
-- Do not describe the auth model as hardened. The API uses Basic Auth and the
-  frontend stores credentials in `localStorage`, and source create/list
-  responses echo stored credential payloads.
+- Do not describe the auth model as hardened. The API accepts HTTP Basic Auth,
+  bearer tokens, and GitHub OAuth sessions through an `auth_token` cookie. The
+  frontend still stores Basic Auth credentials or token state in `localStorage`,
+  and source create/list responses echo stored credential payloads.
 - Do not imply identical observability across source types. Google Drive,
   Telegram, and S3-compatible sources return different levels of file/quota
   detail.
+- Do not describe rate limiting as complete abuse protection. The API has
+  in-memory request limits, but they are not a distributed production
+  throttling layer.
 
 ## Local Development Notes
 
 - Default local backend config lives in `api-go/config/local.yaml`.
 - The Go API listens on the Gin default port, `:8080`.
 - `api-go/docker-compose.yml` starts the local MongoDB dependency.
-- The checked-in frontend points at a hosted dev API URL in
-  `webui/src/shared/api/*.ts`, so a fully local browser loop still requires a
-  small manual config edit.
+- The frontend API helper reads `VITE_API_BASE` at build time and defaults to
+  the relative `/api/v1` path. In local Vite development, `/api` requests are
+  proxied to `VITE_API_URL`, which defaults to `http://localhost:8080`.
 
 ## Naming
 

--- a/docs/launch-campaign.md
+++ b/docs/launch-campaign.md
@@ -25,7 +25,7 @@ so you can use any S3 SDK or tool (rclone, mc, boto3) to read and write objects.
 
 What actually works today (v0.1.0):
 
-- Go backend with REST API and Swagger docs
+- Go backend with REST API and API docs
 - Three storage backends: Google Drive, Telegram, S3-compatible
 - S3-compatible endpoint with AWS SigV4 auth
 - React web UI for signup, bucket management, file upload/download/preview
@@ -41,7 +41,8 @@ What it does NOT do (being upfront):
   source, those files are gone.
 - No erasure coding.
 - Auth is functional but not production-hardened.
-- No rate limiting yet.
+- Rate limiting is in-memory and basic, not a full production abuse protection
+  layer.
 
 This is an early-stage project aimed at self-hosters and homelab tinkerers who
 want to unify their scattered free storage behind one interface. It is not a
@@ -80,7 +81,7 @@ distributed round-robin across them. Every bucket also gets S3-compatible
 credentials, so tools like rclone or mc just work.
 
 **What works right now (v0.1.0):**
-- Go backend with full REST API + Swagger docs
+- Go backend with full REST API + API docs
 - Google Drive, Telegram, and S3-compatible backends
 - S3-compatible endpoint (AWS SigV4 auth)
 - React web UI for buckets, files, preview, and public share links
@@ -92,7 +93,7 @@ credentials, so tools like rclone or mc just work.
 - Early stage — no replication or erasure coding
 - Auth is functional, not production-hardened
 - Losing an upstream source = data loss for affected chunks
-- No rate limiting yet
+- Rate limiting exists, but it is in-memory and still basic
 
 This is aimed at homelab/self-hosting experimentation, not production
 workloads. If you're interested in the approach or want to contribute, the
@@ -117,18 +118,18 @@ single object store with an S3-compatible interface.
 **How it works:**
 1. Register storage sources (Google Drive, Telegram bots, S3-compatible services)
 2. Create a bucket backed by your chosen sources
-3. Upload files — SFree chunks and distributes them round-robin
-4. Download files — SFree reassembles from the chunk manifest
+3. Upload files through REST, the web UI, or the S3-compatible endpoint
+4. SFree chunks, distributes, and reassembles objects from the saved manifest
 5. Use any S3 SDK/tool via auto-generated per-bucket credentials
 
 **Tech stack:** Go 1.24, MongoDB, React 19, Docker Compose, Woodpecker CI.
 
 This is early-stage software — no replication, no erasure coding, experimental.
-But the core loop works: chunk, distribute, reassemble, serve over S3. Plus
-public share links, GitHub OAuth, a CLI, and configurable distribution
-strategies shipped in v0.1.0.
+But the core loop works: chunk, distribute, reassemble, serve over S3, and apply
+basic request limits. Plus public share links, GitHub OAuth, a CLI, and
+configurable distribution strategies shipped in v0.1.0.
 
-Contributions welcome — the codebase is clean Go with Swagger docs and CI.
+Contributions welcome — the codebase is clean Go with API docs and CI.
 
 https://github.com/siberianbearofficial/sfree
 ```
@@ -166,6 +167,8 @@ configurable distribution strategies (round-robin or weighted).
 **Fair warnings:**
 - No chunk replication — if a source goes down, affected files are gone
 - Auth is functional but not production-hardened — run it behind a reverse proxy
+- Rate limiting is basic and in-memory, so keep normal proxy protections in
+  front of public deployments
 - This is experimental, not for irreplaceable data
 
 If you're into storage hacking or want to help add backends, check it out:
@@ -212,7 +215,7 @@ based on early reactions.
 - [x] Landing page merged and live
 - [x] Demo visuals (annotated screenshots) in README
 - [ ] README Quick Start verified end-to-end (fresh clone to running)
-- [ ] Swagger docs accessible and accurate
+- [ ] API docs accessible and accurate
 - [ ] Docker Compose brings up a working instance
 - [ ] GitHub repo has: description, topics, license badge, social preview image
 - [ ] GitHub topics set: `storage`, `s3`, `self-hosted`, `google-drive`,

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -37,7 +37,7 @@ api-1    | [GIN-debug] Listening and serving HTTP on :8080
 | ------------- | ----------------------------------------- |
 | Frontend      | http://localhost:3000                      |
 | REST API      | http://localhost:8080                      |
-| Swagger docs  | http://localhost:8080/swagger/index.html   |
+| API docs      | http://localhost:8080/api/docs             |
 | MinIO Console | http://localhost:9001                      |
 
 ## 2. Create a user
@@ -107,7 +107,7 @@ curl -s -X POST http://localhost:8080/api/v1/sources/s3 \
 Save the `id` — you need it to create a bucket.
 
 > **Other source types:** SFree also supports Google Drive and Telegram
-> sources. See the [API docs](http://localhost:8080/swagger/index.html) for
+> sources. See the [API docs](http://localhost:8080/api/docs) for
 > details.
 
 ## 4. Create a bucket


### PR DESCRIPTION
## Summary

- Update architecture docs for Basic Auth plus GitHub OAuth/cookie auth and current frontend API env/proxy behavior.
- Refresh launch copy so rate limiting is no longer listed as missing while keeping caveats conservative.
- Align contributor and quickstart API docs links with `/api/docs` and `/api/openapi.json`.

## Validation

- `git diff --check`
- `rg -n "No rate limiting yet|route-aware|webui/src/shared/api|swagger/index.html|Swagger docs|Swagger is served|/swagger" docs/architecture.md docs/launch-campaign.md CONTRIBUTING.md docs/quickstart.md` (no matches)

Closes THE-609.