### PR TITLE
THE-619: split webui CI validation

### DIFF
--- a/.woodpecker/webui.yml
+++ b/.woodpecker/webui.yml
@@ -13,12 +13,19 @@ when:
         - webui/**
 
 steps:
-  - name: validate and e2e
+  - name: validate
     image: node:20
     commands:
       - cd webui
       - npm ci --include=dev
       - npm run lint
+      - npm run build
+
+  - name: e2e tests
+    image: node:20
+    commands:
+      - cd webui
+      - npm ci --include=dev
       - npm run build
       - npx playwright install --with-deps chromium
       - npm run test:e2e

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -8,7 +8,7 @@ Actions workflows to this repository.
 | Pipeline | Paths | `pull_request` | `push` to `main` | Behavior |
 | --- | --- | --- | --- | --- |
 | `.woodpecker/api-go.yml` | `.woodpecker/api-go.yml`, `api-go/**` | Yes | Yes | Runs `golangci-lint run`, Go unit tests, and Python and Go E2E suites against the local S3-compatible MinIO source. Pushes to `main` also publish the backend image. |
-| `.woodpecker/webui.yml` | `.woodpecker/webui.yml`, `webui/**` | Yes | Yes | Runs frontend dependency install, lint, production build, and Chromium Playwright E2E validation with `npm run test:e2e`. Pushes to `main` also publish the frontend image. |
+| `.woodpecker/webui.yml` | `.woodpecker/webui.yml`, `webui/**` | Yes | Yes | Runs frontend dependency install, lint, and production build in `validate`, then runs Chromium Playwright E2E validation in `e2e tests`. Pushes to `main` also publish the frontend image. |
 | `.woodpecker/smoke.yml` | `.woodpecker/smoke.yml`, `docker-compose.yml`, `scripts/woodpecker-smoke.sh`, `api-go/**`, `webui/**` | Yes | Yes | Starts the root Compose stack in Woodpecker, creates a user and MinIO-backed source, creates a bucket, uploads and downloads a file with the CLI, and verifies S3-compatible credential download bytes. |
 
 ## Required Secrets

--- a/webui/e2e/buckets.spec.ts
+++ b/webui/e2e/buckets.spec.ts
@@ -41,7 +41,7 @@ test.describe("Bucket creation flow", () => {
     await mockGet(page, "/buckets", []);
     await page.goto("/buckets");
     await expect(
-      page.getByRole("heading", { name: "Buckets" }),
+      page.getByRole("heading", { name: /^Buckets$/, level: 1 }),
     ).toBeVisible();
     await expect(page.getByText("No buckets yet")).toBeVisible();
     await expect(


### PR DESCRIPTION
## Summary
- split the webui Woodpecker step into fast `validate` and separate `e2e tests` steps
- keep Playwright browser installation and `npm run test:e2e` in the CI-only E2E step
- align `docs/ci.md` with the final webui step names and responsibilities

## Validation
- `git diff --check -- .woodpecker/webui.yml docs/ci.md`
- reviewed `.woodpecker/webui.yml` diff manually
- did not run local Playwright, Docker, or browser installation; runtime validation must be observed in Woodpecker per THE-619
