### PR TITLE
THE-617 Validate source provider configs

### DIFF
--- a/api-go/internal/handlers/source.go
+++ b/api-go/internal/handlers/source.go
@@ -3,10 +3,12 @@ package handlers
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/example/sfree/api-go/internal/manager"
@@ -99,6 +101,11 @@ func CreateGDriveSource(repo *repository.SourceRepository) gin.HandlerFunc {
 			c.Status(http.StatusBadRequest)
 			return
 		}
+		if strings.TrimSpace(req.Key) == "" || !json.Valid([]byte(req.Key)) {
+			slog.WarnContext(c.Request.Context(), "create gdrive source: invalid credentials")
+			c.Status(http.StatusBadRequest)
+			return
+		}
 		saveSource(c, repo, repository.SourceTypeGDrive, req.Name, req.Key)
 	}
 }
@@ -123,7 +130,13 @@ func CreateTelegramSource(repo *repository.SourceRepository) gin.HandlerFunc {
 			c.Status(http.StatusBadRequest)
 			return
 		}
-		key, err := telegram.EncodeConfig(telegram.Config{Token: req.Token, ChatID: req.ChatID})
+		cfg, err := telegram.ValidateConfig(telegram.Config{Token: req.Token, ChatID: req.ChatID})
+		if err != nil {
+			slog.WarnContext(c.Request.Context(), "create telegram source: invalid config", slog.String("error", err.Error()))
+			c.Status(http.StatusBadRequest)
+			return
+		}
+		key, err := telegram.EncodeConfig(cfg)
 		if err != nil {
 			slog.ErrorContext(c.Request.Context(), "create telegram source: encode key", slog.String("error", err.Error()))
 			c.Status(http.StatusInternalServerError)
@@ -153,7 +166,7 @@ func CreateS3Source(repo *repository.SourceRepository) gin.HandlerFunc {
 			c.Status(http.StatusBadRequest)
 			return
 		}
-		key, err := s3compat.EncodeConfig(s3compat.Config{
+		cfg, err := s3compat.ValidateConfig(s3compat.Config{
 			Endpoint:     req.Endpoint,
 			Region:       req.Region,
 			Bucket:       req.Bucket,
@@ -161,6 +174,12 @@ func CreateS3Source(repo *repository.SourceRepository) gin.HandlerFunc {
 			SecretAccess: req.SecretAccessKey,
 			PathStyle:    req.PathStyle,
 		})
+		if err != nil {
+			slog.WarnContext(c.Request.Context(), "create s3 source: invalid config", slog.String("error", err.Error()))
+			c.Status(http.StatusBadRequest)
+			return
+		}
+		key, err := s3compat.EncodeConfig(cfg)
 		if err != nil {
 			slog.ErrorContext(c.Request.Context(), "create s3 source: encode key", slog.String("error", err.Error()))
 			c.Status(http.StatusInternalServerError)

--- a/api-go/internal/handlers/unit_test.go
+++ b/api-go/internal/handlers/unit_test.go
@@ -44,6 +44,22 @@ func TestCreateGDriveSourceMissingFields(t *testing.T) {
 	}
 }
 
+func TestCreateGDriveSourceMalformedKeyJSON(t *testing.T) {
+	t.Parallel()
+	r := gin.New()
+	r.POST("/sources/gdrive", CreateGDriveSource(nil))
+
+	body, _ := json.Marshal(map[string]string{"name": "gdrive", "key": "{"})
+	req, _ := http.NewRequest(http.MethodPost, "/sources/gdrive", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
 func TestCreateTelegramSourceMissingFields(t *testing.T) {
 	t.Parallel()
 	r := gin.New()
@@ -60,6 +76,38 @@ func TestCreateTelegramSourceMissingFields(t *testing.T) {
 	}
 }
 
+func TestCreateTelegramSourceRejectsBlankConfig(t *testing.T) {
+	t.Parallel()
+	r := gin.New()
+	r.POST("/sources/telegram", CreateTelegramSource(nil))
+
+	body, _ := json.Marshal(map[string]string{"name": "tg", "token": "   ", "chat_id": "123"})
+	req, _ := http.NewRequest(http.MethodPost, "/sources/telegram", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestCreateTelegramSourceValidConfigReachesPersistence(t *testing.T) {
+	t.Parallel()
+	r := gin.New()
+	r.POST("/sources/telegram", CreateTelegramSource(nil))
+
+	body, _ := json.Marshal(map[string]string{"name": "tg", "token": "token", "chat_id": "123"})
+	req, _ := http.NewRequest(http.MethodPost, "/sources/telegram", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d", w.Code)
+	}
+}
+
 func TestCreateS3SourceMissingFields(t *testing.T) {
 	t.Parallel()
 	r := gin.New()
@@ -73,6 +121,72 @@ func TestCreateS3SourceMissingFields(t *testing.T) {
 
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestCreateS3SourceRejectsMalformedEndpoint(t *testing.T) {
+	t.Parallel()
+	r := gin.New()
+	r.POST("/sources/s3", CreateS3Source(nil))
+
+	body, _ := json.Marshal(map[string]any{
+		"name":              "s3",
+		"endpoint":          "not a url",
+		"bucket":            "bucket",
+		"access_key_id":     "access",
+		"secret_access_key": "secret",
+	})
+	req, _ := http.NewRequest(http.MethodPost, "/sources/s3", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestCreateS3SourceRejectsBlankConfig(t *testing.T) {
+	t.Parallel()
+	r := gin.New()
+	r.POST("/sources/s3", CreateS3Source(nil))
+
+	body, _ := json.Marshal(map[string]any{
+		"name":              "s3",
+		"endpoint":          "https://s3.example.com",
+		"bucket":            "   ",
+		"access_key_id":     "access",
+		"secret_access_key": "secret",
+	})
+	req, _ := http.NewRequest(http.MethodPost, "/sources/s3", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestCreateS3SourceValidConfigReachesPersistence(t *testing.T) {
+	t.Parallel()
+	r := gin.New()
+	r.POST("/sources/s3", CreateS3Source(nil))
+
+	body, _ := json.Marshal(map[string]any{
+		"name":              "s3",
+		"endpoint":          "https://s3.example.com",
+		"bucket":            "bucket",
+		"access_key_id":     "access",
+		"secret_access_key": "secret",
+	})
+	req, _ := http.NewRequest(http.MethodPost, "/sources/s3", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d", w.Code)
 	}
 }
 

--- a/api-go/internal/s3compat/client.go
+++ b/api-go/internal/s3compat/client.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/url"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
@@ -46,8 +48,24 @@ func ParseConfig(raw string) (Config, error) {
 	if err := json.Unmarshal([]byte(raw), &cfg); err != nil {
 		return Config{}, err
 	}
+	return ValidateConfig(cfg)
+}
+
+func ValidateConfig(cfg Config) (Config, error) {
+	cfg.Endpoint = strings.TrimSpace(cfg.Endpoint)
+	cfg.Region = strings.TrimSpace(cfg.Region)
+	cfg.Bucket = strings.TrimSpace(cfg.Bucket)
+	cfg.AccessKeyID = strings.TrimSpace(cfg.AccessKeyID)
+	cfg.SecretAccess = strings.TrimSpace(cfg.SecretAccess)
 	if cfg.Endpoint == "" {
 		return Config{}, fmt.Errorf("s3 endpoint is required")
+	}
+	endpointURL, err := url.ParseRequestURI(cfg.Endpoint)
+	if err != nil || endpointURL.Scheme == "" || endpointURL.Host == "" {
+		return Config{}, fmt.Errorf("s3 endpoint must be a valid URL")
+	}
+	if endpointURL.Scheme != "http" && endpointURL.Scheme != "https" {
+		return Config{}, fmt.Errorf("s3 endpoint must use http or https")
 	}
 	if cfg.Bucket == "" {
 		return Config{}, fmt.Errorf("s3 bucket is required")

--- a/api-go/internal/s3compat/client_test.go
+++ b/api-go/internal/s3compat/client_test.go
@@ -28,6 +28,22 @@ func TestParseConfigSetsDefaultRegion(t *testing.T) {
 	}
 }
 
+func TestParseConfigRejectsMalformedEndpoint(t *testing.T) {
+	t.Parallel()
+	_, err := ParseConfig(`{"endpoint":"not a url","bucket":"b","access_key_id":"a","secret_access_key":"s"}`)
+	if err == nil {
+		t.Fatal("expected parse error")
+	}
+}
+
+func TestParseConfigRejectsBlankFields(t *testing.T) {
+	t.Parallel()
+	_, err := ParseConfig(`{"endpoint":"http://localhost:9000","bucket":" ","access_key_id":"a","secret_access_key":"s"}`)
+	if err == nil {
+		t.Fatal("expected parse error")
+	}
+}
+
 func TestListObjectsFollowsPagination(t *testing.T) {
 	t.Parallel()
 	cli := &Client{cfg: Config{Bucket: "bucket"}}

--- a/api-go/internal/telegram/client.go
+++ b/api-go/internal/telegram/client.go
@@ -33,11 +33,9 @@ func NewClient(cfg Config) (*Client, error) {
 }
 
 func NewClientWithBaseURL(cfg Config, baseURL string) (*Client, error) {
-	if strings.TrimSpace(cfg.Token) == "" {
-		return nil, fmt.Errorf("telegram token is required")
-	}
-	if strings.TrimSpace(cfg.ChatID) == "" {
-		return nil, fmt.Errorf("telegram chat_id is required")
+	cfg, err := ValidateConfig(cfg)
+	if err != nil {
+		return nil, err
 	}
 	base := strings.TrimRight(baseURL, "/")
 	return &Client{
@@ -46,6 +44,18 @@ func NewClientWithBaseURL(cfg Config, baseURL string) (*Client, error) {
 		fileBase:   fmt.Sprintf("%s/file/bot%s", base, cfg.Token),
 		httpClient: http.DefaultClient,
 	}, nil
+}
+
+func ValidateConfig(cfg Config) (Config, error) {
+	cfg.Token = strings.TrimSpace(cfg.Token)
+	cfg.ChatID = strings.TrimSpace(cfg.ChatID)
+	if strings.TrimSpace(cfg.Token) == "" {
+		return Config{}, fmt.Errorf("telegram token is required")
+	}
+	if strings.TrimSpace(cfg.ChatID) == "" {
+		return Config{}, fmt.Errorf("telegram chat_id is required")
+	}
+	return cfg, nil
 }
 
 func ParseConfig(raw string) (Config, error) {

--- a/api-go/internal/telegram/client_test.go
+++ b/api-go/internal/telegram/client_test.go
@@ -106,6 +106,27 @@ func TestConfigCodec(t *testing.T) {
 	}
 }
 
+func TestValidateConfigRejectsBlankFields(t *testing.T) {
+	t.Parallel()
+	if _, err := ValidateConfig(Config{Token: " ", ChatID: "c"}); err == nil {
+		t.Fatal("expected token error")
+	}
+	if _, err := ValidateConfig(Config{Token: "t", ChatID: " "}); err == nil {
+		t.Fatal("expected chat_id error")
+	}
+}
+
+func TestValidateConfigTrimsFields(t *testing.T) {
+	t.Parallel()
+	cfg, err := ValidateConfig(Config{Token: " token ", ChatID: " 123 "})
+	if err != nil {
+		t.Fatalf("validate config: %v", err)
+	}
+	if cfg.Token != "token" || cfg.ChatID != "123" {
+		t.Fatalf("unexpected config: %+v", cfg)
+	}
+}
+
 func TestCheckChat(t *testing.T) {
 	t.Parallel()
 	const (


### PR DESCRIPTION
## Summary
- validate Google Drive credential JSON syntactically before persistence
- validate and normalize Telegram token/chat ID before encoding source config
- validate and normalize S3-compatible config, including endpoint URL shape and default region
- add focused handler/config tests for invalid and valid Telegram/S3 payloads

## Tests
- `go test ./internal/handlers ./internal/s3compat ./internal/telegram`

Woodpecker should run the broader backend validation in CI.