### PR TITLE
Handle webui download failures

### DIFF
--- a/webui/e2e/files.spec.ts
+++ b/webui/e2e/files.spec.ts
@@ -126,6 +126,34 @@ test.describe("File listing and download", () => {
     await expect.poll(() => downloadCalled).toBe(true);
   });
 
+  test("failed bucket download shows an error toast", async ({ page }) => {
+    await injectAuth(page);
+    await mockGet(page, "/buckets", [MOCK_BUCKET]);
+    await mockGet(page, "/buckets/bkt-1/files", [MOCK_FILES[0]]);
+
+    await page.route("**/api/v1/buckets/bkt-1/files/file-1/download", async (route) => {
+      await route.fulfill({
+        status: 500,
+        contentType: "application/json",
+        body: JSON.stringify({error: "download unavailable"}),
+      });
+    });
+
+    await page.goto("/buckets/bkt-1");
+    await expect(page.getByText("report.pdf")).toBeVisible();
+
+    const firstRow = page.locator("tbody tr").first();
+    const actionCell = firstRow.locator("td").last();
+    const actionButtons = actionCell.getByRole("button");
+    const actionButtonCount = await actionButtons.count();
+    await actionButtons.nth(actionButtonCount === 1 ? 0 : 1).click();
+
+    await expect(page.getByText("Something went wrong")).toBeVisible();
+    await expect(
+      page.getByText("The server returned an error. Try again later."),
+    ).toBeVisible();
+  });
+
   test("back button is present and navigates back", async ({ page }) => {
     await injectAuth(page);
     await mockGet(page, "/buckets", [MOCK_BUCKET]);

--- a/webui/src/features/bucket/ui/file-preview-modal.tsx
+++ b/webui/src/features/bucket/ui/file-preview-modal.tsx
@@ -11,6 +11,7 @@ import {
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { FileInfo } from "../../../shared/api/buckets";
 import { fetchFileBlob, downloadFile } from "../../../shared/api/buckets";
+import { showErrorToast } from "../../../shared/api/error";
 import { DownloadIcon } from "../../../shared/icons";
 import { formatSize } from "../../../shared/lib/format";
 
@@ -39,6 +40,15 @@ export function FilePreviewModal({ isOpen, onClose, file, bucketId }: Props) {
   const ext = file ? getExtension(file.name) : "";
   const isImage = IMAGE_EXTENSIONS.has(ext);
   const isText = TEXT_EXTENSIONS.has(ext);
+
+  async function handleDownload() {
+    if (!file) return;
+    try {
+      await downloadFile(bucketId, file);
+    } catch (err) {
+      showErrorToast(err);
+    }
+  }
 
   const loadPreview = useCallback(async () => {
     if (!file) return;
@@ -137,7 +147,7 @@ export function FilePreviewModal({ isOpen, onClose, file, bucketId }: Props) {
             <Button
               color="primary"
               startContent={<DownloadIcon className="w-4 h-4" />}
-              onPress={() => downloadFile(bucketId, file)}
+              onPress={handleDownload}
             >
               Download
             </Button>

--- a/webui/src/pages/bucket/ui/bucket-page.tsx
+++ b/webui/src/pages/bucket/ui/bucket-page.tsx
@@ -99,6 +99,15 @@ export function BucketPage() {
     setShareFile(file);
   }
 
+  async function handleDownload(file: FileInfo) {
+    if (!id) return;
+    try {
+      await downloadFile(id, file);
+    } catch (err) {
+      showErrorToast(err);
+    }
+  }
+
   if (isLoading) {
     return (
       <div className="p-8 flex items-center justify-center min-h-[200px]">
@@ -223,7 +232,7 @@ export function BucketPage() {
                       <Button
                         isIconOnly
                         variant="light"
-                        onPress={() => downloadFile(id!, f)}
+                        onPress={() => handleDownload(f)}
                       >
                         <DownloadIcon className="w-5 h-5" />
                       </Button>

--- a/webui/src/pages/source/ui/source-page.tsx
+++ b/webui/src/pages/source/ui/source-page.tsx
@@ -2,7 +2,8 @@ import {Button, CircularProgress, Spinner} from "@heroui/react";
 import {useCallback, useEffect, useState} from "react";
 import {useNavigate, useParams} from "react-router-dom";
 import {downloadFile, getSourceInfo} from "../../../shared/api/sources";
-import type {SourceInfo} from "../../../shared/api/sources";
+import type {SourceFile, SourceInfo} from "../../../shared/api/sources";
+import {showErrorToast} from "../../../shared/api/error";
 import {SourceTypeChip} from "../../../entities/source";
 import {DownloadIcon} from "../../../shared/icons";
 import {ArrowLeftIcon} from "@heroui/shared-icons";
@@ -28,6 +29,15 @@ export function SourcePage() {
   useEffect(() => {
     load();
   }, [load]);
+
+  async function handleDownload(file: SourceFile) {
+    if (!id) return;
+    try {
+      await downloadFile(id, file);
+    } catch (err) {
+      showErrorToast(err);
+    }
+  }
 
   if (isLoading) {
     return (
@@ -118,7 +128,7 @@ export function SourcePage() {
                     <Button
                       isIconOnly
                       variant="light"
-                      onPress={() => downloadFile(id!, f)}
+                      onPress={() => handleDownload(f)}
                     >
                       <DownloadIcon className="w-5 h-5" />
                     </Button>


### PR DESCRIPTION
## Summary
- catch bucket row download failures and show the shared error toast
- catch preview modal and source download failures with the same toast behavior
- add a focused Playwright regression for a failed bucket download toast

## Validation
- `git diff --check`
- Not run locally per task instruction: Playwright/build/lint are left for Woodpecker validation.