### PR TITLE
THE-625: Refresh QA coverage audit

### DIFF
--- a/docs/qa-coverage-audit-2026-04-22.md
+++ b/docs/qa-coverage-audit-2026-04-22.md
@@ -2,11 +2,14 @@
 
 Date: 2026-04-22
 
-Scope: `api-go` automated tests, Woodpecker backend validation, recent `origin/main` changes, and open backend PRs as of 2026-04-22 06:20 UTC.
+Scope: `api-go` automated tests, Woodpecker validation, recent `origin/main` changes, and open backend/web UI PRs as of 2026-04-22 07:17 UTC.
 
 ## Recent Inputs
 
 - `origin/main` now includes focused S3 range GET, ListObjectsV2 pagination, checksum verification, multipart checksum preservation, atomic multipart part replacement cleanup, one-file-per-bucket-object enforcement, S3 GET stream-failure semantics, DeleteObjects support, CopyObject support, SDK CopyObject and HEAD compatibility coverage, bucket grant route scoping, S3 helper coverage, multipart malformed error-shape coverage, SigV4 redaction coverage, SigV4 payload-hash bounds, upload-failure cleanup coverage, short-read upload chunking coverage, weighted source validation, bucket-content cleanup on delete, S3 missing-object and cross-bucket credential-isolation E2E coverage, unsupported CopyObject metadata-directive XML error coverage, manager-level S3 object mutation coverage, REST lifecycle routing through the shared object service, REST/share download preflight coverage, S3 bucket deletion cleanup E2E coverage, deterministic S3 Go E2E readiness/expired-presign coverage, OpenAPI docs route coverage, Woodpecker image-pinning, lint enforcement, Woodpecker E2E image-pull speedups, and the unit-only `api-go` Makefile `test` target.
+- Open PR [#262](https://github.com/siberianbearofficial/sfree/pull/262) handles web UI download failures and adds file-page E2E coverage for failed downloads from bucket/source views.
+- Open PR [#261](https://github.com/siberianbearofficial/sfree/pull/261) validates source provider configs and adds handler/unit client coverage for S3 and Telegram configuration paths.
+- Open PR [#260](https://github.com/siberianbearofficial/sfree/pull/260) splits web UI validation in Woodpecker so lint/build and Playwright can report as separate gates.
 - Merged commit `350dd9c` (`THE-564`) replaces fixed sleeps in S3 Go E2E readiness and expired-presign coverage with bounded Mongo readiness retry and deterministic expired presign signing.
 - Merged commit `a29ffd9` (`THE-561`) adds Go S3 E2E coverage proving unsupported CopyObject `x-amz-metadata-directive: REPLACE` returns a stable XML `NotImplemented` error.
 - Merged PR [#238](https://github.com/siberianbearofficial/sfree/pull/238) routes REST file lifecycle mutations through the shared object service and adds manager coverage for REST delete cleanup, bucket-content cleanup, and cleanup-failure propagation.
@@ -46,7 +49,7 @@ Scope: `api-go` automated tests, Woodpecker backend validation, recent `origin/m
 - Open PR [#231](https://github.com/siberianbearofficial/sfree/pull/231) implements minimal S3 object metadata persistence and adds handler, manager, repository, Go S3 E2E, and Python SDK E2E coverage for Content-Type and user metadata.
 - Open PR [#241](https://github.com/siberianbearofficial/sfree/pull/241) keeps wrapped download contexts alive until response body close and adds unit coverage for successful stream reads before close plus timeout-before-body behavior.
 - Open PR [#254](https://github.com/siberianbearofficial/sfree/pull/254) drops returned upload names on wrapped upload errors and adds `TestWrapperUploadErrorDropsReturnedName`.
-- Open PR [#253](https://github.com/siberianbearofficial/sfree/pull/253) adds dependency audit gates with backend and web UI Woodpecker checks pending.
+- Open PR [#253](https://github.com/siberianbearofficial/sfree/pull/253) adds dependency audit gates for backend and web UI Woodpecker validation.
 - Open PR [#258](https://github.com/siberianbearofficial/sfree/pull/258) preserves multipart abort cleanup failures; Woodpecker API and smoke checks were pending during this refresh.
 - Open PR [#257](https://github.com/siberianbearofficial/sfree/pull/257) adds focused CLI helper coverage for local command helpers; Woodpecker API and smoke checks were pending during this refresh.
 - Open PR [#252](https://github.com/siberianbearofficial/sfree/pull/252) proxies share downloads through the frontend origin with web UI and smoke checks pending.
@@ -75,29 +78,35 @@ Scope: `api-go` automated tests, Woodpecker backend validation, recent `origin/m
 | Source/backend failure cases | Manager failover, resilience wrappers, upload retry body replay, uploaded-chunk cleanup after later failures, S3 GET stream-failure handler behavior, REST/share download preflight behavior, and source health paths have tests. Open PR #241 adds direct download-context lifetime regressions. Open PR #245 adds missing-source repository and manager coverage. | Covered for upload/retry/cleanup logic, pre-commit S3/REST/shared download failure behavior, and source health; direct source download lifetime and missing-source handler status/error-shape coverage remain open. |
 | Critical S3-compatible API behavior | Go E2E covers source/bucket creation, object lifecycle, auth failure, presigned GET/PUT, HEAD, expired presign, range GET, ListObjectsV2 prefix/delimiter/pagination, DeleteObjects, CopyObject, unsupported CopyObject metadata-directive XML errors, missing-object XML errors, cross-bucket credential isolation, multipart lifecycle, malformed multipart errors, and DeleteObjects malformed/oversized error codes. PR #231 adds metadata-header E2E coverage. Python SDK E2E covers ListObjectsV2, range GET, DeleteObjects, CopyObject, multipart, HEAD, and metadata once PR #231 merges. | Covered for currently implemented core operations once PR #231 merges; still weak for broader unsupported/malformed request combinations. |
 | Recent bug regressions | Recent checksum, ListObjectsV2, range GET, multipart checksum propagation, DeleteObjects, CopyObject, S3 GET stream-failure, REST/share download preflight, SigV4 body-hash buffering, SigV4 payload-hash bounds, file-manager cache, upload retry body replay, upload failure cleanup, source-client factory, one-file-per-object enforcement, bucket grant route scoping, bucket grant lookup errors, short-read chunking, download context lifetime, multipart replacement atomicity, bucket delete cleanup, REST lifecycle cleanup routing, filename search, route-aware rate limiting, source health, and multipart replacement cleanup-order work have focused tests or open test branches. | Covered for latest backend regressions once open branches merge. |
-| Recently changed code paths | Backend CI runs lint, Go unit tests, generated docs freshness, Python E2E, and Go E2E through Woodpecker for `api-go/**`; `make test` is unit-only on `origin/main`, keeping CPU-heavy integration/E2E work in CI. THE-564's S3 E2E readiness/presign timing paths, THE-561's CopyObject unsupported metadata-directive path, PR #238's REST lifecycle routing, PR #237's S3 bucket deletion cleanup, PR #220's download preflight paths, PR #234's source health paths, PR #222's OpenAPI freshness check, PR #233's filename search paths, PR #228's S3 missing-object/auth paths, THE-484's bucket cleanup paths, THE-552's weighted validation paths, and THE-542's SigV4 body-hash paths are already covered on main. | Covered by CI routing once open branches merge. |
+| Recently changed code paths | Backend CI runs lint, Go unit tests, generated docs freshness, Python E2E, and Go E2E through Woodpecker for `api-go/**`; `make test` is unit-only on `origin/main`, keeping CPU-heavy integration/E2E work in CI. Web UI CI runs lint/build/Playwright through Woodpecker for `webui/**`, with PR #260 proposing split gates. THE-564's S3 E2E readiness/presign timing paths, THE-561's CopyObject unsupported metadata-directive path, PR #238's REST lifecycle routing, PR #237's S3 bucket deletion cleanup, PR #220's download preflight paths, PR #234's source health paths, PR #222's OpenAPI freshness check, PR #233's filename search paths, PR #228's S3 missing-object/auth paths, THE-484's bucket cleanup paths, THE-552's weighted validation paths, and THE-542's SigV4 body-hash paths are already covered on main. | Covered by CI routing once open branches merge; web UI check observability improves if PR #260 lands. |
 
 ## Prioritized Missing Tests
 
 1. Add public handler regressions for missing bucket-source upload failures before PR #245 merges.
    Acceptance: REST upload, S3 PutObject, and S3 UploadPart requests against a bucket whose `source_ids` include a deleted/missing source return stable client errors (`400`/S3 XML `InvalidRequest`) without attempting chunk upload, and repository/manager missing-source errors do not leak as generic `500` responses.
 
-2. Expand malformed/unsupported request error-shape coverage at SDK and raw HTTP levels.
+2. Add source provider config validation matrix coverage around PR #261 before it merges.
+   Acceptance: S3 config validation rejects missing endpoint, missing credentials, and invalid bucket/region combinations with stable `400` responses; Telegram config validation rejects missing bot tokens/chat IDs; valid configs for each provider remain accepted. Tests should live in existing `api-go/internal/handlers` and provider-client unit suites.
+
+3. Expand malformed/unsupported request error-shape coverage at SDK and raw HTTP levels.
    Acceptance: remaining missing-bucket, missing-upload, invalid-range, unsupported-operation, and malformed query combinations return XML S3 errors with stable status codes instead of generic JSON or empty responses.
 
-3. Add focused advanced metadata compatibility coverage only when product support expands beyond PR #231's minimal scope.
+4. Add focused advanced metadata compatibility coverage only when product support expands beyond PR #231's minimal scope.
    Acceptance: supported checksum headers, object tags, response header overrides, or `x-amz-metadata-directive: REPLACE` each get one SDK or raw-HTTP regression when implemented; unsupported metadata features return stable S3 XML errors.
 
-4. Add SDK-level presigned URL coverage if the Python SDK compatibility suite is expected to be the long-term compatibility matrix rather than a focused SDK smoke branch.
+5. Add SDK-level presigned URL coverage if the Python SDK compatibility suite is expected to be the long-term compatibility matrix rather than a focused SDK smoke branch.
    Acceptance: aiobotocore-generated presigned GET/PUT URLs work without client-specific signing hacks and return stable S3-compatible responses.
 
-5. Keep one public-route overwrite/delete regression for every user-visible cleanup path that manager-only coverage cannot prove.
+6. Keep one public-route overwrite/delete regression for every user-visible cleanup path that manager-only coverage cannot prove.
    Acceptance: repeated S3 PUT, REST upload over an existing file, CopyObject over an existing destination, CompleteMultipartUpload over an existing key, and bucket delete leave exactly the expected file/multipart records, preserve retrievable latest content where applicable, and clean only chunks no longer referenced by any file or multipart upload.
 
-6. Add a lightweight permission regression for grant listing only if product requirements expect route-bucket scoping symmetry beyond update/delete.
+7. Add web UI failure-state coverage for download failures not covered by PR #262.
+   Acceptance: bucket-file preview/download and source-file download failures show actionable errors without navigating away, and success paths still close or retain UI state according to existing behavior. Keep this in `webui/e2e/files.spec.ts` or the closest existing Playwright suite and run it only through Woodpecker.
+
+8. Add a lightweight permission regression for grant listing only if product requirements expect route-bucket scoping symmetry beyond update/delete.
    Acceptance: listing grants for bucket A never exposes grants from bucket B even when grant IDs or users overlap in setup fixtures.
 
-7. Add a REST bucket-delete integration regression if users depend on REST route semantics beyond the S3 bucket deletion path now covered by PR #237.
+9. Add a REST bucket-delete integration regression if users depend on REST route semantics beyond the S3 bucket deletion path now covered by PR #237.
    Acceptance: deleting a bucket with objects and incomplete multipart uploads through the REST route returns the expected HTTP status, removes the bucket, and leaves no retrievable object or multipart residue through repository-backed checks.
 
 ## Work Completed In This Audit
@@ -156,8 +165,11 @@ Scope: `api-go` automated tests, Woodpecker backend validation, recent `origin/m
 - Confirmed open PR #254 adds `TestWrapperUploadErrorDropsReturnedName` for the upload-name-on-error regression.
 - Confirmed open PR #257 adds CLI helper unit coverage; API and smoke Woodpecker checks were pending during this refresh.
 - Confirmed open PR #258 adds multipart abort cleanup-failure preservation coverage; API and smoke Woodpecker checks were pending during this refresh.
+- Confirmed open PR #260 splits web UI Woodpecker validation into separate lint/build and Playwright gates, improving failure localization without changing the test surface.
+- Confirmed open PR #261 adds source provider config validation coverage for handler/client paths; the main remaining risk is matrix completeness around invalid provider-specific fields.
+- Confirmed open PR #262 adds web UI E2E coverage for download failure toasts in bucket/source download flows.
 - Reviewed `.woodpecker/api-go.yml`; backend PRs and pushes to main run lint, Go unit tests, generated docs freshness, and S3-backed Python and Go E2E suites in Woodpecker.
-- Reviewed open PR check state with `gh pr list`; current API/smoke/web UI Woodpecker checks were pending during this refresh.
+- Reviewed open PR check state with `gh pr list` and targeted `gh pr view` calls; check rollups were not conclusively named in this environment, so merge readiness still depends on Woodpecker results in the PR UI.
 
 ## Verification
 


### PR DESCRIPTION
## Summary
- refresh the 2026-04-22 QA coverage audit with current open PR inputs
- add concrete missing-test items for source config validation and web UI download failure states
- note that local CPU-heavy validation was intentionally skipped per QA execution policy

## Verification
- git diff --check
- Not run: local Go/Docker/Playwright test suites; these belong in Woodpecker.