### PR TITLE
THE-628 Require bucket check before aborting multipart uploads

### DIFF
--- a/api-go/internal/handlers/s3_multipart.go
+++ b/api-go/internal/handlers/s3_multipart.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/xml"
 	"errors"
 	"fmt"
@@ -78,6 +79,11 @@ type partXML struct {
 	LastModified string `xml:"LastModified"`
 }
 
+type multipartUploadAbortStore interface {
+	GetByUploadID(ctx context.Context, uploadID string) (*repository.MultipartUpload, error)
+	Delete(ctx context.Context, uploadID string) error
+}
+
 // PostObject dispatches POST requests on S3 object paths.
 // ?uploads → CreateMultipartUpload
 // ?uploadId=X → CompleteMultipartUpload
@@ -146,7 +152,7 @@ func DeleteObjectOrAbort(bucketRepo *repository.BucketRepository, sourceRepo *re
 	return func(c *gin.Context) {
 		if mpRepo != nil {
 			if _, ok := c.GetQuery("uploadId"); ok {
-				abortMultipartUpload(c, sourceRepo, mpRepo)
+				abortMultipartUpload(c, bucketRepo, sourceRepo, mpRepo)
 				return
 			}
 		}
@@ -367,7 +373,7 @@ func completedMultipartChunks(parts []completionPart, partMap map[int]repository
 	return allChunks
 }
 
-func abortMultipartUpload(c *gin.Context, sourceRepo *repository.SourceRepository, mpRepo *repository.MultipartUploadRepository) {
+func abortMultipartUpload(c *gin.Context, bucketRepo objectBucketReader, sourceRepo *repository.SourceRepository, mpRepo multipartUploadAbortStore) {
 	ctx := c.Request.Context()
 	uploadID := c.Query("uploadId")
 
@@ -382,7 +388,15 @@ func abortMultipartUpload(c *gin.Context, sourceRepo *repository.SourceRepositor
 		return
 	}
 
-	// Delete all part chunks from sources.
+	bucketDoc, ok := lookupBucket(c, bucketRepo)
+	if !ok {
+		return
+	}
+	if mu.BucketID != bucketDoc.ID {
+		writeS3Error(c, http.StatusNotFound, "NoSuchUpload", "")
+		return
+	}
+
 	for _, p := range mu.Parts {
 		if delErr := manager.DeleteFileChunks(ctx, sourceRepo, p.Chunks); delErr != nil {
 			slog.WarnContext(ctx, "abort multipart: delete part chunks",

--- a/api-go/internal/handlers/s3_multipart_test.go
+++ b/api-go/internal/handlers/s3_multipart_test.go
@@ -2,15 +2,38 @@ package handlers
 
 import (
 	"bytes"
+	"context"
 	"encoding/xml"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/example/sfree/api-go/internal/repository"
 	"github.com/gin-gonic/gin"
 	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
 )
+
+type fakeAbortMultipartStore struct {
+	upload        *repository.MultipartUpload
+	getErr        error
+	deleteCalls   int
+	deletedUpload string
+}
+
+func (s *fakeAbortMultipartStore) GetByUploadID(_ context.Context, _ string) (*repository.MultipartUpload, error) {
+	if s.getErr != nil {
+		return nil, s.getErr
+	}
+	return s.upload, nil
+}
+
+func (s *fakeAbortMultipartStore) Delete(_ context.Context, uploadID string) error {
+	s.deleteCalls++
+	s.deletedUpload = uploadID
+	return nil
+}
 
 func TestPostObjectNilRepos(t *testing.T) {
 	t.Parallel()
@@ -287,5 +310,78 @@ func TestListPartsResultXML(t *testing.T) {
 	}
 	if !bytes.Contains(data, []byte("<PartNumber>2</PartNumber>")) {
 		t.Fatalf("missing part 2: %s", s)
+	}
+}
+
+func TestAbortMultipartUploadRejectsOtherBucketUpload(t *testing.T) {
+	t.Parallel()
+
+	routeBucketID := primitive.NewObjectID()
+	otherBucketID := primitive.NewObjectID()
+	uploadID := primitive.NewObjectID().Hex()
+	store := &fakeAbortMultipartStore{
+		upload: &repository.MultipartUpload{
+			BucketID:  otherBucketID,
+			ObjectKey: "object.txt",
+			UploadID:  uploadID,
+			Parts: []repository.UploadPart{
+				{
+					PartNumber: 1,
+					Chunks: []repository.FileChunk{
+						{SourceID: primitive.NewObjectID(), Name: "part-1", Size: 5},
+					},
+				},
+			},
+		},
+	}
+
+	c, w := testS3GinContext("/api/s3/route-bucket/object.txt?uploadId=" + uploadID)
+	c.Request.Method = http.MethodDelete
+	c.Params = gin.Params{
+		{Key: "bucket", Value: "route-bucket"},
+		{Key: "object", Value: "/object.txt"},
+	}
+	c.Set("accessKey", "route-access")
+
+	abortMultipartUpload(c, fakeObjectBucketReader{
+		bucket: &repository.Bucket{
+			ID:        routeBucketID,
+			Key:       "route-bucket",
+			AccessKey: "route-access",
+		},
+	}, &repository.SourceRepository{}, store)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+	if body := w.Body.String(); !strings.Contains(body, "<Code>NoSuchUpload</Code>") {
+		t.Fatalf("unexpected body: %s", body)
+	}
+	if store.deleteCalls != 0 {
+		t.Fatalf("expected upload metadata to remain, delete called %d times for %q", store.deleteCalls, store.deletedUpload)
+	}
+}
+
+func TestAbortMultipartUploadUnknownUploadKeepsNoSuchUpload(t *testing.T) {
+	t.Parallel()
+
+	store := &fakeAbortMultipartStore{getErr: mongo.ErrNoDocuments}
+	c, w := testS3GinContext("/api/s3/route-bucket/object.txt?uploadId=missing")
+	c.Request.Method = http.MethodDelete
+	c.Params = gin.Params{
+		{Key: "bucket", Value: "route-bucket"},
+		{Key: "object", Value: "/object.txt"},
+	}
+
+	abortMultipartUpload(c, fakeObjectBucketReader{}, &repository.SourceRepository{}, store)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+	if body := w.Body.String(); !strings.Contains(body, "<Code>NoSuchUpload</Code>") {
+		t.Fatalf("unexpected body: %s", body)
+	}
+	if store.deleteCalls != 0 {
+		t.Fatalf("expected no delete calls, got %d", store.deleteCalls)
 	}
 }


### PR DESCRIPTION
## Summary
- validate the signed route bucket before aborting an S3 multipart upload
- return `NoSuchUpload` without deleting chunks or metadata when the upload belongs to another bucket
- add focused handler tests for cross-bucket abort denial and unknown upload behavior

## Tests
- `go test ./internal/handlers -run 'TestAbortMultipartUpload|TestDeleteObjectOrAbortNilMpRepoDelegatesToDelete'`
- `go run github.com/swaggo/swag/cmd/swag@v1.16.4 init --generalInfo cmd/server/main.go --dir . --output internal/docs --outputTypes go --parseInternal --quiet && git diff --exit-code -- internal/docs/docs.go`

Woodpecker should run the broader lint, unit, docs, and CI-only E2E checks.