### PR TITLE
THE-637 Regenerate docs for source health

### DIFF
--- a/api-go/internal/docs/docs.go
+++ b/api-go/internal/docs/docs.go
@@ -2011,13 +2011,16 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "quota_free_bytes": {
-                    "type": "integer"
+                    "type": "integer",
+                    "x-nullable": true
                 },
                 "quota_total_bytes": {
-                    "type": "integer"
+                    "type": "integer",
+                    "x-nullable": true
                 },
                 "quota_used_bytes": {
-                    "type": "integer"
+                    "type": "integer",
+                    "x-nullable": true
                 },
                 "reason_code": {
                     "type": "string"

--- a/api-go/internal/handlers/source.go
+++ b/api-go/internal/handlers/source.go
@@ -70,9 +70,9 @@ type sourceHealthResponse struct {
 	LatencyMS       int64     `json:"latency_ms"`
 	ReasonCode      string    `json:"reason_code"`
 	Message         string    `json:"message"`
-	QuotaTotalBytes *int64    `json:"quota_total_bytes"`
-	QuotaUsedBytes  *int64    `json:"quota_used_bytes"`
-	QuotaFreeBytes  *int64    `json:"quota_free_bytes"`
+	QuotaTotalBytes *int64    `json:"quota_total_bytes" extensions:"x-nullable"`
+	QuotaUsedBytes  *int64    `json:"quota_used_bytes" extensions:"x-nullable"`
+	QuotaFreeBytes  *int64    `json:"quota_free_bytes" extensions:"x-nullable"`
 }
 
 type sourceGetter interface {


### PR DESCRIPTION
## Summary
- Rebased onto current `main`; the generated `/api/v1/sources/{id}/health` docs artifact is already present upstream.
- Keep the remaining source-health schema fix: mark nullable quota byte fields with `x-nullable: true` in the Swagger 2 schema and source struct tags.

## Validation
- Not run locally due resource policy: `make docs-check`, `make test`, `golangci-lint run`.
- Woodpecker pipeline 494 should validate docs freshness and affected api-go checks for commit `d27a32c`.

Closes THE-637.