### PR TITLE
THE-642 Reject malformed share-link bodies

### DIFF
--- a/api-go/internal/docs/docs.go
+++ b/api-go/internal/docs/docs.go
@@ -1470,6 +1470,61 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/sources/{id}/health": {
+            "get": {
+                "security": [
+                    {
+                        "BasicAuth": []
+                    }
+                ],
+                "description": "Runs a lightweight on-demand provider probe. Google Drive returns native quota when available; S3-compatible and Telegram quota fields are null because no cheap native capacity is available.",
+                "tags": [
+                    "sources"
+                ],
+                "summary": "Check source health",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Source ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.sourceHealthResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/sources/{id}/info": {
             "get": {
                 "security": [
@@ -1936,6 +1991,41 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "url": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.sourceHealthResponse": {
+            "type": "object",
+            "properties": {
+                "checked_at": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "latency_ms": {
+                    "type": "integer"
+                },
+                "message": {
+                    "type": "string"
+                },
+                "quota_free_bytes": {
+                    "type": "integer"
+                },
+                "quota_total_bytes": {
+                    "type": "integer"
+                },
+                "quota_used_bytes": {
+                    "type": "integer"
+                },
+                "reason_code": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "type": {
                     "type": "string"
                 }
             }

--- a/api-go/internal/handlers/sharelink.go
+++ b/api-go/internal/handlers/sharelink.go
@@ -1,7 +1,11 @@
 package handlers
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"time"
@@ -16,6 +20,10 @@ const shareTokenLength = 32
 
 type createShareRequest struct {
 	ExpiresIn *int `json:"expires_in"` // seconds until expiry, optional
+}
+
+type shareLinkCreator interface {
+	Create(ctx context.Context, sl repository.ShareLink) (*repository.ShareLink, error)
 }
 
 type shareLinkResponse struct {
@@ -51,8 +59,24 @@ func CreateShareLink(bucketRepo *repository.BucketRepository, fileRepo *reposito
 			c.Status(http.StatusServiceUnavailable)
 			return
 		}
+		var grantReader bucketAccessGrantReader
+		if grantRepo != nil {
+			grantReader = grantRepo
+		}
+		createShareLink(bucketRepo, fileRepo, shareLinkRepo, grantReader)(c)
+	}
+}
 
-		acc := requireBucketAccess(c, bucketRepo, grantRepo, repository.RoleEditor)
+func createShareLink(bucketRepo bucketAccessBucketReader, fileRepo fileByIDReader, shareLinkRepo shareLinkCreator, grantRepo bucketAccessGrantReader) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		ctx := c.Request.Context()
+		if bucketRepo == nil || fileRepo == nil || shareLinkRepo == nil {
+			slog.ErrorContext(ctx, "create share link: repository is nil")
+			c.Status(http.StatusServiceUnavailable)
+			return
+		}
+
+		acc := requireBucketAccessFor(c, bucketRepo, grantRepo, repository.RoleEditor)
 		if acc == nil {
 			return
 		}
@@ -84,8 +108,10 @@ func CreateShareLink(bucketRepo *repository.BucketRepository, fileRepo *reposito
 		}
 
 		var req createShareRequest
-		// Body is optional; ignore bind errors for empty body.
-		_ = c.ShouldBindJSON(&req)
+		if err := decodeOptionalCreateShareRequest(c, &req); err != nil {
+			c.Status(http.StatusBadRequest)
+			return
+		}
 
 		token, err := cryptoutil.RandomString(shareTokenLength)
 		if err != nil {
@@ -124,6 +150,18 @@ func CreateShareLink(bucketRepo *repository.BucketRepository, fileRepo *reposito
 			CreatedAt: created.CreatedAt,
 		})
 	}
+}
+
+func decodeOptionalCreateShareRequest(c *gin.Context, req *createShareRequest) error {
+	body, err := io.ReadAll(c.Request.Body)
+	if err != nil {
+		return err
+	}
+	c.Request.Body = io.NopCloser(bytes.NewReader(body))
+	if len(bytes.TrimSpace(body)) == 0 {
+		return nil
+	}
+	return json.Unmarshal(body, req)
 }
 
 // GetSharedFile godoc

--- a/api-go/internal/handlers/sharelink_test.go
+++ b/api-go/internal/handlers/sharelink_test.go
@@ -1,0 +1,136 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/example/sfree/api-go/internal/repository"
+	"github.com/gin-gonic/gin"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+type fakeShareBucketReader struct {
+	bucket *repository.Bucket
+}
+
+func (r fakeShareBucketReader) GetByID(_ context.Context, _ primitive.ObjectID) (*repository.Bucket, error) {
+	return r.bucket, nil
+}
+
+type fakeShareFileReader struct {
+	file *repository.File
+}
+
+func (r fakeShareFileReader) GetByID(_ context.Context, _ primitive.ObjectID) (*repository.File, error) {
+	return r.file, nil
+}
+
+type fakeShareLinkCreator struct {
+	created []repository.ShareLink
+}
+
+func (r *fakeShareLinkCreator) Create(_ context.Context, sl repository.ShareLink) (*repository.ShareLink, error) {
+	sl.ID = primitive.NewObjectID()
+	r.created = append(r.created, sl)
+	return &sl, nil
+}
+
+func TestCreateShareLinkAcceptsEmptyBody(t *testing.T) {
+	t.Parallel()
+	creator, w := serveCreateShareLinkTest(t, nil)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if len(creator.created) != 1 {
+		t.Fatalf("expected one share link, got %d", len(creator.created))
+	}
+	if creator.created[0].ExpiresAt != nil {
+		t.Fatalf("expected no expiry, got %v", creator.created[0].ExpiresAt)
+	}
+}
+
+func TestCreateShareLinkAcceptsValidExpiryBody(t *testing.T) {
+	t.Parallel()
+	body := []byte(`{"expires_in":3600}`)
+	creator, w := serveCreateShareLinkTest(t, body)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if len(creator.created) != 1 {
+		t.Fatalf("expected one share link, got %d", len(creator.created))
+	}
+	if creator.created[0].ExpiresAt == nil {
+		t.Fatal("expected expiry to be set")
+	}
+	if time.Until(*creator.created[0].ExpiresAt) <= 0 {
+		t.Fatalf("expected future expiry, got %v", creator.created[0].ExpiresAt)
+	}
+}
+
+func TestCreateShareLinkRejectsMalformedJSONBody(t *testing.T) {
+	t.Parallel()
+	creator, w := serveCreateShareLinkTest(t, []byte(`{"expires_in":`))
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+	if len(creator.created) != 0 {
+		t.Fatalf("expected no share links, got %d", len(creator.created))
+	}
+}
+
+func TestCreateShareLinkRejectsWrongTypeExpiresIn(t *testing.T) {
+	t.Parallel()
+	body, err := json.Marshal(map[string]any{"expires_in": "3600"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	creator, w := serveCreateShareLinkTest(t, body)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+	if len(creator.created) != 0 {
+		t.Fatalf("expected no share links, got %d", len(creator.created))
+	}
+}
+
+func serveCreateShareLinkTest(t *testing.T, body []byte) (*fakeShareLinkCreator, *httptest.ResponseRecorder) {
+	t.Helper()
+	ownerID := primitive.NewObjectID()
+	bucketID := primitive.NewObjectID()
+	fileID := primitive.NewObjectID()
+	creator := &fakeShareLinkCreator{}
+	router := gin.New()
+	router.POST(
+		"/buckets/:id/files/:file_id/share",
+		setUserID(ownerID.Hex()),
+		createShareLink(
+			fakeShareBucketReader{bucket: &repository.Bucket{ID: bucketID, UserID: ownerID}},
+			fakeShareFileReader{file: &repository.File{ID: fileID, BucketID: bucketID, Name: "report.pdf"}},
+			creator,
+			nil,
+		),
+	)
+
+	var reader *bytes.Reader
+	if body == nil {
+		reader = bytes.NewReader(nil)
+	} else {
+		reader = bytes.NewReader(body)
+	}
+	req, _ := http.NewRequest(http.MethodPost, "/buckets/"+bucketID.Hex()+"/files/"+fileID.Hex()+"/share", reader)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	return creator, w
+}


### PR DESCRIPTION
## Summary
- Reject malformed optional JSON bodies for share-link creation with `400 Bad Request`
- Preserve empty-body share creation and positive `expires_in` expiry handling
- Add focused handler tests for empty, valid expiry, malformed JSON, and wrong-type `expires_in` bodies

## Tests
- `go test ./internal/handlers -run 'TestCreateShareLink(AcceptsEmptyBody|AcceptsValidExpiryBody|RejectsMalformedJSONBody|RejectsWrongTypeExpiresIn)$'`

## Notes
- Did not run Docker, Playwright, integration tests, or full local suites per limited-resource task policy; Woodpecker should run broader validation.