### PR TITLE
THE-653 Add bucket detail API

### DIFF
--- a/api-go/internal/app/router_routes.go
+++ b/api-go/internal/app/router_routes.go
@@ -53,6 +53,7 @@ func registerBucketRoutes(router *gin.Engine, cfg *config.Config, deps *routerDe
 	}
 	router.POST("/api/v1/buckets", deps.auth, handlers.CreateBucket(deps.bucketRepo, deps.sourceRepo, routerAccessSecret(cfg)))
 	router.GET("/api/v1/buckets", deps.auth, handlers.ListBuckets(deps.bucketRepo, deps.grantRepo))
+	router.GET("/api/v1/buckets/:id", deps.auth, handlers.GetBucket(deps.bucketRepo, deps.grantRepo))
 	router.DELETE("/api/v1/buckets/:id", deps.auth, handlers.DeleteBucketWithFactory(deps.bucketRepo, deps.sourceRepo, deps.fileRepo, deps.mpRepo, deps.grantRepo, deps.sourceFactory))
 	router.PATCH("/api/v1/buckets/:id/distribution", deps.auth, handlers.UpdateBucketDistribution(deps.bucketRepo, deps.grantRepo))
 

--- a/api-go/internal/docs/docs.go
+++ b/api-go/internal/docs/docs.go
@@ -463,6 +463,61 @@ const docTemplate = `{
             }
         },
         "/api/v1/buckets/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "BasicAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "buckets"
+                ],
+                "summary": "Get bucket",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Bucket ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.bucketResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            },
             "delete": {
                 "security": [
                     {

--- a/api-go/internal/handlers/bucket.go
+++ b/api-go/internal/handlers/bucket.go
@@ -39,6 +39,17 @@ type bucketResponse struct {
 	Shared    bool      `json:"shared"`
 }
 
+func bucketDocResponse(bucket repository.Bucket, role repository.BucketRole, shared bool) bucketResponse {
+	return bucketResponse{
+		ID:        bucket.ID.Hex(),
+		Key:       bucket.Key,
+		AccessKey: bucket.AccessKey,
+		CreatedAt: bucket.CreatedAt,
+		Role:      string(role),
+		Shared:    shared,
+	}
+}
+
 type fileResponse struct {
 	ID        string    `json:"id"`
 	Name      string    `json:"name"`
@@ -223,14 +234,7 @@ func ListBuckets(repo *repository.BucketRepository, grantRepo *repository.Bucket
 		}
 		resp := make([]bucketResponse, 0, len(buckets))
 		for _, b := range buckets {
-			resp = append(resp, bucketResponse{
-				ID:        b.ID.Hex(),
-				Key:       b.Key,
-				AccessKey: b.AccessKey,
-				CreatedAt: b.CreatedAt,
-				Role:      string(repository.RoleOwner),
-				Shared:    false,
-			})
+			resp = append(resp, bucketDocResponse(b, repository.RoleOwner, false))
 		}
 
 		// Shared-with-me buckets.
@@ -256,19 +260,60 @@ func ListBuckets(repo *repository.BucketRepository, grantRepo *repository.Bucket
 				}
 				for _, b := range sharedBuckets {
 					g := grantByBucket[b.ID]
-					resp = append(resp, bucketResponse{
-						ID:        b.ID.Hex(),
-						Key:       b.Key,
-						AccessKey: b.AccessKey,
-						CreatedAt: b.CreatedAt,
-						Role:      string(g.Role),
-						Shared:    true,
-					})
+					resp = append(resp, bucketDocResponse(b, g.Role, true))
 				}
 			}
 		}
 
 		c.JSON(http.StatusOK, resp)
+	}
+}
+
+// GetBucket godoc
+// @Summary Get bucket
+// @Tags buckets
+// @Produce json
+// @Param id path string true "Bucket ID"
+// @Success 200 {object} bucketResponse
+// @Failure 400 {string} string ""
+// @Failure 401 {string} string ""
+// @Failure 404 {string} string ""
+// @Failure 500 {string} string ""
+// @Security BasicAuth
+// @Router /api/v1/buckets/{id} [get]
+func GetBucket(repo *repository.BucketRepository, grantRepo *repository.BucketGrantRepository) gin.HandlerFunc {
+	if repo == nil {
+		return func(c *gin.Context) {
+			slog.ErrorContext(c.Request.Context(), "get bucket: repository is nil")
+			c.Status(http.StatusServiceUnavailable)
+		}
+	}
+	var grantReader bucketAccessGrantReader
+	if grantRepo != nil {
+		grantReader = grantRepo
+	}
+	return getBucket(repo, grantReader)
+}
+
+func getBucket(bucketRepo bucketAccessBucketReader, grantRepo bucketAccessGrantReader) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		ctx := c.Request.Context()
+		if bucketRepo == nil {
+			slog.ErrorContext(ctx, "get bucket: repository is nil")
+			c.Status(http.StatusServiceUnavailable)
+			return
+		}
+
+		acc := requireBucketAccessFor(c, bucketRepo, grantRepo, repository.RoleViewer)
+		if acc == nil {
+			return
+		}
+		userID, ok := authenticatedUserID(c)
+		if !ok {
+			return
+		}
+
+		c.JSON(http.StatusOK, bucketDocResponse(*acc.Bucket, acc.Role, acc.Bucket.UserID != userID))
 	}
 }
 

--- a/api-go/internal/handlers/bucket_detail_test.go
+++ b/api-go/internal/handlers/bucket_detail_test.go
@@ -1,0 +1,179 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/example/sfree/api-go/internal/repository"
+	"github.com/gin-gonic/gin"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+type bucketDetailBucketReader struct {
+	bucket *repository.Bucket
+	err    error
+}
+
+func (r bucketDetailBucketReader) GetByID(context.Context, primitive.ObjectID) (*repository.Bucket, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	return r.bucket, nil
+}
+
+type bucketDetailGrantReader struct {
+	grant *repository.BucketGrant
+	err   error
+}
+
+func (r bucketDetailGrantReader) GetByBucketAndUser(context.Context, primitive.ObjectID, primitive.ObjectID) (*repository.BucketGrant, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	return r.grant, nil
+}
+
+func TestGetBucketOwnerAccess(t *testing.T) {
+	t.Parallel()
+
+	ownerID := primitive.NewObjectID()
+	bucket := bucketDetailTestBucket(ownerID)
+	resp := performGetBucketRequest(t, ownerID, bucketDetailBucketReader{bucket: bucket}, nil, bucket.ID.Hex())
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.Code)
+	}
+	var body bucketResponse
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+	if body.ID != bucket.ID.Hex() || body.Key != bucket.Key || body.AccessKey != bucket.AccessKey {
+		t.Fatalf("unexpected bucket response: %+v", body)
+	}
+	if body.Role != string(repository.RoleOwner) || body.Shared {
+		t.Fatalf("expected owner non-shared bucket, got role=%q shared=%v", body.Role, body.Shared)
+	}
+}
+
+func TestGetBucketSharedAccess(t *testing.T) {
+	t.Parallel()
+
+	ownerID := primitive.NewObjectID()
+	viewerID := primitive.NewObjectID()
+	bucket := bucketDetailTestBucket(ownerID)
+	grant := &repository.BucketGrant{
+		BucketID: bucket.ID,
+		UserID:   viewerID,
+		Role:     repository.RoleViewer,
+	}
+	resp := performGetBucketRequest(
+		t,
+		viewerID,
+		bucketDetailBucketReader{bucket: bucket},
+		bucketDetailGrantReader{grant: grant},
+		bucket.ID.Hex(),
+	)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.Code)
+	}
+	var body bucketResponse
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+	if body.Role != string(repository.RoleViewer) || !body.Shared {
+		t.Fatalf("expected shared viewer bucket, got role=%q shared=%v", body.Role, body.Shared)
+	}
+}
+
+func TestGetBucketMissingOrInaccessible(t *testing.T) {
+	t.Parallel()
+
+	ownerID := primitive.NewObjectID()
+	otherUserID := primitive.NewObjectID()
+	bucket := bucketDetailTestBucket(ownerID)
+
+	tests := []struct {
+		name       string
+		bucketRepo bucketAccessBucketReader
+		grantRepo  bucketAccessGrantReader
+	}{
+		{
+			name:       "missing",
+			bucketRepo: bucketDetailBucketReader{err: mongo.ErrNoDocuments},
+		},
+		{
+			name:       "inaccessible",
+			bucketRepo: bucketDetailBucketReader{bucket: bucket},
+			grantRepo:  bucketDetailGrantReader{err: mongo.ErrNoDocuments},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			resp := performGetBucketRequest(t, otherUserID, tt.bucketRepo, tt.grantRepo, bucket.ID.Hex())
+			if resp.Code != http.StatusNotFound {
+				t.Fatalf("expected 404, got %d", resp.Code)
+			}
+		})
+	}
+}
+
+func TestGetBucketBadID(t *testing.T) {
+	t.Parallel()
+
+	resp := performGetBucketRequest(t, primitive.NewObjectID(), bucketDetailBucketReader{}, nil, "not-a-valid-oid")
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", resp.Code)
+	}
+}
+
+func TestGetBucketRepositoryFailure(t *testing.T) {
+	t.Parallel()
+
+	resp := performGetBucketRequest(
+		t,
+		primitive.NewObjectID(),
+		bucketDetailBucketReader{err: errors.New("repo down")},
+		nil,
+		primitive.NewObjectID().Hex(),
+	)
+	if resp.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", resp.Code)
+	}
+}
+
+func performGetBucketRequest(
+	t *testing.T,
+	userID primitive.ObjectID,
+	bucketRepo bucketAccessBucketReader,
+	grantRepo bucketAccessGrantReader,
+	bucketID string,
+) *httptest.ResponseRecorder {
+	t.Helper()
+	r := gin.New()
+	r.GET("/buckets/:id", setUserID(userID.Hex()), getBucket(bucketRepo, grantRepo))
+
+	req, _ := http.NewRequest(http.MethodGet, "/buckets/"+bucketID, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func bucketDetailTestBucket(ownerID primitive.ObjectID) *repository.Bucket {
+	return &repository.Bucket{
+		ID:        primitive.NewObjectID(),
+		UserID:    ownerID,
+		Key:       "bucket-detail-test",
+		AccessKey: "bucket-detail-access",
+		CreatedAt: time.Now().UTC(),
+	}
+}

--- a/webui/e2e/buckets.spec.ts
+++ b/webui/e2e/buckets.spec.ts
@@ -121,6 +121,7 @@ test.describe("Bucket creation flow", () => {
   }) => {
     await injectAuth(page);
     await mockGet(page, "/buckets", [MOCK_BUCKET]);
+    await mockGet(page, "/buckets/bkt-1", MOCK_BUCKET);
     await mockGet(page, "/buckets/bkt-1/files", []);
     await page.goto("/buckets/bkt-1");
 
@@ -132,6 +133,7 @@ test.describe("Bucket creation flow", () => {
   test("viewer bucket detail hides write actions", async ({ page }) => {
     await injectAuth(page);
     await mockGet(page, "/buckets", [MOCK_VIEWER_BUCKET]);
+    await mockGet(page, "/buckets/bkt-1", MOCK_VIEWER_BUCKET);
     await mockGet(page, "/buckets/bkt-1/files", []);
     await page.goto("/buckets/bkt-1");
 

--- a/webui/e2e/error-states.spec.ts
+++ b/webui/e2e/error-states.spec.ts
@@ -16,8 +16,7 @@ test.describe("Error states", () => {
     page,
   }) => {
     await injectAuth(page);
-    // API returns empty bucket list — bucket ID won't match
-    await mockGet(page, "/buckets", []);
+    await mockGet(page, "/buckets/does-not-exist", { error: "not found" }, 404);
     await mockGet(page, "/buckets/does-not-exist/files", []);
     await page.goto("/buckets/does-not-exist");
 

--- a/webui/e2e/files.spec.ts
+++ b/webui/e2e/files.spec.ts
@@ -51,6 +51,7 @@ test.describe("File listing and download", () => {
   test("bucket detail shows bucket info", async ({ page }) => {
     await injectAuth(page);
     await mockGet(page, "/buckets", [MOCK_BUCKET]);
+    await mockGet(page, "/buckets/bkt-1", MOCK_BUCKET);
     await mockGet(page, "/buckets/bkt-1/files", []);
     await page.goto("/buckets/bkt-1");
 
@@ -61,6 +62,7 @@ test.describe("File listing and download", () => {
   test("bucket detail shows empty state when no files", async ({ page }) => {
     await injectAuth(page);
     await mockGet(page, "/buckets", [MOCK_BUCKET]);
+    await mockGet(page, "/buckets/bkt-1", MOCK_BUCKET);
     await mockGet(page, "/buckets/bkt-1/files", []);
     await page.goto("/buckets/bkt-1");
 
@@ -72,6 +74,7 @@ test.describe("File listing and download", () => {
   }) => {
     await injectAuth(page);
     await mockGet(page, "/buckets", [MOCK_BUCKET]);
+    await mockGet(page, "/buckets/bkt-1", MOCK_BUCKET);
     await mockGet(page, "/buckets/bkt-1/files", MOCK_FILES);
     await page.goto("/buckets/bkt-1");
 
@@ -90,6 +93,7 @@ test.describe("File listing and download", () => {
   test("each file row has a download button", async ({ page }) => {
     await injectAuth(page);
     await mockGet(page, "/buckets", [MOCK_BUCKET]);
+    await mockGet(page, "/buckets/bkt-1", MOCK_BUCKET);
     await mockGet(page, "/buckets/bkt-1/files", MOCK_FILES);
     await page.goto("/buckets/bkt-1");
 
@@ -118,6 +122,7 @@ test.describe("File listing and download", () => {
   test("viewer file rows only expose download actions", async ({ page }) => {
     await injectAuth(page);
     await mockGet(page, "/buckets", [MOCK_VIEWER_BUCKET]);
+    await mockGet(page, "/buckets/bkt-1", MOCK_VIEWER_BUCKET);
     await mockGet(page, "/buckets/bkt-1/files", MOCK_FILES);
     await page.goto("/buckets/bkt-1");
 
@@ -135,6 +140,7 @@ test.describe("File listing and download", () => {
   test("editor file rows expose file actions without bucket sharing", async ({ page }) => {
     await injectAuth(page);
     await mockGet(page, "/buckets", [MOCK_EDITOR_BUCKET]);
+    await mockGet(page, "/buckets/bkt-1", MOCK_EDITOR_BUCKET);
     await mockGet(page, "/buckets/bkt-1/files", [MOCK_FILES[0]]);
     await page.goto("/buckets/bkt-1");
 
@@ -150,6 +156,7 @@ test.describe("File listing and download", () => {
   }) => {
     await injectAuth(page);
     await mockGet(page, "/buckets", [MOCK_BUCKET]);
+    await mockGet(page, "/buckets/bkt-1", MOCK_BUCKET);
     await mockGet(page, "/buckets/bkt-1/files", [MOCK_FILES[0]]);
 
     // Intercept download call and fulfill with a blob
@@ -174,6 +181,7 @@ test.describe("File listing and download", () => {
   test("failed bucket download shows an error toast", async ({ page }) => {
     await injectAuth(page);
     await mockGet(page, "/buckets", [MOCK_BUCKET]);
+    await mockGet(page, "/buckets/bkt-1", MOCK_BUCKET);
     await mockGet(page, "/buckets/bkt-1/files", [MOCK_FILES[0]]);
 
     await page.route("**/api/v1/buckets/bkt-1/files/file-1/download", async (route) => {
@@ -202,6 +210,7 @@ test.describe("File listing and download", () => {
   test("back button is present and navigates back", async ({ page }) => {
     await injectAuth(page);
     await mockGet(page, "/buckets", [MOCK_BUCKET]);
+    await mockGet(page, "/buckets/bkt-1", MOCK_BUCKET);
     await mockGet(page, "/buckets/bkt-1/files", []);
     await page.goto("/buckets");
     // Navigate to bucket detail

--- a/webui/src/pages/bucket/ui/bucket-page.tsx
+++ b/webui/src/pages/bucket/ui/bucket-page.tsx
@@ -21,7 +21,7 @@ import {FilePreviewModal} from "../../../features/bucket/ui/file-preview-modal";
 import {ShareBucketDialog} from "../../../features/bucket/ui/share-bucket-dialog";
 import {ShareFileDialog} from "../../../features/bucket/ui/share-file-dialog";
 import {formatSize} from "../../../shared/lib/format";
-import {showErrorToast} from "../../../shared/api/error";
+import {ApiError, showErrorToast} from "../../../shared/api/error";
 
 export function BucketPage() {
   const {id} = useParams<{id: string}>();
@@ -51,6 +51,11 @@ export function BucketPage() {
       setBucket(loadedBucket);
       setFiles(fs);
     } catch (err) {
+      if (err instanceof ApiError && err.status === 404) {
+        setBucket(null);
+        setFiles([]);
+        return;
+      }
       setError(err instanceof Error ? err.message : "Failed to load bucket");
     } finally {
       setIsLoading(false);

--- a/webui/src/pages/bucket/ui/bucket-page.tsx
+++ b/webui/src/pages/bucket/ui/bucket-page.tsx
@@ -9,7 +9,7 @@ import {useNavigate, useParams} from "react-router-dom";
 import {
   deleteFile,
   downloadFile,
-  listBuckets,
+  getBucket,
   listFiles,
   uploadFile,
 } from "../../../shared/api/buckets";
@@ -44,8 +44,11 @@ export function BucketPage() {
     setIsLoading(true);
     setError(null);
     try {
-      const [buckets, fs] = await Promise.all([listBuckets(), listFiles(id)]);
-      setBucket(buckets.find((b) => b.id === id) || null);
+      const [loadedBucket, fs] = await Promise.all([
+        getBucket(id),
+        listFiles(id),
+      ]);
+      setBucket(loadedBucket);
       setFiles(fs);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to load bucket");

--- a/webui/src/shared/api/buckets.ts
+++ b/webui/src/shared/api/buckets.ts
@@ -27,6 +27,10 @@ export async function listBuckets(): Promise<Bucket[]> {
   return apiJson<Bucket[]>("/buckets", "Failed to list buckets");
 }
 
+export async function getBucket(id: string): Promise<Bucket> {
+  return apiJson<Bucket>(`/buckets/${id}`, "Failed to load bucket");
+}
+
 export async function createBucket(
   key: string,
   sourceIds: string[],


### PR DESCRIPTION
## Summary
- Add authenticated `GET /api/v1/buckets/:id` using existing bucket access checks and the list bucket response shape.
- Add focused handler coverage for owner, shared, missing/inaccessible, bad id, and repository failure cases.
- Add `getBucket(id)` in the web UI and stop the bucket detail page from calling `listBuckets()`.
- Update Swagger/OpenAPI docs for the new endpoint.

## Validation
- `go test ./internal/handlers -run TestGetBucket -count=1`
- `go test ./internal/app -run TestOpenAPIJSONRoute -count=1`

Woodpecker should run broader backend/frontend validation. Per task policy, I did not run Docker, Playwright, or full E2E locally.