### PR TITLE
Handle escaped source download keys

### DIFF
--- a/api-go/internal/app/router_routes.go
+++ b/api-go/internal/app/router_routes.go
@@ -96,6 +96,7 @@ func registerSourceRoutes(router *gin.Engine, deps *routerDependencies) {
 	router.GET("/api/v1/sources", deps.auth, handlers.ListSources(deps.sourceRepo))
 	router.GET("/api/v1/sources/:id/health", deps.auth, handlers.GetSourceHealthWithFactory(deps.sourceRepo, deps.sourceFactory))
 	router.GET("/api/v1/sources/:id/info", deps.auth, handlers.GetSourceInfoWithFactory(deps.sourceRepo, deps.sourceFactory))
+	router.GET("/api/v1/sources/:id/download", deps.auth, handlers.DownloadSourceFileWithFactory(deps.sourceRepo, deps.sourceFactory))
 	router.GET("/api/v1/sources/:id/files/:file_id/download", deps.auth, handlers.DownloadSourceFileWithFactory(deps.sourceRepo, deps.sourceFactory))
 	router.DELETE("/api/v1/sources/:id", deps.auth, handlers.DeleteSource(deps.sourceRepo, deps.bucketRepo))
 }

--- a/api-go/internal/app/router_routes.go
+++ b/api-go/internal/app/router_routes.go
@@ -96,7 +96,7 @@ func registerSourceRoutes(router *gin.Engine, deps *routerDependencies) {
 	router.GET("/api/v1/sources", deps.auth, handlers.ListSources(deps.sourceRepo))
 	router.GET("/api/v1/sources/:id/health", deps.auth, handlers.GetSourceHealthWithFactory(deps.sourceRepo, deps.sourceFactory))
 	router.GET("/api/v1/sources/:id/info", deps.auth, handlers.GetSourceInfoWithFactory(deps.sourceRepo, deps.sourceFactory))
-	router.GET("/api/v1/sources/:id/download", deps.auth, handlers.DownloadSourceFileWithFactory(deps.sourceRepo, deps.sourceFactory))
+	router.GET("/api/v1/sources/:id/download", deps.auth, handlers.DownloadSourceFileByQueryWithFactory(deps.sourceRepo, deps.sourceFactory))
 	router.GET("/api/v1/sources/:id/files/:file_id/download", deps.auth, handlers.DownloadSourceFileWithFactory(deps.sourceRepo, deps.sourceFactory))
 	router.DELETE("/api/v1/sources/:id", deps.auth, handlers.DeleteSource(deps.sourceRepo, deps.bucketRepo))
 }

--- a/api-go/internal/app/router_test.go
+++ b/api-go/internal/app/router_test.go
@@ -107,6 +107,29 @@ func TestOpenAPIJSONRoute(t *testing.T) {
 	}
 }
 
+func TestRegisterSourceRoutesIncludesQueryDownloadRoute(t *testing.T) {
+	r := gin.New()
+	registerSourceRoutes(r, &routerDependencies{
+		auth: func(c *gin.Context) {
+			c.Next()
+		},
+		sourceRepo: &repository.SourceRepository{},
+	})
+
+	expectedRoutes := []struct {
+		method string
+		path   string
+	}{
+		{http.MethodGet, "/api/v1/sources/:id/download"},
+		{http.MethodGet, "/api/v1/sources/:id/files/:file_id/download"},
+	}
+	for _, expected := range expectedRoutes {
+		if !hasRoute(r, expected.method, expected.path) {
+			t.Fatalf("expected %s %s to be registered", expected.method, expected.path)
+		}
+	}
+}
+
 func TestOpenAPIDocsRouteRedirectsToIndex(t *testing.T) {
 	r, err := SetupRouter(nil, nil)
 	if err != nil {

--- a/api-go/internal/app/router_test.go
+++ b/api-go/internal/app/router_test.go
@@ -100,7 +100,7 @@ func TestOpenAPIJSONRoute(t *testing.T) {
 	if doc.Swagger != "2.0" {
 		t.Fatalf("expected Swagger 2.0, got %q", doc.Swagger)
 	}
-	for _, path := range []string{"/api/v1/buckets", "/api/v1/sources/s3", "/api/s3/{bucket}", "/api/s3/{bucket}/{object}"} {
+	for _, path := range []string{"/api/v1/buckets", "/api/v1/sources/s3", "/api/v1/sources/{id}/download", "/api/s3/{bucket}", "/api/s3/{bucket}/{object}"} {
 		if _, ok := doc.Paths[path]; !ok {
 			t.Fatalf("expected OpenAPI path %s", path)
 		}

--- a/api-go/internal/docs/docs.go
+++ b/api-go/internal/docs/docs.go
@@ -1541,6 +1541,70 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/sources/{id}/download": {
+            "get": {
+                "security": [
+                    {
+                        "BasicAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/octet-stream"
+                ],
+                "tags": [
+                    "sources"
+                ],
+                "summary": "Download a file from a source",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Source ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "File ID (GDrive file ID or S3 object key)",
+                        "name": "file_id",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "file"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/sources/{id}/files/{file_id}/download": {
             "get": {
                 "security": [

--- a/api-go/internal/handlers/source.go
+++ b/api-go/internal/handlers/source.go
@@ -466,6 +466,26 @@ func getSourceHealth(repo sourceGetter, factory manager.SourceClientFactory) gin
 // @Tags sources
 // @Produce octet-stream
 // @Param id path string true "Source ID"
+// @Param file_id path string true "File ID (GDrive file ID or S3 object key)"
+// @Success 200 {file} file
+// @Failure 400 {string} string ""
+// @Failure 401 {string} string ""
+// @Failure 404 {string} string ""
+// @Failure 500 {string} string ""
+// @Security BasicAuth
+// @Router /api/v1/sources/{id}/files/{file_id}/download [get]
+func DownloadSourceFile(sourceRepo *repository.SourceRepository) gin.HandlerFunc {
+	if sourceRepo == nil {
+		return downloadSourceFile(nil, nil)
+	}
+	return downloadSourceFile(sourceRepo, nil)
+}
+
+// DownloadSourceFileByQuery godoc
+// @Summary Download a file from a source
+// @Tags sources
+// @Produce octet-stream
+// @Param id path string true "Source ID"
 // @Param file_id query string true "File ID (GDrive file ID or S3 object key)"
 // @Success 200 {file} file
 // @Failure 400 {string} string ""
@@ -474,12 +494,18 @@ func getSourceHealth(repo sourceGetter, factory manager.SourceClientFactory) gin
 // @Failure 500 {string} string ""
 // @Security BasicAuth
 // @Router /api/v1/sources/{id}/download [get]
-// @Router /api/v1/sources/{id}/files/{file_id}/download [get]
-func DownloadSourceFile(sourceRepo *repository.SourceRepository) gin.HandlerFunc {
+func DownloadSourceFileByQuery(sourceRepo *repository.SourceRepository) gin.HandlerFunc {
 	if sourceRepo == nil {
 		return downloadSourceFile(nil, nil)
 	}
 	return downloadSourceFile(sourceRepo, nil)
+}
+
+func DownloadSourceFileByQueryWithFactory(sourceRepo *repository.SourceRepository, factory manager.SourceClientFactory) gin.HandlerFunc {
+	if sourceRepo == nil {
+		return downloadSourceFile(nil, factory)
+	}
+	return downloadSourceFile(sourceRepo, factory)
 }
 
 func DownloadSourceFileWithFactory(sourceRepo *repository.SourceRepository, factory manager.SourceClientFactory) gin.HandlerFunc {

--- a/api-go/internal/handlers/source.go
+++ b/api-go/internal/handlers/source.go
@@ -466,13 +466,14 @@ func getSourceHealth(repo sourceGetter, factory manager.SourceClientFactory) gin
 // @Tags sources
 // @Produce octet-stream
 // @Param id path string true "Source ID"
-// @Param file_id path string true "File ID (GDrive file ID or S3 object key)"
+// @Param file_id query string true "File ID (GDrive file ID or S3 object key)"
 // @Success 200 {file} file
 // @Failure 400 {string} string ""
 // @Failure 401 {string} string ""
 // @Failure 404 {string} string ""
 // @Failure 500 {string} string ""
 // @Security BasicAuth
+// @Router /api/v1/sources/{id}/download [get]
 // @Router /api/v1/sources/{id}/files/{file_id}/download [get]
 func DownloadSourceFile(sourceRepo *repository.SourceRepository) gin.HandlerFunc {
 	if sourceRepo == nil {
@@ -503,7 +504,10 @@ func downloadSourceFile(sourceRepo sourceGetter, factory manager.SourceClientFac
 		if !ok {
 			return
 		}
-		fileID := c.Param("file_id")
+		fileID := c.Query("file_id")
+		if fileID == "" {
+			fileID = c.Param("file_id")
+		}
 		if fileID == "" {
 			c.Status(http.StatusBadRequest)
 			return

--- a/api-go/internal/handlers/source_download_test.go
+++ b/api-go/internal/handlers/source_download_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -16,14 +17,18 @@ import (
 )
 
 type sourceDownloadHandlerClient struct {
-	body io.ReadCloser
+	body         io.ReadCloser
+	downloadName *string
 }
 
 func (c sourceDownloadHandlerClient) Upload(context.Context, string, io.Reader) (string, error) {
 	return "", nil
 }
 
-func (c sourceDownloadHandlerClient) Download(context.Context, string) (io.ReadCloser, error) {
+func (c sourceDownloadHandlerClient) Download(_ context.Context, name string) (io.ReadCloser, error) {
+	if c.downloadName != nil {
+		*c.downloadName = name
+	}
 	return c.body, nil
 }
 
@@ -39,6 +44,38 @@ func (f failingReadCloser) Read([]byte) (int, error) {
 
 func (f failingReadCloser) Close() error {
 	return nil
+}
+
+func TestDownloadSourceFileAcceptsEscapedQueryFileID(t *testing.T) {
+	t.Parallel()
+	userID := primitive.NewObjectID()
+	source := &repository.Source{
+		ID:     primitive.NewObjectID(),
+		UserID: userID,
+		Type:   repository.SourceTypeS3,
+	}
+	fileID := "folder/a+b #?.txt"
+	var downloadedName string
+	r := gin.New()
+	r.GET("/sources/:id/download", setUserID(userID.Hex()), downloadSourceFile(fakeSourceGetter{source: source}, func(context.Context, *repository.Source) (manager.SourceClient, error) {
+		return sourceDownloadHandlerClient{
+			body:         io.NopCloser(strings.NewReader("payload")),
+			downloadName: &downloadedName,
+		}, nil
+	}))
+
+	params := url.Values{}
+	params.Set("file_id", fileID)
+	req, _ := http.NewRequest(http.MethodGet, "/sources/"+source.ID.Hex()+"/download?"+params.Encode(), nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if downloadedName != fileID {
+		t.Fatalf("expected source download key %q, got %q", fileID, downloadedName)
+	}
 }
 
 func TestDownloadSourceFilePreflightFailureBeforeHeaders(t *testing.T) {

--- a/webui/e2e/sources.spec.ts
+++ b/webui/e2e/sources.spec.ts
@@ -27,7 +27,7 @@ test.describe("Source creation flow", () => {
     await mockGet(page, "/sources", []);
     await page.goto("/sources");
     await expect(
-      page.getByRole("heading", { name: "Sources" }),
+      page.getByRole("heading", { name: "Sources", exact: true }),
     ).toBeVisible();
     await expect(page.getByText("No sources yet")).toBeVisible();
     await expect(

--- a/webui/src/shared/api/sources.ts
+++ b/webui/src/shared/api/sources.ts
@@ -97,8 +97,9 @@ export async function downloadFile(
   sourceId: string,
   file: SourceFile,
 ): Promise<void> {
+  const params = new URLSearchParams({file_id: file.id});
   await apiDownload(
-    `/sources/${sourceId}/files/${file.id}/download`,
+    `/sources/${sourceId}/download?${params.toString()}`,
     file.name,
     "Failed to download file",
   );


### PR DESCRIPTION
## Summary
- Add a query-based source download endpoint at `/api/v1/sources/:id/download?file_id=...` so S3 object keys can include slashes and reserved characters.
- Keep the legacy `/api/v1/sources/:id/files/:file_id/download` route for existing segment-safe source file IDs.
- Update the webui source download URL builder to encode `file_id` with `URLSearchParams`.
- Add focused backend route/handler coverage for escaped S3-style keys containing `/`, space, `+`, `?`, and `#`.

## Validation
- `gofmt`
- `git diff --check`

Per task constraints, heavier Go/webui validation is left to Woodpecker CI.