### PR TITLE
THE-658 Add range corruption regression test

### DIFF
--- a/api-go/internal/manager/file_test.go
+++ b/api-go/internal/manager/file_test.go
@@ -964,3 +964,28 @@ func TestStreamFileRangeVerifiesChecksummedChunk(t *testing.T) {
 		t.Fatalf("range output mismatch: got %q, want %q", got, want)
 	}
 }
+
+func TestStreamFileRangeRejectsCorruptedChecksummedChunk(t *testing.T) {
+	t.Parallel()
+	payload := []byte("abcdefghij")
+	sum := sha256.Sum256(payload)
+	chunk := repository.FileChunk{
+		SourceID: primitive.NewObjectID(),
+		Name:     "chunk0",
+		Order:    0,
+		Size:     int64(len(payload)),
+		Checksum: hex.EncodeToString(sum[:]),
+	}
+	f := &repository.File{Chunks: []repository.FileChunk{chunk}}
+
+	var buf bytes.Buffer
+	err := streamFileRangeWithFactory(context.Background(), f, &buf, 2, 6, func(_ context.Context, _ *repository.Source) (sourceClient, error) {
+		return &fixedDownloadClient{data: map[string][]byte{"chunk0": []byte("abcDEFghij")}}, nil
+	})
+	if !errors.Is(err, ErrChecksumMismatch) {
+		t.Fatalf("expected ErrChecksumMismatch, got %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Fatalf("expected no range bytes written before checksum validation, got %d", buf.Len())
+	}
+}


### PR DESCRIPTION
## Summary
- Add focused manager coverage for ranged file streaming when a checksummed chunk is corrupted.
- Assert the ranged stream returns ErrChecksumMismatch and writes no partial response bytes before validation passes.

## QA audit notes
- Recent api-go coverage is strong for full object roundtrip, chunking, placement, multipart replacement/cleanup, source health, and S3 compatibility.
- This was the highest-signal missing regression found during the audit: ranged retrieval had a checksum success test, but no corruption rejection/no-partial-write assertion.

## Validation
- `gofmt`
- `git diff --check`

Per QA resource policy, local `go test`, Docker, and Playwright were not run. Woodpecker should validate the branch.