### PR TITLE
THE-661 Remove dead multipart handler helpers

### DIFF
--- a/api-go/internal/handlers/s3_multipart.go
+++ b/api-go/internal/handlers/s3_multipart.go
@@ -281,15 +281,6 @@ func uploadPart(c *gin.Context, bucketRepo *repository.BucketRepository, sourceR
 	c.Status(http.StatusOK)
 }
 
-func multipartPartChunks(parts []repository.UploadPart, partNumber int) []repository.FileChunk {
-	for _, part := range parts {
-		if part.PartNumber == partNumber {
-			return part.Chunks
-		}
-	}
-	return nil
-}
-
 func completeMultipartUpload(c *gin.Context, bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository, mpRepo *repository.MultipartUploadRepository) {
 	ctx := c.Request.Context()
 	uploadID := c.Query("uploadId")
@@ -357,20 +348,6 @@ func completeMultipartUpload(c *gin.Context, bucketRepo *repository.BucketReposi
 		Key:      result.Upload.ObjectKey,
 		ETag:     result.ETag,
 	})
-}
-
-func completedMultipartChunks(parts []completionPart, partMap map[int]repository.UploadPart) []repository.FileChunk {
-	var allChunks []repository.FileChunk
-	chunkOrder := 0
-	for _, rp := range parts {
-		up := partMap[rp.PartNumber]
-		for _, ch := range up.Chunks {
-			ch.Order = chunkOrder
-			allChunks = append(allChunks, ch)
-			chunkOrder++
-		}
-	}
-	return allChunks
 }
 
 func abortMultipartUpload(c *gin.Context, bucketRepo objectBucketReader, sourceRepo *repository.SourceRepository, mpRepo multipartUploadAbortStore) {

--- a/api-go/internal/handlers/s3_multipart_test.go
+++ b/api-go/internal/handlers/s3_multipart_test.go
@@ -199,68 +199,6 @@ func TestCompleteMultipartUploadResultXML(t *testing.T) {
 	}
 }
 
-func TestCompletedMultipartChunksPreservesChecksums(t *testing.T) {
-	t.Parallel()
-
-	sourceID := primitive.NewObjectID()
-	partMap := map[int]repository.UploadPart{
-		1: {
-			Chunks: []repository.FileChunk{
-				{SourceID: sourceID, Name: "part-1-chunk-1", Order: 17, Size: 5, Checksum: "checksum-a"},
-				{SourceID: sourceID, Name: "part-1-chunk-2", Order: 18, Size: 6, Checksum: "checksum-b"},
-			},
-		},
-		2: {
-			Chunks: []repository.FileChunk{
-				{SourceID: sourceID, Name: "part-2-chunk-1", Order: 3, Size: 7, Checksum: "checksum-c"},
-			},
-		},
-	}
-
-	chunks := completedMultipartChunks([]completionPart{{PartNumber: 1}, {PartNumber: 2}}, partMap)
-	if len(chunks) != 3 {
-		t.Fatalf("expected 3 chunks, got %d", len(chunks))
-	}
-
-	wantChecksums := []string{"checksum-a", "checksum-b", "checksum-c"}
-	for i, want := range wantChecksums {
-		if chunks[i].Checksum != want {
-			t.Fatalf("chunk %d checksum: got %q, want %q", i, chunks[i].Checksum, want)
-		}
-		if chunks[i].Order != i {
-			t.Fatalf("chunk %d order: got %d, want %d", i, chunks[i].Order, i)
-		}
-	}
-}
-
-func TestMultipartPartChunksReturnsReplacedPartChunks(t *testing.T) {
-	t.Parallel()
-
-	sourceID := primitive.NewObjectID()
-	parts := []repository.UploadPart{
-		{
-			PartNumber: 1,
-			Chunks: []repository.FileChunk{
-				{SourceID: sourceID, Name: "part-1-old", Order: 0, Size: 5},
-			},
-		},
-		{
-			PartNumber: 2,
-			Chunks: []repository.FileChunk{
-				{SourceID: sourceID, Name: "part-2-kept", Order: 1, Size: 7},
-			},
-		},
-	}
-
-	got := multipartPartChunks(parts, 1)
-	if len(got) != 1 || got[0].Name != "part-1-old" {
-		t.Fatalf("expected previous chunks for replaced part, got %+v", got)
-	}
-	if got := multipartPartChunks(parts, 3); got != nil {
-		t.Fatalf("expected nil chunks for new part, got %+v", got)
-	}
-}
-
 func TestListMultipartUploadsResultXML(t *testing.T) {
 	t.Parallel()
 

--- a/api-go/internal/manager/s3_object_test.go
+++ b/api-go/internal/manager/s3_object_test.go
@@ -738,7 +738,8 @@ func TestObjectServiceCompleteMultipartUploadBuildsFinalFileAndCleansUnusedChunk
 	oldChunk := repository.FileChunk{SourceID: primitive.NewObjectID(), Name: "old-file-chunk", Size: 2}
 	part1ChunkA := repository.FileChunk{SourceID: primitive.NewObjectID(), Name: "part-1a", Size: 5, Checksum: "sum-a"}
 	part1ChunkB := repository.FileChunk{SourceID: primitive.NewObjectID(), Name: "part-1b", Size: 6, Checksum: "sum-b"}
-	part2Chunk := repository.FileChunk{SourceID: primitive.NewObjectID(), Name: "part-2", Size: 7}
+	part2Chunk := repository.FileChunk{SourceID: primitive.NewObjectID(), Name: "part-2", Size: 7, Checksum: "sum-c"}
+	unusedPartChunk := repository.FileChunk{SourceID: primitive.NewObjectID(), Name: "part-3-unused", Size: 8}
 	files := newFakeObjectFiles(repository.File{
 		ID:       primitive.NewObjectID(),
 		BucketID: bucketID,
@@ -755,12 +756,14 @@ func TestObjectServiceCompleteMultipartUploadBuildsFinalFileAndCleansUnusedChunk
 			Parts: []repository.UploadPart{
 				{PartNumber: 1, ETag: `"d41d8cd98f00b204e9800998ecf8427e"`, Chunks: []repository.FileChunk{part1ChunkA, part1ChunkB}},
 				{PartNumber: 2, ETag: `"0cc175b9c0f1b6a831c399e269772661"`, Chunks: []repository.FileChunk{part2Chunk}},
+				{PartNumber: 3, ETag: `"900150983cd24fb0d6963f7d28e17f72"`, Chunks: []repository.FileChunk{unusedPartChunk}},
 			},
 		},
 	}}
 
 	result, err := svc.CompleteMultipartUpload(context.Background(), bucketID, "upload-1", []CompleteMultipartPart{
 		{PartNumber: 1, ETag: "d41d8cd98f00b204e9800998ecf8427e"},
+		{PartNumber: 2, ETag: "0cc175b9c0f1b6a831c399e269772661"},
 	})
 	if err != nil {
 		t.Fatalf("CompleteMultipartUpload returned error: %v", err)
@@ -768,22 +771,25 @@ func TestObjectServiceCompleteMultipartUploadBuildsFinalFileAndCleansUnusedChunk
 	if result.File.Name != "object.txt" {
 		t.Fatalf("expected final object name, got %q", result.File.Name)
 	}
-	if len(result.File.Chunks) != 2 {
-		t.Fatalf("expected two final chunks, got %#v", result.File.Chunks)
+	if len(result.File.Chunks) != 3 {
+		t.Fatalf("expected three final chunks, got %#v", result.File.Chunks)
 	}
-	if result.File.Chunks[0].Order != 0 || result.File.Chunks[1].Order != 1 {
-		t.Fatalf("expected chunks to be renumbered, got %#v", result.File.Chunks)
-	}
-	if result.File.Chunks[0].Checksum != part1ChunkA.Checksum {
-		t.Fatalf("expected checksum to be preserved")
+	wantChecksums := []string{part1ChunkA.Checksum, part1ChunkB.Checksum, part2Chunk.Checksum}
+	for i, want := range wantChecksums {
+		if result.File.Chunks[i].Order != i {
+			t.Fatalf("chunk %d order: got %d, want %d", i, result.File.Chunks[i].Order, i)
+		}
+		if result.File.Chunks[i].Checksum != want {
+			t.Fatalf("chunk %d checksum: got %q, want %q", i, result.File.Chunks[i].Checksum, want)
+		}
 	}
 	if len(deleted) != 2 {
 		t.Fatalf("expected old file chunk and unreferenced part cleanup, got %#v", deleted)
 	}
-	if deleted[0].Name != oldChunk.Name || deleted[1].Name != part2Chunk.Name {
+	if deleted[0].Name != oldChunk.Name || deleted[1].Name != unusedPartChunk.Name {
 		t.Fatalf("unexpected cleanup order: %#v", deleted)
 	}
-	if !strings.HasSuffix(result.ETag, `-1"`) {
+	if !strings.HasSuffix(result.ETag, `-2"`) {
 		t.Fatalf("unexpected multipart etag: %s", result.ETag)
 	}
 	if _, err := svc.multipart.GetByUploadID(context.Background(), "upload-1"); !errors.Is(err, mongo.ErrNoDocuments) {


### PR DESCRIPTION
## Summary
- Remove the now-dead multipart chunk helper functions from the S3 handler.
- Remove handler tests that only exercised those production helpers.
- Strengthen the ObjectService multipart completion test to keep checksum preservation and chunk ordering coverage at the manager boundary.

## Tests
- Not run locally per task guidance and limited-machine policy; relying on Woodpecker backend checks for validation.