### PR TITLE
Normalize S3 object key parsing

### DIFF
--- a/api-go/internal/handlers/s3.go
+++ b/api-go/internal/handlers/s3.go
@@ -209,6 +209,10 @@ func lookupBucket(c *gin.Context, bucketRepo objectBucketReader) (*repository.Bu
 	return bucketDoc, true
 }
 
+func s3ObjectKey(c *gin.Context) string {
+	return strings.TrimPrefix(c.Param("object"), "/")
+}
+
 func parseCopySource(raw string) (string, string, bool) {
 	raw = strings.TrimSpace(raw)
 	raw = strings.TrimPrefix(raw, "/")
@@ -270,7 +274,7 @@ func parseObjectRange(raw string, total int64) (objectRange, bool) {
 
 func lookupObject(c *gin.Context, bucketRepo objectBucketReader, fileRepo objectFileReader) (*repository.File, int64, bool) {
 	ctx := c.Request.Context()
-	name := strings.TrimPrefix(c.Param("object"), "/")
+	name := s3ObjectKey(c)
 	bucketDoc, ok := lookupBucket(c, bucketRepo)
 	if !ok {
 		return nil, 0, false
@@ -418,7 +422,7 @@ func PutObject(bucketRepo *repository.BucketRepository, sourceRepo *repository.S
 			c.Status(http.StatusServiceUnavailable)
 			return
 		}
-		name := strings.TrimPrefix(c.Param("object"), "/")
+		name := s3ObjectKey(c)
 		if name == "" {
 			writeS3Error(c, http.StatusBadRequest, "InvalidRequest", "")
 			return
@@ -466,7 +470,7 @@ func CopyObject(bucketRepo *repository.BucketRepository, sourceRepo *repository.
 		if !ok {
 			return
 		}
-		destKey := strings.TrimPrefix(c.Param("object"), "/")
+		destKey := s3ObjectKey(c)
 		if destKey == "" {
 			writeS3Error(c, http.StatusBadRequest, "InvalidRequest", "empty destination object key")
 			return
@@ -539,7 +543,7 @@ func DeleteObject(bucketRepo *repository.BucketRepository, sourceRepo *repositor
 		if !ok {
 			return
 		}
-		name := strings.TrimPrefix(c.Param("object"), "/")
+		name := s3ObjectKey(c)
 		if name == "" {
 			c.Status(http.StatusNoContent)
 			return

--- a/api-go/internal/handlers/s3_multipart.go
+++ b/api-go/internal/handlers/s3_multipart.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"sort"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/example/sfree/api-go/internal/manager"
@@ -204,7 +203,7 @@ func createMultipartUpload(c *gin.Context, bucketRepo *repository.BucketReposito
 	if !ok {
 		return
 	}
-	objectKey := strings.TrimPrefix(c.Param("object"), "/")
+	objectKey := s3ObjectKey(c)
 	if objectKey == "" {
 		writeS3Error(c, http.StatusBadRequest, "InvalidRequest", "empty object key")
 		return

--- a/api-go/internal/handlers/s3_test.go
+++ b/api-go/internal/handlers/s3_test.go
@@ -80,6 +80,35 @@ func TestParseCopySource(t *testing.T) {
 	}
 }
 
+func TestS3ObjectKeyNormalizesGinWildcard(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		param string
+		want  string
+	}{
+		{name: "leading slash key", param: "/dir/object.txt", want: "dir/object.txt"},
+		{name: "normal key", param: "dir/object.txt", want: "dir/object.txt"},
+		{name: "empty wildcard slash", param: "/", want: ""},
+		{name: "empty wildcard", param: "", want: ""},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			c, _ := testS3GinContext("/api/s3/bucket/" + tt.param)
+			c.Params = gin.Params{{Key: "object", Value: tt.param}}
+
+			if got := s3ObjectKey(c); got != tt.want {
+				t.Fatalf("expected object key %q, got %q", tt.want, got)
+			}
+		})
+	}
+}
+
 func TestParseObjectRange(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- add a shared S3 object-key helper for Gin wildcard route params
- use it across object lookup, put, copy, delete, and multipart create paths
- add focused coverage for normal, leading-slash, and empty wildcard object keys

## Validation
- gofmt on changed Go files
- git diff --check
- Not run locally: Go test suite, Docker, E2E, Playwright. Woodpecker owns CI validation per agent resource constraints.

Paperclip: [THE-631](/THE/issues/THE-631)