### PR TITLE
THE-681 Fix weighted upload failover

### DIFF
--- a/api-go/internal/manager/chunk_upload.go
+++ b/api-go/internal/manager/chunk_upload.go
@@ -59,7 +59,7 @@ func UploadFileChunksWithStrategy(ctx context.Context, r io.Reader, sources []re
 		chunkData := make([]byte, n)
 		copy(chunkData, buf[:n])
 
-		src, cli, err := pickSourceClient(ctx, sources, selector, clientCache)
+		srcIdx, src, cli, err := pickSourceClient(ctx, sources, selector, clientCache)
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, "source selection failed")
@@ -81,12 +81,13 @@ func UploadFileChunksWithStrategy(ctx context.Context, r io.Reader, sources []re
 		if uploadErr != nil && len(sources) > 1 {
 			chunkSpan.RecordError(uploadErr)
 			tried := map[primitive.ObjectID]bool{src.ID: true}
-			for attempt := 0; attempt < len(sources)-1; attempt++ {
-				altSrc, altCli, altErr := pickSourceClient(ctx, sources, selector, clientCache)
-				if altErr != nil {
+			for offset := 1; offset < len(sources); offset++ {
+				altSrc := sources[(srcIdx+offset)%len(sources)]
+				if tried[altSrc.ID] {
 					continue
 				}
-				if tried[altSrc.ID] {
+				altCli, altErr := clientCache.get(ctx, altSrc)
+				if altErr != nil {
 					continue
 				}
 				tried[altSrc.ID] = true
@@ -163,14 +164,14 @@ func cleanupUploadedChunks(ctx context.Context, chunks []repository.FileChunk, c
 	}
 }
 
-func pickSourceClient(ctx context.Context, sources []repository.Source, selector SourceSelector, clientCache *sourceClientCache) (repository.Source, sourceClient, error) {
-	_, src, err := selector.NextSource(sources)
+func pickSourceClient(ctx context.Context, sources []repository.Source, selector SourceSelector, clientCache *sourceClientCache) (int, repository.Source, sourceClient, error) {
+	idx, src, err := selector.NextSource(sources)
 	if err != nil {
-		return repository.Source{}, nil, err
+		return 0, repository.Source{}, nil, err
 	}
 	cli, err := clientCache.get(ctx, src)
 	if err != nil {
-		return repository.Source{}, nil, err
+		return 0, repository.Source{}, nil, err
 	}
-	return src, cli, nil
+	return idx, src, cli, nil
 }

--- a/api-go/internal/manager/file_test.go
+++ b/api-go/internal/manager/file_test.go
@@ -415,6 +415,43 @@ func TestUploadFileChunksWithWeightedStrategy(t *testing.T) {
 	}
 }
 
+func TestUploadFileChunksWeightedFailoverTriesLowWeightSource(t *testing.T) {
+	t.Parallel()
+	s1 := repository.Source{ID: primitive.NewObjectID(), Type: repository.SourceTypeTelegram}
+	s2 := repository.Source{ID: primitive.NewObjectID(), Type: repository.SourceTypeTelegram}
+	sources := []repository.Source{s1, s2}
+
+	failingStub := &stubSourceClient{uploadErr: errors.New("source down")}
+	workingStub := &stubSourceClient{}
+	factory := func(_ context.Context, src *repository.Source) (sourceClient, error) {
+		if src.ID == s1.ID {
+			return failingStub, nil
+		}
+		return workingStub, nil
+	}
+
+	weights := map[string]int{s1.ID.Hex(): MaxWeightedSourceWeight, s2.ID.Hex(): 1}
+	sel := NewWeightedSelector(sources, weights)
+
+	payload := []byte("abcdef")
+	chunks, err := UploadFileChunksWithStrategy(context.Background(), bytes.NewReader(payload), sources, len(payload), factory, sel)
+	if err != nil {
+		t.Fatalf("expected failover to low-weight source, got %v", err)
+	}
+	if len(chunks) != 1 {
+		t.Fatalf("expected 1 chunk, got %d", len(chunks))
+	}
+	if chunks[0].SourceID != s2.ID {
+		t.Fatalf("expected chunk on low-weight source after failover, got %s", chunks[0].SourceID.Hex())
+	}
+	if failingStub.uploadCalls != 1 {
+		t.Fatalf("expected failing source to be tried once, got %d", failingStub.uploadCalls)
+	}
+	if workingStub.uploadCalls != 1 {
+		t.Fatalf("expected low-weight source to be tried once, got %d", workingStub.uploadCalls)
+	}
+}
+
 func TestSelectorForBucketRoundRobin(t *testing.T) {
 	t.Parallel()
 	bucket := &repository.Bucket{DistributionStrategy: repository.StrategyRoundRobin}


### PR DESCRIPTION
## Summary
- make upload failover enumerate each configured source once after an initial upload failure
- preserve weighted selector distribution for successful primary placement
- add a focused regression test for a 1000:1 weighted failing source failing over to a healthy low-weight source

## Validation
- `gofmt` on changed Go files
- `git diff --check`
- Local Go tests not run per task guidance to keep local checks lightweight; full backend validation should run in Woodpecker.

Fixes THE-681