### PR TITLE
Docs: clarify Docker quickstart bucket ID flow

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -140,16 +140,41 @@ Replace `SOURCE_ID` with the source id from step 3.
 Save `access_key` and `access_secret` — these are S3 credentials for this
 bucket (used in step 7).
 
+Now fetch the bucket id used by the REST upload and download endpoints:
+
+```bash
+curl -s http://localhost:8080/api/v1/buckets \
+  -H "Authorization: Basic $AUTH"
+```
+
+**Expected output:**
+
+```json
+[
+  {
+    "id": "BUCKET_ID",
+    "key": "my-bucket",
+    "access_key": "my-bucket",
+    "created_at": "...",
+    "role": "owner",
+    "shared": false
+  }
+]
+```
+
+Set `BUCKET_ID` to the `id` for `my-bucket`:
+
+```bash
+BUCKET_ID=BUCKET_ID
+```
+
 ## 5. Upload a file
 
 ```bash
-curl -s -X POST http://localhost:8080/api/v1/buckets/BUCKET_ID/upload \
+curl -s -X POST "http://localhost:8080/api/v1/buckets/$BUCKET_ID/upload" \
   -H "Authorization: Basic $AUTH" \
   -F 'file=@README.md'
 ```
-
-Replace `BUCKET_ID` with the bucket `id` from step 4 (check with
-`GET /api/v1/buckets` if needed).
 
 **Expected output:**
 
@@ -164,7 +189,7 @@ Replace `BUCKET_ID` with the bucket `id` from step 4 (check with
 ## 6. Download the file
 
 ```bash
-curl -s http://localhost:8080/api/v1/buckets/BUCKET_ID/files/FILE_ID/download \
+curl -s "http://localhost:8080/api/v1/buckets/$BUCKET_ID/files/FILE_ID/download" \
   -H "Authorization: Basic $AUTH" \
   -o downloaded-README.md
 ```


### PR DESCRIPTION
## Summary
- Add an explicit `GET /api/v1/buckets` step after bucket creation in the Docker quickstart.
- Show the current Go API list-buckets response shape, including `id`, `key`, `access_key`, `created_at`, `role`, and `shared`.
- Reuse `$BUCKET_ID` in the REST upload and download examples.

## Validation
- `git diff --check`
- Markdown/diff review only, per task constraints. No Docker Compose or other CPU-heavy validation run.