### PR TITLE
THE-689 Surface bucket grant cleanup failures

### DIFF
--- a/api-go/internal/handlers/bucket.go
+++ b/api-go/internal/handlers/bucket.go
@@ -403,6 +403,13 @@ func handleDeleteBucket(c *gin.Context, repo bucketDeleteStore, shareLinkRepo sh
 		c.Status(http.StatusInternalServerError)
 		return
 	}
+	if grantDeleter != nil {
+		if err := grantDeleter.DeleteByBucket(ctx, acc.Bucket.ID); err != nil {
+			slog.ErrorContext(ctx, "delete bucket: cleanup grants", slog.String("bucket_id", acc.Bucket.ID.Hex()), slog.String("owner_user_id", acc.Bucket.UserID.Hex()), slog.String("error", err.Error()))
+			c.Status(http.StatusInternalServerError)
+			return
+		}
+	}
 	if err := repo.Delete(ctx, acc.Bucket.ID, acc.Bucket.UserID); err != nil {
 		if err == mongo.ErrNoDocuments {
 			c.Status(http.StatusNotFound)
@@ -411,9 +418,6 @@ func handleDeleteBucket(c *gin.Context, repo bucketDeleteStore, shareLinkRepo sh
 		slog.ErrorContext(ctx, "delete bucket: failed to delete", slog.String("error", err.Error()))
 		c.Status(http.StatusInternalServerError)
 		return
-	}
-	if grantDeleter != nil {
-		_ = grantDeleter.DeleteByBucket(ctx, acc.Bucket.ID)
 	}
 	c.Status(http.StatusOK)
 }

--- a/api-go/internal/handlers/bucket_delete_cleanup_test.go
+++ b/api-go/internal/handlers/bucket_delete_cleanup_test.go
@@ -85,7 +85,7 @@ func TestDeleteFileShareCleanupFailureReturns500AndSkipsObjectDelete(t *testing.
 	}
 }
 
-func TestDeleteBucketCleansShareLinksBeforeContentsDelete(t *testing.T) {
+func TestDeleteBucketCleansShareLinksAndGrantsBeforeBucketDelete(t *testing.T) {
 	t.Parallel()
 
 	userID := primitive.NewObjectID()
@@ -102,7 +102,7 @@ func TestDeleteBucketCleansShareLinksBeforeContentsDelete(t *testing.T) {
 				&fakeShareLinkCleanup{events: &events},
 				&fakeBucketContentsDelete{events: &events},
 				nil,
-				nil,
+				&fakeBucketGrantCleanup{events: &events},
 			)
 		},
 	)
@@ -114,7 +114,7 @@ func TestDeleteBucketCleansShareLinksBeforeContentsDelete(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", w.Code)
 	}
-	if !reflect.DeepEqual(events, []string{"share_bucket", "bucket_contents", "bucket_delete"}) {
+	if !reflect.DeepEqual(events, []string{"share_bucket", "bucket_contents", "bucket_grants", "bucket_delete"}) {
 		t.Fatalf("unexpected event order: %v", events)
 	}
 }
@@ -149,6 +149,40 @@ func TestDeleteBucketShareCleanupFailureReturns500AndSkipsDeletes(t *testing.T) 
 		t.Fatalf("expected 500, got %d", w.Code)
 	}
 	if !reflect.DeepEqual(events, []string{"share_bucket"}) {
+		t.Fatalf("unexpected event order: %v", events)
+	}
+}
+
+func TestDeleteBucketGrantCleanupFailureReturns500AndSkipsBucketDelete(t *testing.T) {
+	t.Parallel()
+
+	userID := primitive.NewObjectID()
+	bucketID := primitive.NewObjectID()
+	events := []string{}
+
+	router := gin.New()
+	router.DELETE("/buckets/:id",
+		setUserID(userID.Hex()),
+		func(c *gin.Context) {
+			handleDeleteBucket(
+				c,
+				&fakeBucketDeleteStore{bucket: testDeleteBucket(bucketID, userID), events: &events},
+				&fakeShareLinkCleanup{events: &events},
+				&fakeBucketContentsDelete{events: &events},
+				nil,
+				&fakeBucketGrantCleanup{events: &events, err: errors.New("grant cleanup failed")},
+			)
+		},
+	)
+
+	req, _ := http.NewRequest(http.MethodDelete, "/buckets/"+bucketID.Hex(), nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", w.Code)
+	}
+	if !reflect.DeepEqual(events, []string{"share_bucket", "bucket_contents", "bucket_grants"}) {
 		t.Fatalf("unexpected event order: %v", events)
 	}
 }
@@ -200,6 +234,18 @@ func (f *fakeShareLinkCleanup) DeleteByFile(_ context.Context, _ primitive.Objec
 func (f *fakeShareLinkCleanup) DeleteByBucket(_ context.Context, _ primitive.ObjectID) error {
 	if f.events != nil {
 		*f.events = append(*f.events, "share_bucket")
+	}
+	return f.err
+}
+
+type fakeBucketGrantCleanup struct {
+	events *[]string
+	err    error
+}
+
+func (f *fakeBucketGrantCleanup) DeleteByBucket(_ context.Context, _ primitive.ObjectID) error {
+	if f.events != nil {
+		*f.events = append(*f.events, "bucket_grants")
 	}
 	return f.err
 }


### PR DESCRIPTION
## Summary

- Make REST bucket deletion treat bucket grant cleanup as part of the observable delete operation.
- Preserve current-main bucket cleanup wiring: share links are deleted first, then bucket contents, then bucket grants, then the bucket document.
- Return HTTP 500 when bucket grant cleanup fails so the delete call does not report success while leaving stale grant state behind.
- Add focused cleanup-order coverage for successful grant cleanup and grant cleanup failure on the current-main handler test surface.

## Validation

- `gofmt -w api-go/internal/handlers/bucket.go api-go/internal/handlers/bucket_delete_cleanup_test.go`
- `git diff --check`
- `go test ./internal/handlers -run '^TestDelete(Bucket|File)'`
- `go test ./... -run '^$'`
- Woodpecker rerun pending on refreshed head `fcb2c98`

Link: [THE-689](/THE/issues/THE-689)