### PR TITLE
THE-697 Add graceful api-go server shutdown

### DIFF
--- a/api-go/cmd/server/main.go
+++ b/api-go/cmd/server/main.go
@@ -8,8 +8,13 @@ package main
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"log/slog"
+	"net/http"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"time"
 
@@ -23,23 +28,42 @@ import (
 	"github.com/example/sfree/api-go/internal/telemetry"
 )
 
+const (
+	serverAddr      = ":8080"
+	shutdownTimeout = 10 * time.Second
+)
+
+type gracefulServer interface {
+	ListenAndServe() error
+	Shutdown(context.Context) error
+}
+
 func main() {
 	observability.SetupLogger()
 
-	cfg, err := config.Load()
-	if err != nil {
-		slog.Error("failed to load config", slog.String("error", err.Error()))
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	if err := run(ctx); err != nil {
+		slog.Error("server exited with error", slog.String("error", err.Error()))
 		os.Exit(1)
 	}
-	ctx := context.Background()
+}
+
+func run(ctx context.Context) error {
+	cfg, err := config.Load()
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
 
 	shutdownTracer, err := telemetry.Init(ctx, "sfree-api")
 	if err != nil {
-		slog.Error("failed to init telemetry", slog.String("error", err.Error()))
-		os.Exit(1)
+		return fmt.Errorf("failed to init telemetry: %w", err)
 	}
 	defer func() {
-		if err := shutdownTracer(ctx); err != nil {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+		defer cancel()
+		if err := shutdownTracer(shutdownCtx); err != nil {
 			slog.Error("failed to shutdown tracer", slog.String("error", err.Error()))
 		}
 	}()
@@ -68,17 +92,58 @@ func main() {
 
 	mongoConn, err := db.Connect(ctx, cfg.Mongo)
 	if err != nil {
-		slog.Error("failed to connect mongo", slog.String("error", err.Error()))
-		os.Exit(1)
+		return fmt.Errorf("failed to connect mongo: %w", err)
 	}
+	defer func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+		defer cancel()
+		if err := mongoConn.Close(shutdownCtx); err != nil {
+			slog.Error("failed to close mongo", slog.String("error", err.Error()))
+		}
+	}()
+
 	router, err := app.SetupRouter(mongoConn, cfg)
 	if err != nil {
-		slog.Error("failed to initialize router", slog.String("error", err.Error()))
-		os.Exit(1)
+		return fmt.Errorf("failed to initialize router: %w", err)
 	}
-	slog.Info("starting server")
-	if err := router.Run(); err != nil {
-		slog.Error("failed to run server", slog.String("error", err.Error()))
-		os.Exit(1)
+
+	server := &http.Server{
+		Addr:    serverAddr,
+		Handler: router,
 	}
+
+	slog.Info("starting server", slog.String("addr", server.Addr))
+	if err := runServer(ctx, server, shutdownTimeout); err != nil {
+		return fmt.Errorf("failed to run server: %w", err)
+	}
+	slog.Info("server stopped")
+	return nil
+}
+
+func runServer(ctx context.Context, server gracefulServer, timeout time.Duration) error {
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- server.ListenAndServe()
+	}()
+
+	select {
+	case err := <-errCh:
+		if errors.Is(err, http.ErrServerClosed) {
+			return nil
+		}
+		return err
+	case <-ctx.Done():
+	}
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	if err := server.Shutdown(shutdownCtx); err != nil {
+		return err
+	}
+
+	err := <-errCh
+	if errors.Is(err, http.ErrServerClosed) {
+		return nil
+	}
+	return err
 }

--- a/api-go/cmd/server/main_test.go
+++ b/api-go/cmd/server/main_test.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+)
+
+type fakeGracefulServer struct {
+	listenErr      error
+	shutdownErr    error
+	listenStarted  chan struct{}
+	releaseListen  chan struct{}
+	shutdownCalled chan context.Context
+}
+
+func newFakeGracefulServer(listenErr error) *fakeGracefulServer {
+	return &fakeGracefulServer{
+		listenErr:      listenErr,
+		listenStarted:  make(chan struct{}),
+		releaseListen:  make(chan struct{}),
+		shutdownCalled: make(chan context.Context, 1),
+	}
+}
+
+func (s *fakeGracefulServer) ListenAndServe() error {
+	close(s.listenStarted)
+	<-s.releaseListen
+	return s.listenErr
+}
+
+func (s *fakeGracefulServer) Shutdown(ctx context.Context) error {
+	s.shutdownCalled <- ctx
+	close(s.releaseListen)
+	return s.shutdownErr
+}
+
+type immediateServer struct {
+	err error
+}
+
+func (s immediateServer) ListenAndServe() error {
+	return s.err
+}
+
+func (s immediateServer) Shutdown(context.Context) error {
+	return nil
+}
+
+func TestRunServerGracefulShutdown(t *testing.T) {
+	server := newFakeGracefulServer(http.ErrServerClosed)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+
+	go func() {
+		done <- runServer(ctx, server, time.Second)
+	}()
+
+	<-server.listenStarted
+	cancel()
+
+	shutdownCtx := <-server.shutdownCalled
+	if _, ok := shutdownCtx.Deadline(); !ok {
+		t.Fatal("shutdown context has no deadline")
+	}
+
+	if err := <-done; err != nil {
+		t.Fatalf("runServer returned error: %v", err)
+	}
+}
+
+func TestRunServerReturnsListenError(t *testing.T) {
+	wantErr := errors.New("listen failed")
+	err := runServer(context.Background(), immediateServer{err: wantErr}, time.Second)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("runServer error = %v, want %v", err, wantErr)
+	}
+}
+
+func TestRunServerReturnsShutdownError(t *testing.T) {
+	wantErr := errors.New("shutdown failed")
+	server := newFakeGracefulServer(http.ErrServerClosed)
+	server.shutdownErr = wantErr
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+
+	go func() {
+		done <- runServer(ctx, server, time.Second)
+	}()
+
+	<-server.listenStarted
+	cancel()
+
+	err := <-done
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("runServer error = %v, want %v", err, wantErr)
+	}
+}


### PR DESCRIPTION
## Summary
- replace Gin router.Run with an http.Server using the existing :8080 bind address
- handle SIGINT/SIGTERM with bounded graceful HTTP shutdown
- close MongoDB and shutdown tracing with bounded contexts
- add focused unit coverage for the shutdown helper without binding a fixed port

## Validation
- go test -count=1 ./cmd/server

## Notes
- No API routes, config format, Docker targets, or Woodpecker pipeline behavior changed.