### PR TITLE
THE-696 Cascade share-link cleanup on delete

### DIFF
--- a/api-go/internal/app/router_routes.go
+++ b/api-go/internal/app/router_routes.go
@@ -55,7 +55,7 @@ func registerBucketRoutes(router *gin.Engine, cfg *config.Config, deps *routerDe
 	router.POST("/api/v1/buckets", protectedHandlers(limits, deps.auth, handlers.CreateBucket(deps.bucketRepo, deps.sourceRepo, routerAccessSecret(cfg)))...)
 	router.GET("/api/v1/buckets", protectedHandlers(limits, deps.auth, handlers.ListBuckets(deps.bucketRepo, deps.grantRepo))...)
 	router.GET("/api/v1/buckets/:id", protectedHandlers(limits, deps.auth, handlers.GetBucket(deps.bucketRepo, deps.grantRepo))...)
-	router.DELETE("/api/v1/buckets/:id", protectedHandlers(limits, deps.auth, handlers.DeleteBucketWithFactory(deps.bucketRepo, deps.sourceRepo, deps.fileRepo, deps.mpRepo, deps.grantRepo, deps.sourceFactory))...)
+	router.DELETE("/api/v1/buckets/:id", protectedHandlers(limits, deps.auth, handlers.DeleteBucketWithFactory(deps.bucketRepo, deps.sourceRepo, deps.fileRepo, deps.mpRepo, deps.shareLinkRepo, deps.grantRepo, deps.sourceFactory))...)
 	router.PATCH("/api/v1/buckets/:id/distribution", protectedHandlers(limits, deps.auth, handlers.UpdateBucketDistribution(deps.bucketRepo, deps.grantRepo))...)
 
 	registerBucketGrantRoutes(router, deps, limits)
@@ -79,7 +79,7 @@ func registerBucketFileRoutes(router *gin.Engine, cfg *config.Config, deps *rout
 	router.POST("/api/v1/buckets/:id/upload", protectedHandlers(limits, deps.auth, handlers.UploadFileWithFactory(deps.bucketRepo, deps.sourceRepo, deps.fileRepo, deps.grantRepo, routerUploadChunkSize(cfg), deps.sourceFactory))...)
 	router.GET("/api/v1/buckets/:id/files", protectedHandlers(limits, deps.auth, handlers.ListFiles(deps.bucketRepo, deps.fileRepo, deps.grantRepo))...)
 	router.GET("/api/v1/buckets/:id/files/:file_id/download", protectedHandlers(limits, deps.auth, handlers.DownloadFileWithFactory(deps.bucketRepo, deps.sourceRepo, deps.fileRepo, deps.grantRepo, deps.sourceFactory))...)
-	router.DELETE("/api/v1/buckets/:id/files/:file_id", protectedHandlers(limits, deps.auth, handlers.DeleteFileWithFactory(deps.bucketRepo, deps.sourceRepo, deps.fileRepo, deps.grantRepo, deps.sourceFactory))...)
+	router.DELETE("/api/v1/buckets/:id/files/:file_id", protectedHandlers(limits, deps.auth, handlers.DeleteFileWithFactory(deps.bucketRepo, deps.sourceRepo, deps.fileRepo, deps.shareLinkRepo, deps.grantRepo, deps.sourceFactory))...)
 	if deps.shareLinkRepo == nil {
 		return
 	}

--- a/api-go/internal/handlers/bucket.go
+++ b/api-go/internal/handlers/bucket.go
@@ -34,6 +34,31 @@ type bucketCreator interface {
 	Create(context.Context, repository.Bucket) (*repository.Bucket, error)
 }
 
+type bucketDeleteStore interface {
+	bucketAccessBucketReader
+	Delete(ctx context.Context, id primitive.ObjectID, userID primitive.ObjectID) error
+}
+
+type bucketGrantBucketDeleter interface {
+	DeleteByBucket(ctx context.Context, bucketID primitive.ObjectID) error
+}
+
+type bucketContentsDeleter interface {
+	DeleteBucketContents(ctx context.Context, bucketID primitive.ObjectID) (manager.DeleteBucketContentsResult, error)
+}
+
+type objectFileDeleter interface {
+	DeleteFile(ctx context.Context, bucketID, fileID primitive.ObjectID) (manager.DeleteObjectResult, error)
+}
+
+type shareLinkBucketDeleter interface {
+	DeleteByBucket(ctx context.Context, bucketID primitive.ObjectID) error
+}
+
+type shareLinkFileDeleter interface {
+	DeleteByFile(ctx context.Context, fileID primitive.ObjectID) error
+}
+
 func validateSourceWeights(weights map[string]int, sourceIDs []primitive.ObjectID) error {
 	if len(weights) == 0 {
 		return nil
@@ -324,11 +349,11 @@ func getBucket(bucketRepo bucketAccessBucketReader, grantRepo bucketAccessGrantR
 // @Failure 500 {string} string ""
 // @Security BasicAuth
 // @Router /api/v1/buckets/{id} [delete]
-func DeleteBucket(repo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository, mpRepo *repository.MultipartUploadRepository, grantRepo *repository.BucketGrantRepository) gin.HandlerFunc {
-	return DeleteBucketWithFactory(repo, sourceRepo, fileRepo, mpRepo, grantRepo, nil)
+func DeleteBucket(repo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository, mpRepo *repository.MultipartUploadRepository, shareLinkRepo *repository.ShareLinkRepository, grantRepo *repository.BucketGrantRepository) gin.HandlerFunc {
+	return DeleteBucketWithFactory(repo, sourceRepo, fileRepo, mpRepo, shareLinkRepo, grantRepo, nil)
 }
 
-func DeleteBucketWithFactory(repo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository, mpRepo *repository.MultipartUploadRepository, grantRepo *repository.BucketGrantRepository, factory manager.SourceClientFactory) gin.HandlerFunc {
+func DeleteBucketWithFactory(repo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository, mpRepo *repository.MultipartUploadRepository, shareLinkRepo *repository.ShareLinkRepository, grantRepo *repository.BucketGrantRepository, factory manager.SourceClientFactory) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		ctx := c.Request.Context()
 		if repo == nil {
@@ -336,39 +361,61 @@ func DeleteBucketWithFactory(repo *repository.BucketRepository, sourceRepo *repo
 			c.Status(http.StatusServiceUnavailable)
 			return
 		}
-
-		acc := requireBucketAccess(c, repo, grantRepo, repository.RoleOwner)
-		if acc == nil {
-			return
+		var objectSvc bucketContentsDeleter
+		if sourceRepo != nil && fileRepo != nil {
+			objectSvc = manager.NewObjectServiceWithSourceClientFactory(sourceRepo, fileRepo, mpRepo, factory)
 		}
-
-		if sourceRepo == nil || fileRepo == nil {
-			slog.ErrorContext(ctx, "delete bucket: cleanup repository is nil")
-			c.Status(http.StatusServiceUnavailable)
-			return
-		}
-		objectSvc := manager.NewObjectServiceWithSourceClientFactory(sourceRepo, fileRepo, mpRepo, factory)
-		if _, err := objectSvc.DeleteBucketContents(ctx, acc.Bucket.ID); err != nil {
-			slog.ErrorContext(ctx, "delete bucket: cleanup contents", slog.String("error", err.Error()))
-			c.Status(http.StatusInternalServerError)
-			return
-		}
-
-		if err := repo.Delete(ctx, acc.Bucket.ID, acc.Bucket.UserID); err != nil {
-			if err == mongo.ErrNoDocuments {
-				c.Status(http.StatusNotFound)
-				return
-			}
-			slog.ErrorContext(ctx, "delete bucket: failed to delete", slog.String("error", err.Error()))
-			c.Status(http.StatusInternalServerError)
-			return
-		}
-		// Clean up all grants for this bucket.
+		var grantReader bucketAccessGrantReader
+		var grantDeleter bucketGrantBucketDeleter
 		if grantRepo != nil {
-			_ = grantRepo.DeleteByBucket(ctx, acc.Bucket.ID)
+			grantReader = grantRepo
+			grantDeleter = grantRepo
 		}
-		c.Status(http.StatusOK)
+		handleDeleteBucket(c, repo, shareLinkRepo, objectSvc, grantReader, grantDeleter)
 	}
+}
+
+func handleDeleteBucket(c *gin.Context, repo bucketDeleteStore, shareLinkRepo shareLinkBucketDeleter, objectSvc bucketContentsDeleter, grantRepo bucketAccessGrantReader, grantDeleter bucketGrantBucketDeleter) {
+	ctx := c.Request.Context()
+	if repo == nil {
+		slog.ErrorContext(ctx, "delete bucket: repository is nil")
+		c.Status(http.StatusServiceUnavailable)
+		return
+	}
+
+	acc := requireBucketAccessFor(c, repo, grantRepo, repository.RoleOwner)
+	if acc == nil {
+		return
+	}
+	if shareLinkRepo == nil || objectSvc == nil {
+		slog.ErrorContext(ctx, "delete bucket: cleanup repository is nil")
+		c.Status(http.StatusServiceUnavailable)
+		return
+	}
+
+	if err := shareLinkRepo.DeleteByBucket(ctx, acc.Bucket.ID); err != nil {
+		slog.ErrorContext(ctx, "delete bucket: cleanup share links", slog.String("error", err.Error()))
+		c.Status(http.StatusInternalServerError)
+		return
+	}
+	if _, err := objectSvc.DeleteBucketContents(ctx, acc.Bucket.ID); err != nil {
+		slog.ErrorContext(ctx, "delete bucket: cleanup contents", slog.String("error", err.Error()))
+		c.Status(http.StatusInternalServerError)
+		return
+	}
+	if err := repo.Delete(ctx, acc.Bucket.ID, acc.Bucket.UserID); err != nil {
+		if err == mongo.ErrNoDocuments {
+			c.Status(http.StatusNotFound)
+			return
+		}
+		slog.ErrorContext(ctx, "delete bucket: failed to delete", slog.String("error", err.Error()))
+		c.Status(http.StatusInternalServerError)
+		return
+	}
+	if grantDeleter != nil {
+		_ = grantDeleter.DeleteByBucket(ctx, acc.Bucket.ID)
+	}
+	c.Status(http.StatusOK)
 }
 
 type updateDistributionRequest struct {

--- a/api-go/internal/handlers/bucket_delete_cleanup_test.go
+++ b/api-go/internal/handlers/bucket_delete_cleanup_test.go
@@ -1,0 +1,240 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/example/sfree/api-go/internal/manager"
+	"github.com/example/sfree/api-go/internal/repository"
+	"github.com/gin-gonic/gin"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+func TestDeleteFileCleansShareLinksBeforeObjectDelete(t *testing.T) {
+	t.Parallel()
+
+	userID := primitive.NewObjectID()
+	bucketID := primitive.NewObjectID()
+	fileID := primitive.NewObjectID()
+	events := []string{}
+
+	router := gin.New()
+	router.DELETE("/buckets/:id/files/:file_id",
+		setUserID(userID.Hex()),
+		func(c *gin.Context) {
+			handleDeleteFile(
+				c,
+				fakeBucketDeleteStore{bucket: testDeleteBucket(bucketID, userID)},
+				fakeDeleteFileReader{file: &repository.File{ID: fileID, BucketID: bucketID, CreatedAt: time.Now().UTC()}},
+				&fakeShareLinkCleanup{events: &events},
+				&fakeObjectFileDelete{events: &events},
+				nil,
+			)
+		},
+	)
+
+	req, _ := http.NewRequest(http.MethodDelete, "/buckets/"+bucketID.Hex()+"/files/"+fileID.Hex(), nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if !reflect.DeepEqual(events, []string{"share_file", "object_file"}) {
+		t.Fatalf("unexpected event order: %v", events)
+	}
+}
+
+func TestDeleteFileShareCleanupFailureReturns500AndSkipsObjectDelete(t *testing.T) {
+	t.Parallel()
+
+	userID := primitive.NewObjectID()
+	bucketID := primitive.NewObjectID()
+	fileID := primitive.NewObjectID()
+	events := []string{}
+
+	router := gin.New()
+	router.DELETE("/buckets/:id/files/:file_id",
+		setUserID(userID.Hex()),
+		func(c *gin.Context) {
+			handleDeleteFile(
+				c,
+				fakeBucketDeleteStore{bucket: testDeleteBucket(bucketID, userID)},
+				fakeDeleteFileReader{file: &repository.File{ID: fileID, BucketID: bucketID, CreatedAt: time.Now().UTC()}},
+				&fakeShareLinkCleanup{events: &events, err: errors.New("share cleanup failed")},
+				&fakeObjectFileDelete{events: &events},
+				nil,
+			)
+		},
+	)
+
+	req, _ := http.NewRequest(http.MethodDelete, "/buckets/"+bucketID.Hex()+"/files/"+fileID.Hex(), nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", w.Code)
+	}
+	if !reflect.DeepEqual(events, []string{"share_file"}) {
+		t.Fatalf("unexpected event order: %v", events)
+	}
+}
+
+func TestDeleteBucketCleansShareLinksBeforeContentsDelete(t *testing.T) {
+	t.Parallel()
+
+	userID := primitive.NewObjectID()
+	bucketID := primitive.NewObjectID()
+	events := []string{}
+
+	router := gin.New()
+	router.DELETE("/buckets/:id",
+		setUserID(userID.Hex()),
+		func(c *gin.Context) {
+			handleDeleteBucket(
+				c,
+				&fakeBucketDeleteStore{bucket: testDeleteBucket(bucketID, userID), events: &events},
+				&fakeShareLinkCleanup{events: &events},
+				&fakeBucketContentsDelete{events: &events},
+				nil,
+				nil,
+			)
+		},
+	)
+
+	req, _ := http.NewRequest(http.MethodDelete, "/buckets/"+bucketID.Hex(), nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if !reflect.DeepEqual(events, []string{"share_bucket", "bucket_contents", "bucket_delete"}) {
+		t.Fatalf("unexpected event order: %v", events)
+	}
+}
+
+func TestDeleteBucketShareCleanupFailureReturns500AndSkipsDeletes(t *testing.T) {
+	t.Parallel()
+
+	userID := primitive.NewObjectID()
+	bucketID := primitive.NewObjectID()
+	events := []string{}
+
+	router := gin.New()
+	router.DELETE("/buckets/:id",
+		setUserID(userID.Hex()),
+		func(c *gin.Context) {
+			handleDeleteBucket(
+				c,
+				&fakeBucketDeleteStore{bucket: testDeleteBucket(bucketID, userID), events: &events},
+				&fakeShareLinkCleanup{events: &events, err: errors.New("share cleanup failed")},
+				&fakeBucketContentsDelete{events: &events},
+				nil,
+				nil,
+			)
+		},
+	)
+
+	req, _ := http.NewRequest(http.MethodDelete, "/buckets/"+bucketID.Hex(), nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", w.Code)
+	}
+	if !reflect.DeepEqual(events, []string{"share_bucket"}) {
+		t.Fatalf("unexpected event order: %v", events)
+	}
+}
+
+type fakeBucketDeleteStore struct {
+	bucket *repository.Bucket
+	err    error
+	events *[]string
+}
+
+func (f fakeBucketDeleteStore) GetByID(_ context.Context, _ primitive.ObjectID) (*repository.Bucket, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.bucket, nil
+}
+
+func (f *fakeBucketDeleteStore) Delete(_ context.Context, _ primitive.ObjectID, _ primitive.ObjectID) error {
+	if f.events != nil {
+		*f.events = append(*f.events, "bucket_delete")
+	}
+	return f.err
+}
+
+type fakeDeleteFileReader struct {
+	file *repository.File
+	err  error
+}
+
+func (f fakeDeleteFileReader) GetByID(_ context.Context, _ primitive.ObjectID) (*repository.File, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.file, nil
+}
+
+type fakeShareLinkCleanup struct {
+	events *[]string
+	err    error
+}
+
+func (f *fakeShareLinkCleanup) DeleteByFile(_ context.Context, _ primitive.ObjectID) error {
+	if f.events != nil {
+		*f.events = append(*f.events, "share_file")
+	}
+	return f.err
+}
+
+func (f *fakeShareLinkCleanup) DeleteByBucket(_ context.Context, _ primitive.ObjectID) error {
+	if f.events != nil {
+		*f.events = append(*f.events, "share_bucket")
+	}
+	return f.err
+}
+
+type fakeObjectFileDelete struct {
+	events *[]string
+	err    error
+	result manager.DeleteObjectResult
+}
+
+func (f *fakeObjectFileDelete) DeleteFile(_ context.Context, _ primitive.ObjectID, _ primitive.ObjectID) (manager.DeleteObjectResult, error) {
+	if f.events != nil {
+		*f.events = append(*f.events, "object_file")
+	}
+	return f.result, f.err
+}
+
+type fakeBucketContentsDelete struct {
+	events *[]string
+	err    error
+	result manager.DeleteBucketContentsResult
+}
+
+func (f *fakeBucketContentsDelete) DeleteBucketContents(_ context.Context, _ primitive.ObjectID) (manager.DeleteBucketContentsResult, error) {
+	if f.events != nil {
+		*f.events = append(*f.events, "bucket_contents")
+	}
+	return f.result, f.err
+}
+
+func testDeleteBucket(bucketID, userID primitive.ObjectID) *repository.Bucket {
+	return &repository.Bucket{
+		ID:        bucketID,
+		UserID:    userID,
+		Key:       "bucket",
+		CreatedAt: time.Now().UTC(),
+	}
+}

--- a/api-go/internal/handlers/bucket_files.go
+++ b/api-go/internal/handlers/bucket_files.go
@@ -237,45 +237,78 @@ func downloadFile(bucketRepo bucketAccessBucketReader, sourceRepo *repository.So
 // @Failure 500 {string} string ""
 // @Security BasicAuth
 // @Router /api/v1/buckets/{id}/files/{file_id} [delete]
-func DeleteFile(bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository, grantRepo *repository.BucketGrantRepository) gin.HandlerFunc {
-	return DeleteFileWithFactory(bucketRepo, sourceRepo, fileRepo, grantRepo, nil)
+func DeleteFile(bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository, shareLinkRepo *repository.ShareLinkRepository, grantRepo *repository.BucketGrantRepository) gin.HandlerFunc {
+	return DeleteFileWithFactory(bucketRepo, sourceRepo, fileRepo, shareLinkRepo, grantRepo, nil)
 }
 
-func DeleteFileWithFactory(bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository, grantRepo *repository.BucketGrantRepository, factory manager.SourceClientFactory) gin.HandlerFunc {
+func DeleteFileWithFactory(bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository, shareLinkRepo *repository.ShareLinkRepository, grantRepo *repository.BucketGrantRepository, factory manager.SourceClientFactory) gin.HandlerFunc {
 	objectSvc := manager.NewObjectServiceWithSourceClientFactory(sourceRepo, fileRepo, nil, factory)
 	return func(c *gin.Context) {
 		ctx := c.Request.Context()
-		if bucketRepo == nil || sourceRepo == nil || fileRepo == nil {
+		if bucketRepo == nil || sourceRepo == nil || fileRepo == nil || shareLinkRepo == nil {
 			slog.ErrorContext(ctx, "delete file: repository is nil")
 			c.Status(http.StatusServiceUnavailable)
 			return
 		}
-
-		acc := requireBucketAccess(c, bucketRepo, grantRepo, repository.RoleEditor)
-		if acc == nil {
-			return
+		var grantReader bucketAccessGrantReader
+		if grantRepo != nil {
+			grantReader = grantRepo
 		}
-		bucketID := acc.Bucket.ID
-
-		fileID, ok := routeObjectID(c, "file_id")
-		if !ok {
-			return
-		}
-		result, err := objectSvc.DeleteFile(ctx, bucketID, fileID)
-		if err != nil {
-			if errors.Is(err, manager.ErrObjectNotFound) {
-				c.Status(http.StatusNotFound)
-				return
-			}
-			slog.ErrorContext(ctx, "delete file: mutate file", slog.String("error", err.Error()))
-			c.Status(http.StatusInternalServerError)
-			return
-		}
-		if result.CleanupErr != nil {
-			slog.ErrorContext(ctx, "delete file: delete chunk", slog.String("error", result.CleanupErr.Error()))
-			c.Status(http.StatusInternalServerError)
-			return
-		}
-		c.Status(http.StatusOK)
+		handleDeleteFile(c, bucketRepo, fileRepo, shareLinkRepo, objectSvc, grantReader)
 	}
+}
+
+func handleDeleteFile(c *gin.Context, bucketRepo bucketAccessBucketReader, fileRepo fileByIDReader, shareLinkRepo shareLinkFileDeleter, objectSvc objectFileDeleter, grantRepo bucketAccessGrantReader) {
+	ctx := c.Request.Context()
+	if bucketRepo == nil || fileRepo == nil || shareLinkRepo == nil || objectSvc == nil {
+		slog.ErrorContext(ctx, "delete file: repository is nil")
+		c.Status(http.StatusServiceUnavailable)
+		return
+	}
+
+	acc := requireBucketAccessFor(c, bucketRepo, grantRepo, repository.RoleEditor)
+	if acc == nil {
+		return
+	}
+	bucketID := acc.Bucket.ID
+
+	fileID, ok := routeObjectID(c, "file_id")
+	if !ok {
+		return
+	}
+	fileDoc, err := fileRepo.GetByID(ctx, fileID)
+	if err != nil {
+		if err == mongo.ErrNoDocuments {
+			c.Status(http.StatusNotFound)
+			return
+		}
+		slog.ErrorContext(ctx, "delete file: get file", slog.String("error", err.Error()))
+		c.Status(http.StatusInternalServerError)
+		return
+	}
+	if fileDoc.BucketID != bucketID {
+		c.Status(http.StatusNotFound)
+		return
+	}
+	if err := shareLinkRepo.DeleteByFile(ctx, fileID); err != nil {
+		slog.ErrorContext(ctx, "delete file: cleanup share links", slog.String("error", err.Error()))
+		c.Status(http.StatusInternalServerError)
+		return
+	}
+	result, err := objectSvc.DeleteFile(ctx, bucketID, fileID)
+	if err != nil {
+		if errors.Is(err, manager.ErrObjectNotFound) {
+			c.Status(http.StatusNotFound)
+			return
+		}
+		slog.ErrorContext(ctx, "delete file: mutate file", slog.String("error", err.Error()))
+		c.Status(http.StatusInternalServerError)
+		return
+	}
+	if result.CleanupErr != nil {
+		slog.ErrorContext(ctx, "delete file: delete chunk", slog.String("error", result.CleanupErr.Error()))
+		c.Status(http.StatusInternalServerError)
+		return
+	}
+	c.Status(http.StatusOK)
 }

--- a/api-go/internal/handlers/unit_test.go
+++ b/api-go/internal/handlers/unit_test.go
@@ -491,7 +491,7 @@ func TestListBucketsNoUserID(t *testing.T) {
 func TestDeleteBucketNilRepo(t *testing.T) {
 	t.Parallel()
 	r := gin.New()
-	r.DELETE("/buckets/:id", DeleteBucket(nil, nil, nil, nil, nil))
+	r.DELETE("/buckets/:id", DeleteBucket(nil, nil, nil, nil, nil, nil))
 
 	w := serveHandlerTestRequest(t, r, http.MethodDelete, "/buckets/"+primitive.NewObjectID().Hex(), nil)
 
@@ -505,7 +505,7 @@ func TestDeleteBucketInvalidIDParam(t *testing.T) {
 	r := gin.New()
 	r.DELETE("/buckets/:id",
 		setUserID(validUserID()),
-		DeleteBucket(&repository.BucketRepository{}, nil, nil, nil, nil),
+		DeleteBucket(&repository.BucketRepository{}, nil, nil, nil, nil, nil),
 	)
 
 	w := serveHandlerTestRequest(t, r, http.MethodDelete, "/buckets/not-a-valid-oid", nil)

--- a/api-go/internal/repository/sharelink.go
+++ b/api-go/internal/repository/sharelink.go
@@ -35,6 +35,9 @@ func NewShareLinkRepository(db *mongo.Database) (*ShareLinkRepository, error) {
 			Keys: bson.D{{Key: "file_id", Value: 1}},
 		},
 		{
+			Keys: bson.D{{Key: "bucket_id", Value: 1}},
+		},
+		{
 			Keys: bson.D{{Key: "user_id", Value: 1}},
 		},
 	})
@@ -127,4 +130,14 @@ func (r *ShareLinkRepository) Delete(ctx context.Context, id primitive.ObjectID,
 		return mongo.ErrNoDocuments
 	}
 	return nil
+}
+
+func (r *ShareLinkRepository) DeleteByFile(ctx context.Context, fileID primitive.ObjectID) error {
+	_, err := r.coll.DeleteMany(ctx, bson.M{"file_id": fileID})
+	return err
+}
+
+func (r *ShareLinkRepository) DeleteByBucket(ctx context.Context, bucketID primitive.ObjectID) error {
+	_, err := r.coll.DeleteMany(ctx, bson.M{"bucket_id": bucketID})
+	return err
 }

--- a/api-go/internal/repository/sharelink_test.go
+++ b/api-go/internal/repository/sharelink_test.go
@@ -1,0 +1,112 @@
+//go:build integration
+// +build integration
+
+package repository
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/example/sfree/api-go/internal/config"
+	"github.com/example/sfree/api-go/internal/db"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+func TestShareLinkRepositoryDeleteByFile(t *testing.T) {
+	_, repo := newShareLinkRepositoryTestDB(t)
+	ctx := context.Background()
+	bucketID := primitive.NewObjectID()
+	fileID := primitive.NewObjectID()
+	otherFileID := primitive.NewObjectID()
+	userID := primitive.NewObjectID()
+
+	for _, link := range []ShareLink{
+		{BucketID: bucketID, FileID: fileID, UserID: userID, Token: "file-a", CreatedAt: time.Now().UTC()},
+		{BucketID: bucketID, FileID: fileID, UserID: userID, Token: "file-b", CreatedAt: time.Now().UTC()},
+		{BucketID: bucketID, FileID: otherFileID, UserID: userID, Token: "other-file", CreatedAt: time.Now().UTC()},
+	} {
+		if _, err := repo.Create(ctx, link); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := repo.DeleteByFile(ctx, fileID); err != nil {
+		t.Fatal(err)
+	}
+	links, err := repo.ListByFile(ctx, fileID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(links) != 0 {
+		t.Fatalf("expected deleted file links, got %d", len(links))
+	}
+	links, err = repo.ListByFile(ctx, otherFileID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(links) != 1 || links[0].Token != "other-file" {
+		t.Fatalf("expected unrelated file link to remain, got %+v", links)
+	}
+}
+
+func TestShareLinkRepositoryDeleteByBucket(t *testing.T) {
+	_, repo := newShareLinkRepositoryTestDB(t)
+	ctx := context.Background()
+	bucketID := primitive.NewObjectID()
+	otherBucketID := primitive.NewObjectID()
+	fileID := primitive.NewObjectID()
+	otherFileID := primitive.NewObjectID()
+	userID := primitive.NewObjectID()
+
+	for _, link := range []ShareLink{
+		{BucketID: bucketID, FileID: fileID, UserID: userID, Token: "bucket-a", CreatedAt: time.Now().UTC()},
+		{BucketID: bucketID, FileID: primitive.NewObjectID(), UserID: userID, Token: "bucket-b", CreatedAt: time.Now().UTC()},
+		{BucketID: otherBucketID, FileID: otherFileID, UserID: userID, Token: "other-bucket", CreatedAt: time.Now().UTC()},
+	} {
+		if _, err := repo.Create(ctx, link); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := repo.DeleteByBucket(ctx, bucketID); err != nil {
+		t.Fatal(err)
+	}
+	links, err := repo.ListByFile(ctx, fileID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(links) != 0 {
+		t.Fatalf("expected deleted bucket link, got %d", len(links))
+	}
+	links, err = repo.ListByFile(ctx, otherFileID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(links) != 1 || links[0].Token != "other-bucket" {
+		t.Fatalf("expected unrelated bucket link to remain, got %+v", links)
+	}
+}
+
+func newShareLinkRepositoryTestDB(t *testing.T) (*mongo.Database, *ShareLinkRepository) {
+	t.Helper()
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	mongoConn, err := db.Connect(context.Background(), cfg.Mongo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	testDB := mongoConn.Client.Database("sfree_share_link_repository_" + primitive.NewObjectID().Hex())
+	t.Cleanup(func() {
+		_ = testDB.Drop(context.Background())
+		_ = mongoConn.Close(context.Background())
+	})
+	repo, err := NewShareLinkRepository(testDB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return testDB, repo
+}


### PR DESCRIPTION
## Summary
- Add `DeleteByFile` and `DeleteByBucket` helpers to the share-link repository, including a `bucket_id` index.
- Require share-link cleanup in REST file and bucket deletion before object/bucket deletion reports success.
- Preserve current-main source-client factory route wiring while resolving the earlier merge conflict.
- Preserve current-main bucket detail route wiring while keeping THE-696 share-link cleanup dependency in bucket deletion.
- Add focused handler unit coverage for cleanup ordering/failure handling and integration coverage for scoped repository deletes.

## Validation
- Earlier branch validation: `gofmt` on touched Go files.
- Earlier branch validation: `git diff --cached --check` passed before commit.
- For current head `09125e1`: resolved merge conflicts in `api-go/internal/app/router_routes.go` and `api-go/internal/handlers/bucket.go`, then ran `gofmt` on those files only.
- Woodpecker pipeline 596: lint/unit/docs and smoke passed; api-go E2E was killed with exit 137, consistent with CI resource pressure rather than a deterministic test failure.
- For current head `9927ec0`: resolved the latest `api-go/internal/app/router_routes.go` merge conflict by keeping `GET /api/v1/buckets/:id` and the share-link cleanup dependency in `DeleteBucketWithFactory`; ran `gofmt` on that file only.
- Woodpecker pipeline 617 is pending for current head `9927ec0` with `started=0`.
- Local Go test/build suites, Docker, and E2E were not run after conflict resolution per resource policy; Woodpecker should run full validation.