### PR TITLE
THE-703 Refresh QA coverage audit

### DIFF
--- a/api-go/internal/manager/s3_object_test.go
+++ b/api-go/internal/manager/s3_object_test.go
@@ -479,7 +479,7 @@ func TestObjectServiceCopyObjectPreservesChunksAndCleansOverwrittenDestination(t
 	userID := primitive.NewObjectID()
 	sourceBucketID := primitive.NewObjectID()
 	destBucketID := primitive.NewObjectID()
-	sourceChunk := repository.FileChunk{SourceID: primitive.NewObjectID(), Name: "source-chunk", Size: 12}
+	sourceChunk := repository.FileChunk{SourceID: primitive.NewObjectID(), Name: "source-chunk", Order: 3, Size: 12, Checksum: "source-sum"}
 	oldDestChunk := repository.FileChunk{SourceID: primitive.NewObjectID(), Name: "old-dest-chunk", Size: 8}
 	files := newFakeObjectFiles(
 		repository.File{ID: primitive.NewObjectID(), BucketID: sourceBucketID, Name: "source.txt", Chunks: []repository.FileChunk{sourceChunk}},
@@ -500,6 +500,9 @@ func TestObjectServiceCopyObjectPreservesChunksAndCleansOverwrittenDestination(t
 	}
 	if len(result.File.Chunks) != 1 || result.File.Chunks[0].Name != sourceChunk.Name {
 		t.Fatalf("expected copied file to reference source chunk, got %#v", result.File.Chunks)
+	}
+	if result.File.Chunks[0].Order != sourceChunk.Order || result.File.Chunks[0].Checksum != sourceChunk.Checksum {
+		t.Fatalf("expected copied file to preserve chunk metadata, got %#v", result.File.Chunks[0])
 	}
 	if len(deleted) != 1 || deleted[0].Name != oldDestChunk.Name {
 		t.Fatalf("expected overwritten destination chunk cleanup, got %#v", deleted)

--- a/docs/api-go-testing-plan.md
+++ b/docs/api-go-testing-plan.md
@@ -54,6 +54,29 @@ These checks live in the existing Go S3 E2E suite so they run in the Woodpecker 
 2. HTTP API/S3 parity checks for file metadata after S3 overwrite, copy, delete, and multipart completion.
 3. Negative auth coverage across presigned URLs, wrong bucket keys, wrong access keys, and cross-bucket copy attempts.
 
+## 2026-04-22 Regression Audit
+
+Recent merged changes on `origin/main` added share-link request body validation, range corruption regression coverage, multipart abort bucket ownership checks, direct source download preflight coverage, source health behavior, Web UI download failure handling, and manager chunk I/O extraction. Open PRs at audit time included source download query-key handling, share-link cascade cleanup, graceful API shutdown, bucket grant cleanup/error surfacing, weighted upload failover, operation-specific object service construction, S3 object key normalization, multipart abort cleanup failure preservation, missing bucket source upload failure, download context lifetime, authenticated rate-limit identity, and S3 object metadata persistence.
+
+Covered critical behavior:
+
+- Object write/read roundtrip, overwrite, delete, ranged `GET`, `HEAD`, copy, missing-object S3 XML errors, and cross-bucket credential isolation are covered in the Go S3 E2E suite.
+- Chunking, short reads, range reconstruction, per-chunk checksum storage, corruption detection, weighted and round-robin placement, failover, and uploaded-chunk cleanup on source/backend failure are covered in manager unit tests.
+- Multipart create, upload part, list uploads, list parts, complete, abort, replacement, invalid completion, ownership, and checksum preservation paths are covered across Go E2E, handler unit tests, and manager unit tests.
+- Direct source downloads now have preflight failure coverage before success headers are committed, and share-link creation rejects malformed request bodies before records are created.
+
+Test improvement added during this audit:
+
+- `api-go/internal/manager/s3_object_test.go` now asserts `ObjectService.CopyObject` preserves chunk order and checksum metadata, not only chunk name/reference, while still cleaning overwritten destination chunks.
+
+Prioritized missing tests:
+
+1. REST/S3 parity after REST file overwrite and delete. Add an integration or E2E check that uploads through `/api/v1/buckets/{id}/upload`, overwrites the same filename, verifies S3 `GET` returns only the replacement bytes, deletes through the REST file endpoint, and verifies S3 `GET` returns `NoSuchKey`.
+2. Cross-bucket CopyObject authorization and source lookup matrix. Existing coverage checks same-user cross-bucket copy and service-level cross-user rejection; add handler or E2E coverage for wrong destination credentials, unknown source bucket, unknown source key, and source bucket owned by another user.
+3. Multipart completion cleanup on partial completion. Add an E2E or manager test that uploads parts 1, 2, and 3, completes only parts 1 and 3, then verifies part 2 chunks are cleaned while completed object reconstruction remains correct.
+4. Share-link cascade cleanup API path. The cleanup PR adds repository and bucket deletion coverage; after merge, add a public API or E2E check proving revoked bucket/file share links are no longer listable or usable through the user-facing routes after file and bucket deletion.
+5. Source download query-key route compatibility. The open source-download PR adds unit coverage for escaped query keys; after merge, add a Web UI or API compatibility smoke that covers S3 object keys containing `+`, `#`, `?`, and nested slashes through the public route.
+
 ## Validation
 
 No CI behavior changes are required. Woodpecker `.woodpecker/api-go.yml` remains the validation source for Docker-backed E2E execution.


### PR DESCRIPTION
## Summary
- add a 2026-04-22 QA regression audit section to docs/api-go-testing-plan.md
- tighten ObjectService CopyObject regression coverage for chunk order/checksum metadata preservation

## Validation
- gofmt api-go/internal/manager/s3_object_test.go
- git diff --check

Heavy Go, Docker, and E2E suites intentionally left to Woodpecker per QA resource policy.