### PR TITLE
THE-708 extract handler test harness

### DIFF
--- a/api-go/internal/handlers/bucket_grant_test.go
+++ b/api-go/internal/handlers/bucket_grant_test.go
@@ -1,10 +1,7 @@
 package handlers
 
 import (
-	"bytes"
-	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -16,11 +13,7 @@ func TestCreateGrantNilRepos(t *testing.T) {
 	r := gin.New()
 	r.POST("/buckets/:id/grants", CreateGrant(nil, nil, nil))
 
-	body, _ := json.Marshal(map[string]string{"username": "alice", "role": "viewer"})
-	req, _ := http.NewRequest(http.MethodPost, "/buckets/"+primitive.NewObjectID().Hex()+"/grants", bytes.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
-	r.ServeHTTP(w, req)
+	w := serveHandlerTestRequest(t, r, http.MethodPost, "/buckets/"+primitive.NewObjectID().Hex()+"/grants", map[string]string{"username": "alice", "role": "viewer"})
 
 	if w.Code != http.StatusServiceUnavailable {
 		t.Fatalf("expected 503, got %d", w.Code)
@@ -32,9 +25,7 @@ func TestListGrantsNilRepos(t *testing.T) {
 	r := gin.New()
 	r.GET("/buckets/:id/grants", ListGrants(nil, nil, nil))
 
-	req, _ := http.NewRequest(http.MethodGet, "/buckets/"+primitive.NewObjectID().Hex()+"/grants", nil)
-	w := httptest.NewRecorder()
-	r.ServeHTTP(w, req)
+	w := serveHandlerTestRequest(t, r, http.MethodGet, "/buckets/"+primitive.NewObjectID().Hex()+"/grants", nil)
 
 	if w.Code != http.StatusServiceUnavailable {
 		t.Fatalf("expected 503, got %d", w.Code)
@@ -46,14 +37,10 @@ func TestUpdateGrantNilRepos(t *testing.T) {
 	r := gin.New()
 	r.PATCH("/buckets/:id/grants/:grant_id", UpdateGrant(nil, nil))
 
-	body, _ := json.Marshal(map[string]string{"role": "editor"})
-	req, _ := http.NewRequest(http.MethodPatch,
+	w := serveHandlerTestRequest(t, r, http.MethodPatch,
 		"/buckets/"+primitive.NewObjectID().Hex()+"/grants/"+primitive.NewObjectID().Hex(),
-		bytes.NewReader(body),
+		map[string]string{"role": "editor"},
 	)
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
-	r.ServeHTTP(w, req)
 
 	if w.Code != http.StatusServiceUnavailable {
 		t.Fatalf("expected 503, got %d", w.Code)
@@ -65,12 +52,10 @@ func TestDeleteGrantNilRepos(t *testing.T) {
 	r := gin.New()
 	r.DELETE("/buckets/:id/grants/:grant_id", DeleteGrant(nil, nil))
 
-	req, _ := http.NewRequest(http.MethodDelete,
+	w := serveHandlerTestRequest(t, r, http.MethodDelete,
 		"/buckets/"+primitive.NewObjectID().Hex()+"/grants/"+primitive.NewObjectID().Hex(),
 		nil,
 	)
-	w := httptest.NewRecorder()
-	r.ServeHTTP(w, req)
 
 	if w.Code != http.StatusServiceUnavailable {
 		t.Fatalf("expected 503, got %d", w.Code)
@@ -80,22 +65,16 @@ func TestDeleteGrantNilRepos(t *testing.T) {
 func TestDeleteGrantInvalidGrantID(t *testing.T) {
 	t.Parallel()
 	r := gin.New()
-	// Need a valid bucket access first, but with nil repos it will return 503 before checking grant_id.
-	// Let's test invalid grant_id format by setting up with valid user but nil bucket/grant repos
-	// We can't test further without real repos, but we verify the param validation path.
 	r.DELETE("/buckets/:id/grants/:grant_id",
 		setUserID(validUserID()),
 		DeleteGrant(nil, nil),
 	)
 
-	req, _ := http.NewRequest(http.MethodDelete,
+	w := serveHandlerTestRequest(t, r, http.MethodDelete,
 		"/buckets/"+primitive.NewObjectID().Hex()+"/grants/not-valid",
 		nil,
 	)
-	w := httptest.NewRecorder()
-	r.ServeHTTP(w, req)
 
-	// Returns 503 because repos are nil (checked before grant_id validation)
 	if w.Code != http.StatusServiceUnavailable {
 		t.Fatalf("expected 503, got %d", w.Code)
 	}

--- a/api-go/internal/handlers/request_helpers_test.go
+++ b/api-go/internal/handlers/request_helpers_test.go
@@ -52,6 +52,7 @@ func TestRouteObjectIDRejectsShareLinkFileID(t *testing.T) {
 	if _, ok := routeObjectID(c, "file_id"); ok {
 		t.Fatal("expected file id parse to fail")
 	}
+	c.Writer.WriteHeaderNow()
 
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d", w.Code)

--- a/api-go/internal/handlers/request_helpers_test.go
+++ b/api-go/internal/handlers/request_helpers_test.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/example/sfree/api-go/internal/repository"
@@ -36,9 +35,7 @@ func TestAuthenticatedUserIDRejectsMissingAndInvalidUserID(t *testing.T) {
 			})
 			r.GET("/me", handlers...)
 
-			req, _ := http.NewRequest(http.MethodGet, "/me", nil)
-			w := httptest.NewRecorder()
-			r.ServeHTTP(w, req)
+			w := serveHandlerTestRequest(t, r, http.MethodGet, "/me", nil)
 
 			if w.Code != http.StatusUnauthorized {
 				t.Fatalf("expected 401, got %d", w.Code)
@@ -49,16 +46,12 @@ func TestAuthenticatedUserIDRejectsMissingAndInvalidUserID(t *testing.T) {
 
 func TestRouteObjectIDRejectsShareLinkFileID(t *testing.T) {
 	t.Parallel()
-	r := gin.New()
-	r.POST("/buckets/:id/files/:file_id/share", func(c *gin.Context) {
-		if _, ok := routeObjectID(c, "file_id"); ok {
-			t.Fatal("expected file id parse to fail")
-		}
-	})
-
-	req, _ := http.NewRequest(http.MethodPost, "/buckets/"+primitive.NewObjectID().Hex()+"/files/not-a-valid-oid/share", nil)
-	w := httptest.NewRecorder()
-	r.ServeHTTP(w, req)
+	c, w := newHandlerTestContext(t, http.MethodPost, "/buckets/"+primitive.NewObjectID().Hex()+"/files/not-a-valid-oid/share", nil,
+		testRouteParam{Key: "file_id", Value: "not-a-valid-oid"},
+	)
+	if _, ok := routeObjectID(c, "file_id"); ok {
+		t.Fatal("expected file id parse to fail")
+	}
 
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d", w.Code)
@@ -74,13 +67,7 @@ func TestCreateShareLinkRejectsInvalidAuthenticatedUserID(t *testing.T) {
 		CreateShareLink(&repository.BucketRepository{}, &repository.FileRepository{}, &repository.ShareLinkRepository{}, nil),
 	)
 
-	req, _ := http.NewRequest(
-		http.MethodPost,
-		"/buckets/"+primitive.NewObjectID().Hex()+"/files/"+primitive.NewObjectID().Hex()+"/share",
-		nil,
-	)
-	w := httptest.NewRecorder()
-	r.ServeHTTP(w, req)
+	w := serveHandlerTestRequest(t, r, http.MethodPost, "/buckets/"+primitive.NewObjectID().Hex()+"/files/"+primitive.NewObjectID().Hex()+"/share", nil)
 
 	if w.Code != http.StatusUnauthorized {
 		t.Fatalf("expected 401, got %d", w.Code)

--- a/api-go/internal/handlers/test_helpers_test.go
+++ b/api-go/internal/handlers/test_helpers_test.go
@@ -1,0 +1,77 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+type testRouteParam struct {
+	Key   string
+	Value string
+}
+
+func setUserID(id string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Set("userID", id)
+		c.Next()
+	}
+}
+
+func validUserID() string { return primitive.NewObjectID().Hex() }
+
+func newHandlerTestContext(t *testing.T, method, target string, body any, params ...testRouteParam) (*gin.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = newHandlerTestRequest(t, method, target, body)
+	for _, param := range params {
+		c.Params = append(c.Params, gin.Param{Key: param.Key, Value: param.Value})
+	}
+	return c, w
+}
+
+func serveHandlerTestRequest(t *testing.T, h http.Handler, method, target string, body any) *httptest.ResponseRecorder {
+	t.Helper()
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newHandlerTestRequest(t, method, target, body))
+	return w
+}
+
+func newHandlerTestRequest(t *testing.T, method, target string, body any) *http.Request {
+	t.Helper()
+	req, err := http.NewRequest(method, target, testRequestBody(t, body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	return req
+}
+
+func testRequestBody(t *testing.T, body any) io.Reader {
+	t.Helper()
+	switch v := body.(type) {
+	case nil:
+		return nil
+	case io.Reader:
+		return v
+	case []byte:
+		return bytes.NewReader(v)
+	case string:
+		return bytes.NewBufferString(v)
+	default:
+		data, err := json.Marshal(v)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return bytes.NewReader(data)
+	}
+}

--- a/api-go/internal/handlers/unit_test.go
+++ b/api-go/internal/handlers/unit_test.go
@@ -1,10 +1,7 @@
 package handlers
 
 import (
-	"bytes"
-	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/example/sfree/api-go/internal/repository"
@@ -16,16 +13,6 @@ func init() {
 	gin.SetMode(gin.TestMode)
 }
 
-// setUserID is a helper middleware that injects a userID into the gin context.
-func setUserID(id string) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		c.Set("userID", id)
-		c.Next()
-	}
-}
-
-func validUserID() string { return primitive.NewObjectID().Hex() }
-
 // --- Source handler unit tests ---
 
 func TestCreateGDriveSourceMissingFields(t *testing.T) {
@@ -33,11 +20,7 @@ func TestCreateGDriveSourceMissingFields(t *testing.T) {
 	r := gin.New()
 	r.POST("/sources/gdrive", CreateGDriveSource(nil))
 
-	body, _ := json.Marshal(map[string]string{"name": "only-name"}) // missing key
-	req, _ := http.NewRequest(http.MethodPost, "/sources/gdrive", bytes.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
-	r.ServeHTTP(w, req)
+	w := serveHandlerTestRequest(t, r, http.MethodPost, "/sources/gdrive", map[string]string{"name": "only-name"})
 
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d", w.Code)
@@ -49,11 +32,7 @@ func TestCreateTelegramSourceMissingFields(t *testing.T) {
 	r := gin.New()
 	r.POST("/sources/telegram", CreateTelegramSource(nil))
 
-	body, _ := json.Marshal(map[string]string{"name": "tg"}) // missing token and chat_id
-	req, _ := http.NewRequest(http.MethodPost, "/sources/telegram", bytes.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
-	r.ServeHTTP(w, req)
+	w := serveHandlerTestRequest(t, r, http.MethodPost, "/sources/telegram", map[string]string{"name": "tg"})
 
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d", w.Code)
@@ -65,11 +44,7 @@ func TestCreateS3SourceMissingFields(t *testing.T) {
 	r := gin.New()
 	r.POST("/sources/s3", CreateS3Source(nil))
 
-	body, _ := json.Marshal(map[string]string{"name": "s3"}) // missing required fields
-	req, _ := http.NewRequest(http.MethodPost, "/sources/s3", bytes.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
-	r.ServeHTTP(w, req)
+	w := serveHandlerTestRequest(t, r, http.MethodPost, "/sources/s3", map[string]string{"name": "s3"})
 
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d", w.Code)
@@ -81,9 +56,7 @@ func TestListSourcesNilRepo(t *testing.T) {
 	r := gin.New()
 	r.GET("/sources", ListSources(nil))
 
-	req, _ := http.NewRequest(http.MethodGet, "/sources", nil)
-	w := httptest.NewRecorder()
-	r.ServeHTTP(w, req)
+	w := serveHandlerTestRequest(t, r, http.MethodGet, "/sources", nil)
 
 	if w.Code != http.StatusServiceUnavailable {
 		t.Fatalf("expected 503, got %d", w.Code)
@@ -95,9 +68,7 @@ func TestListSourcesNoUserID(t *testing.T) {
 	r := gin.New()
 	r.GET("/sources", ListSources(&repository.SourceRepository{}))
 
-	req, _ := http.NewRequest(http.MethodGet, "/sources", nil)
-	w := httptest.NewRecorder()
-	r.ServeHTTP(w, req)
+	w := serveHandlerTestRequest(t, r, http.MethodGet, "/sources", nil)
 
 	if w.Code != http.StatusUnauthorized {
 		t.Fatalf("expected 401, got %d", w.Code)
@@ -109,9 +80,7 @@ func TestListSourcesInvalidUserID(t *testing.T) {
 	r := gin.New()
 	r.GET("/sources", setUserID("not-a-valid-oid"), ListSources(&repository.SourceRepository{}))
 
-	req, _ := http.NewRequest(http.MethodGet, "/sources", nil)
-	w := httptest.NewRecorder()
-	r.ServeHTTP(w, req)
+	w := serveHandlerTestRequest(t, r, http.MethodGet, "/sources", nil)
 
 	if w.Code != http.StatusUnauthorized {
 		t.Fatalf("expected 401, got %d", w.Code)
@@ -123,9 +92,7 @@ func TestDeleteSourceNilRepos(t *testing.T) {
 	r := gin.New()
 	r.DELETE("/sources/:id", DeleteSource(nil, nil))
 
-	req, _ := http.NewRequest(http.MethodDelete, "/sources/"+primitive.NewObjectID().Hex(), nil)
-	w := httptest.NewRecorder()
-	r.ServeHTTP(w, req)
+	w := serveHandlerTestRequest(t, r, http.MethodDelete, "/sources/"+primitive.NewObjectID().Hex(), nil)
 
 	if w.Code != http.StatusServiceUnavailable {
 		t.Fatalf("expected 503, got %d", w.Code)
@@ -137,9 +104,7 @@ func TestDeleteSourceNoUserID(t *testing.T) {
 	r := gin.New()
 	r.DELETE("/sources/:id", DeleteSource(&repository.SourceRepository{}, &repository.BucketRepository{}))
 
-	req, _ := http.NewRequest(http.MethodDelete, "/sources/"+primitive.NewObjectID().Hex(), nil)
-	w := httptest.NewRecorder()
-	r.ServeHTTP(w, req)
+	w := serveHandlerTestRequest(t, r, http.MethodDelete, "/sources/"+primitive.NewObjectID().Hex(), nil)
 
 	if w.Code != http.StatusUnauthorized {
 		t.Fatalf("expected 401, got %d", w.Code)
@@ -154,9 +119,7 @@ func TestDeleteSourceInvalidIDParam(t *testing.T) {
 		DeleteSource(&repository.SourceRepository{}, &repository.BucketRepository{}),
 	)
 
-	req, _ := http.NewRequest(http.MethodDelete, "/sources/not-a-valid-oid", nil)
-	w := httptest.NewRecorder()
-	r.ServeHTTP(w, req)
+	w := serveHandlerTestRequest(t, r, http.MethodDelete, "/sources/not-a-valid-oid", nil)
 
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d", w.Code)
@@ -168,9 +131,7 @@ func TestGetSourceInfoNilRepo(t *testing.T) {
 	r := gin.New()
 	r.GET("/sources/:id/info", GetSourceInfo(nil))
 
-	req, _ := http.NewRequest(http.MethodGet, "/sources/"+primitive.NewObjectID().Hex()+"/info", nil)
-	w := httptest.NewRecorder()
-	r.ServeHTTP(w, req)
+	w := serveHandlerTestRequest(t, r, http.MethodGet, "/sources/"+primitive.NewObjectID().Hex()+"/info", nil)
 
 	if w.Code != http.StatusServiceUnavailable {
 		t.Fatalf("expected 503, got %d", w.Code)
@@ -185,9 +146,7 @@ func TestGetSourceInfoInvalidIDParam(t *testing.T) {
 		GetSourceInfo(&repository.SourceRepository{}),
 	)
 
-	req, _ := http.NewRequest(http.MethodGet, "/sources/not-a-valid-oid/info", nil)
-	w := httptest.NewRecorder()
-	r.ServeHTTP(w, req)
+	w := serveHandlerTestRequest(t, r, http.MethodGet, "/sources/not-a-valid-oid/info", nil)
 
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d", w.Code)
@@ -199,9 +158,7 @@ func TestDownloadSourceFileNilRepo(t *testing.T) {
 	r := gin.New()
 	r.GET("/sources/:id/files/:file_id/download", DownloadSourceFile(nil))
 
-	req, _ := http.NewRequest(http.MethodGet, "/sources/"+primitive.NewObjectID().Hex()+"/files/somefile/download", nil)
-	w := httptest.NewRecorder()
-	r.ServeHTTP(w, req)
+	w := serveHandlerTestRequest(t, r, http.MethodGet, "/sources/"+primitive.NewObjectID().Hex()+"/files/somefile/download", nil)
 
 	if w.Code != http.StatusServiceUnavailable {
 		t.Fatalf("expected 503, got %d", w.Code)
@@ -213,9 +170,7 @@ func TestDownloadSourceFileNoUserID(t *testing.T) {
 	r := gin.New()
 	r.GET("/sources/:id/files/:file_id/download", DownloadSourceFile(&repository.SourceRepository{}))
 
-	req, _ := http.NewRequest(http.MethodGet, "/sources/"+primitive.NewObjectID().Hex()+"/files/somefile/download", nil)
-	w := httptest.NewRecorder()
-	r.ServeHTTP(w, req)
+	w := serveHandlerTestRequest(t, r, http.MethodGet, "/sources/"+primitive.NewObjectID().Hex()+"/files/somefile/download", nil)
 
 	if w.Code != http.StatusUnauthorized {
 		t.Fatalf("expected 401, got %d", w.Code)
@@ -230,9 +185,7 @@ func TestDownloadSourceFileInvalidSourceID(t *testing.T) {
 		DownloadSourceFile(&repository.SourceRepository{}),
 	)
 
-	req, _ := http.NewRequest(http.MethodGet, "/sources/not-a-valid-oid/files/somefile/download", nil)
-	w := httptest.NewRecorder()
-	r.ServeHTTP(w, req)
+	w := serveHandlerTestRequest(t, r, http.MethodGet, "/sources/not-a-valid-oid/files/somefile/download", nil)
 
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d", w.Code)
@@ -246,11 +199,7 @@ func TestCreateBucketMissingFields(t *testing.T) {
 	r := gin.New()
 	r.POST("/buckets", CreateBucket(nil, nil, "secret"))
 
-	body, _ := json.Marshal(map[string]string{"key": "k"}) // missing source_ids
-	req, _ := http.NewRequest(http.MethodPost, "/buckets", bytes.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
-	r.ServeHTTP(w, req)
+	w := serveHandlerTestRequest(t, r, http.MethodPost, "/buckets", map[string]string{"key": "k"})
 
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d", w.Code)
@@ -262,11 +211,7 @@ func TestCreateBucketNilRepos(t *testing.T) {
 	r := gin.New()
 	r.POST("/buckets", CreateBucket(nil, nil, "secret"))
 
-	body, _ := json.Marshal(map[string]any{"key": "k", "source_ids": []string{primitive.NewObjectID().Hex()}})
-	req, _ := http.NewRequest(http.MethodPost, "/buckets", bytes.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
-	r.ServeHTTP(w, req)
+	w := serveHandlerTestRequest(t, r, http.MethodPost, "/buckets", map[string]any{"key": "k", "source_ids": []string{primitive.NewObjectID().Hex()}})
 
 	if w.Code != http.StatusServiceUnavailable {
 		t.Fatalf("expected 503, got %d", w.Code)
@@ -278,11 +223,7 @@ func TestCreateBucketNoUserID(t *testing.T) {
 	r := gin.New()
 	r.POST("/buckets", CreateBucket(&repository.BucketRepository{}, &repository.SourceRepository{}, "secret"))
 
-	body, _ := json.Marshal(map[string]any{"key": "k", "source_ids": []string{primitive.NewObjectID().Hex()}})
-	req, _ := http.NewRequest(http.MethodPost, "/buckets", bytes.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
-	r.ServeHTTP(w, req)
+	w := serveHandlerTestRequest(t, r, http.MethodPost, "/buckets", map[string]any{"key": "k", "source_ids": []string{primitive.NewObjectID().Hex()}})
 
 	if w.Code != http.StatusUnauthorized {
 		t.Fatalf("expected 401, got %d", w.Code)
@@ -294,9 +235,7 @@ func TestListBucketsNilRepo(t *testing.T) {
 	r := gin.New()
 	r.GET("/buckets", ListBuckets(nil, nil))
 
-	req, _ := http.NewRequest(http.MethodGet, "/buckets", nil)
-	w := httptest.NewRecorder()
-	r.ServeHTTP(w, req)
+	w := serveHandlerTestRequest(t, r, http.MethodGet, "/buckets", nil)
 
 	if w.Code != http.StatusServiceUnavailable {
 		t.Fatalf("expected 503, got %d", w.Code)
@@ -308,9 +247,7 @@ func TestListBucketsNoUserID(t *testing.T) {
 	r := gin.New()
 	r.GET("/buckets", ListBuckets(&repository.BucketRepository{}, nil))
 
-	req, _ := http.NewRequest(http.MethodGet, "/buckets", nil)
-	w := httptest.NewRecorder()
-	r.ServeHTTP(w, req)
+	w := serveHandlerTestRequest(t, r, http.MethodGet, "/buckets", nil)
 
 	if w.Code != http.StatusUnauthorized {
 		t.Fatalf("expected 401, got %d", w.Code)
@@ -322,9 +259,7 @@ func TestDeleteBucketNilRepo(t *testing.T) {
 	r := gin.New()
 	r.DELETE("/buckets/:id", DeleteBucket(nil, nil, nil, nil, nil))
 
-	req, _ := http.NewRequest(http.MethodDelete, "/buckets/"+primitive.NewObjectID().Hex(), nil)
-	w := httptest.NewRecorder()
-	r.ServeHTTP(w, req)
+	w := serveHandlerTestRequest(t, r, http.MethodDelete, "/buckets/"+primitive.NewObjectID().Hex(), nil)
 
 	if w.Code != http.StatusServiceUnavailable {
 		t.Fatalf("expected 503, got %d", w.Code)
@@ -339,9 +274,7 @@ func TestDeleteBucketInvalidIDParam(t *testing.T) {
 		DeleteBucket(&repository.BucketRepository{}, nil, nil, nil, nil),
 	)
 
-	req, _ := http.NewRequest(http.MethodDelete, "/buckets/not-a-valid-oid", nil)
-	w := httptest.NewRecorder()
-	r.ServeHTTP(w, req)
+	w := serveHandlerTestRequest(t, r, http.MethodDelete, "/buckets/not-a-valid-oid", nil)
 
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d", w.Code)
@@ -355,11 +288,7 @@ func TestCreateUserMissingUsername(t *testing.T) {
 	r := gin.New()
 	r.POST("/users", CreateUser(nil))
 
-	body, _ := json.Marshal(map[string]string{}) // missing username
-	req, _ := http.NewRequest(http.MethodPost, "/users", bytes.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
-	r.ServeHTTP(w, req)
+	w := serveHandlerTestRequest(t, r, http.MethodPost, "/users", map[string]string{})
 
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d", w.Code)
@@ -371,11 +300,7 @@ func TestCreateUserNilRepo(t *testing.T) {
 	r := gin.New()
 	r.POST("/users", CreateUser(nil))
 
-	body, _ := json.Marshal(map[string]string{"username": "alice"})
-	req, _ := http.NewRequest(http.MethodPost, "/users", bytes.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
-	r.ServeHTTP(w, req)
+	w := serveHandlerTestRequest(t, r, http.MethodPost, "/users", map[string]string{"username": "alice"})
 
 	if w.Code != http.StatusServiceUnavailable {
 		t.Fatalf("expected 503, got %d", w.Code)


### PR DESCRIPTION
## Summary
- Add a shared handler test harness for Gin router execution, direct Gin contexts, auth user injection, JSON request bodies, and route params.
- Migrate `api-go/internal/handlers/unit_test.go` and `api-go/internal/handlers/bucket_grant_test.go` off repeated request/recorder setup.
- Also route `api-go/internal/handlers/request_helpers_test.go` through the helper where it directly exercises route param parsing.

## Helper scope
The helper is intentionally narrow and test-only: it centralizes the recurring authenticated Gin handler setup without introducing Mongo fixtures, broader integration helpers, or product behavior changes.

## Validation
- Ran `gofmt` on touched test files.
- Ran `git diff --check`.
- Did not run local unit tests per QA instruction to avoid CPU-bound tasks; Woodpecker should run api-go lint and unit tests.