### PR TITLE
THE-706 Decouple source health capabilities

### DIFF
--- a/api-go/internal/gdrive/client.go
+++ b/api-go/internal/gdrive/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 
+	"github.com/example/sfree/api-go/internal/sourcecap"
 	"google.golang.org/api/drive/v3"
 	"google.golang.org/api/option"
 )
@@ -79,4 +80,52 @@ func (c *Client) StorageInfo(ctx context.Context) (total, used, free int64, err 
 	used = about.StorageQuota.Usage
 	free = total - used
 	return
+}
+
+func (c *Client) SourceInfo(ctx context.Context) (sourcecap.Info, error) {
+	files, err := c.ListFiles(ctx)
+	if err != nil {
+		return sourcecap.Info{}, err
+	}
+	total, used, free, err := c.StorageInfo(ctx)
+	if err != nil {
+		return sourcecap.Info{}, err
+	}
+	respFiles := make([]sourcecap.File, 0, len(files))
+	for _, f := range files {
+		respFiles = append(respFiles, sourcecap.File{ID: f.ID, Name: f.Name, Size: f.Size})
+	}
+	return sourcecap.Info{Files: respFiles, StorageTotal: total, StorageUsed: used, StorageFree: free}, nil
+}
+
+func (c *Client) ProbeSourceHealth(ctx context.Context) (sourcecap.Health, error) {
+	total, used, free, err := c.StorageInfo(ctx)
+	if err != nil {
+		return sourcecap.Health{
+			Status:     sourcecap.HealthUnhealthy,
+			ReasonCode: "probe_failed",
+			Message:    "Google Drive metadata probe failed.",
+		}, err
+	}
+	health := sourcecap.Health{
+		Status:     sourcecap.HealthHealthy,
+		ReasonCode: "ok",
+		Message:    "Google Drive metadata is reachable.",
+	}
+	if total > 0 {
+		health.Quota = sourcecap.Quota{TotalBytes: &total, UsedBytes: &used, FreeBytes: &free}
+		if free <= 0 {
+			health.Status = sourcecap.HealthUnhealthy
+			health.ReasonCode = "quota_exhausted"
+			health.Message = "Google Drive quota is exhausted."
+			return health, nil
+		}
+		if free*100/total < 5 {
+			health.Status = sourcecap.HealthDegraded
+			health.ReasonCode = "quota_low"
+			health.Message = "Google Drive quota is nearly exhausted."
+			return health, nil
+		}
+	}
+	return health, nil
 }

--- a/api-go/internal/handlers/source_health_test.go
+++ b/api-go/internal/handlers/source_health_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/example/sfree/api-go/internal/manager"
 	"github.com/example/sfree/api-go/internal/repository"
+	"github.com/example/sfree/api-go/internal/sourcecap"
 	"github.com/gin-gonic/gin"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
@@ -30,7 +31,7 @@ func (f fakeSourceGetter) GetByID(context.Context, primitive.ObjectID) (*reposit
 }
 
 type sourceHealthHandlerClient struct {
-	headErr error
+	healthErr error
 }
 
 func (c sourceHealthHandlerClient) Upload(context.Context, string, io.Reader) (string, error) {
@@ -45,8 +46,19 @@ func (c sourceHealthHandlerClient) Delete(context.Context, string) error {
 	return nil
 }
 
-func (c sourceHealthHandlerClient) HeadBucket(context.Context) error {
-	return c.headErr
+func (c sourceHealthHandlerClient) ProbeSourceHealth(context.Context) (sourcecap.Health, error) {
+	if c.healthErr != nil {
+		return sourcecap.Health{
+			Status:     sourcecap.HealthUnhealthy,
+			ReasonCode: "probe_failed",
+			Message:    "S3 bucket metadata probe failed.",
+		}, c.healthErr
+	}
+	return sourcecap.Health{
+		Status:     sourcecap.HealthHealthy,
+		ReasonCode: "ok",
+		Message:    "S3 bucket metadata is reachable.",
+	}, nil
 }
 
 func TestGetSourceHealthBadID(t *testing.T) {
@@ -138,7 +150,7 @@ func TestGetSourceHealthProviderFailureMapping(t *testing.T) {
 	}
 	r := gin.New()
 	r.GET("/sources/:id/health", setUserID(userID.Hex()), getSourceHealth(fakeSourceGetter{source: source}, func(context.Context, *repository.Source) (manager.SourceClient, error) {
-		return sourceHealthHandlerClient{headErr: errors.New("access denied")}, nil
+		return sourceHealthHandlerClient{healthErr: errors.New("access denied")}, nil
 	}))
 
 	req, _ := http.NewRequest(http.MethodGet, "/sources/"+source.ID.Hex()+"/health", nil)

--- a/api-go/internal/manager/file_test.go
+++ b/api-go/internal/manager/file_test.go
@@ -9,27 +9,21 @@ import (
 	"io"
 	"testing"
 
-	"github.com/example/sfree/api-go/internal/gdrive"
 	"github.com/example/sfree/api-go/internal/repository"
 	"github.com/example/sfree/api-go/internal/resilience"
-	"github.com/example/sfree/api-go/internal/s3compat"
+	"github.com/example/sfree/api-go/internal/sourcecap"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
 type stubSourceClient struct {
-	uploaded     [][]byte
-	uploadErr    error
-	uploadErrAt  int
-	uploadCalls  int
-	downloadErr  error
-	deleted      []string
-	deleteErr    error
-	gdriveFiles  []gdrive.File
-	storageTotal int64
-	storageUsed  int64
-	storageFree  int64
-	s3Objects    []s3compat.ObjectInfo
-	s3Used       int64
+	uploaded    [][]byte
+	uploadErr   error
+	uploadErrAt int
+	uploadCalls int
+	downloadErr error
+	deleted     []string
+	deleteErr   error
+	sourceInfo  sourcecap.Info
 }
 
 type readOnceThenError struct {
@@ -69,16 +63,8 @@ func (c *stubSourceClient) Delete(_ context.Context, name string) error {
 	return c.deleteErr
 }
 
-func (c *stubSourceClient) ListFiles(_ context.Context) ([]gdrive.File, error) {
-	return c.gdriveFiles, nil
-}
-
-func (c *stubSourceClient) StorageInfo(_ context.Context) (int64, int64, int64, error) {
-	return c.storageTotal, c.storageUsed, c.storageFree, nil
-}
-
-func (c *stubSourceClient) ListObjects(_ context.Context) ([]s3compat.ObjectInfo, int64, error) {
-	return c.s3Objects, c.s3Used, nil
+func (c *stubSourceClient) SourceInfo(_ context.Context) (sourcecap.Info, error) {
+	return c.sourceInfo, nil
 }
 
 func TestSourceClientCacheReusesClients(t *testing.T) {
@@ -540,10 +526,12 @@ func TestInspectSourceUsesFactoryForGDrive(t *testing.T) {
 			t.Fatal("expected source pointer to be passed to factory")
 		}
 		return &stubSourceClient{
-			gdriveFiles:  []gdrive.File{{ID: "file-id", Name: "file.txt", Size: 42}},
-			storageTotal: 100,
-			storageUsed:  42,
-			storageFree:  58,
+			sourceInfo: sourcecap.Info{
+				Files:        []sourcecap.File{{ID: "file-id", Name: "file.txt", Size: 42}},
+				StorageTotal: 100,
+				StorageUsed:  42,
+				StorageFree:  58,
+			},
 		}, nil
 	}
 
@@ -572,8 +560,10 @@ func TestInspectSourceUsesFactoryForS3(t *testing.T) {
 			t.Fatal("expected source pointer to be passed to factory")
 		}
 		return &stubSourceClient{
-			s3Objects: []s3compat.ObjectInfo{{Key: "object-key", Size: 12}},
-			s3Used:    12,
+			sourceInfo: sourcecap.Info{
+				Files:       []sourcecap.File{{ID: "object-key", Name: "object-key", Size: 12}},
+				StorageUsed: 12,
+			},
 		}, nil
 	}
 

--- a/api-go/internal/manager/source.go
+++ b/api-go/internal/manager/source.go
@@ -6,9 +6,8 @@ import (
 	"io"
 	"time"
 
-	"github.com/example/sfree/api-go/internal/gdrive"
 	"github.com/example/sfree/api-go/internal/repository"
-	"github.com/example/sfree/api-go/internal/s3compat"
+	"github.com/example/sfree/api-go/internal/sourcecap"
 )
 
 type SourceInfoFile struct {
@@ -59,26 +58,19 @@ func InspectSource(ctx context.Context, src *repository.Source, factory SourceCl
 		if err != nil {
 			return SourceInfo{}, err
 		}
-		infoClient, ok := cli.(interface {
-			ListFiles(context.Context) ([]gdrive.File, error)
-			StorageInfo(context.Context) (int64, int64, int64, error)
-		})
+		infoClient, ok := cli.(sourcecap.InfoProvider)
 		if !ok {
 			return SourceInfo{}, ErrUnsupportedSourceType
 		}
-		files, err := infoClient.ListFiles(ctx)
+		info, err := infoClient.SourceInfo(ctx)
 		if err != nil {
 			return SourceInfo{}, err
 		}
-		total, used, free, err := infoClient.StorageInfo(ctx)
-		if err != nil {
-			return SourceInfo{}, err
-		}
-		respFiles := make([]SourceInfoFile, 0, len(files))
-		for _, f := range files {
+		respFiles := make([]SourceInfoFile, 0, len(info.Files))
+		for _, f := range info.Files {
 			respFiles = append(respFiles, SourceInfoFile{ID: f.ID, Name: f.Name, Size: f.Size})
 		}
-		return SourceInfo{Files: respFiles, StorageTotal: total, StorageUsed: used, StorageFree: free}, nil
+		return SourceInfo{Files: respFiles, StorageTotal: info.StorageTotal, StorageUsed: info.StorageUsed, StorageFree: info.StorageFree}, nil
 	case repository.SourceTypeTelegram:
 		return SourceInfo{Files: []SourceInfoFile{}}, nil
 	case repository.SourceTypeS3:
@@ -86,21 +78,19 @@ func InspectSource(ctx context.Context, src *repository.Source, factory SourceCl
 		if err != nil {
 			return SourceInfo{}, err
 		}
-		infoClient, ok := cli.(interface {
-			ListObjects(context.Context) ([]s3compat.ObjectInfo, int64, error)
-		})
+		infoClient, ok := cli.(sourcecap.InfoProvider)
 		if !ok {
 			return SourceInfo{}, ErrUnsupportedSourceType
 		}
-		files, used, err := infoClient.ListObjects(ctx)
+		info, err := infoClient.SourceInfo(ctx)
 		if err != nil {
 			return SourceInfo{}, err
 		}
-		respFiles := make([]SourceInfoFile, 0, len(files))
-		for _, f := range files {
-			respFiles = append(respFiles, SourceInfoFile{ID: f.Key, Name: f.Key, Size: f.Size})
+		respFiles := make([]SourceInfoFile, 0, len(info.Files))
+		for _, f := range info.Files {
+			respFiles = append(respFiles, SourceInfoFile{ID: f.ID, Name: f.Name, Size: f.Size})
 		}
-		return SourceInfo{Files: respFiles, StorageUsed: used}, nil
+		return SourceInfo{Files: respFiles, StorageTotal: info.StorageTotal, StorageUsed: info.StorageUsed, StorageFree: info.StorageFree}, nil
 	default:
 		return SourceInfo{}, ErrUnsupportedSourceType
 	}
@@ -136,51 +126,45 @@ func CheckSourceHealth(ctx context.Context, src *repository.Source, factory Sour
 	}
 
 	switch src.Type {
-	case repository.SourceTypeGDrive:
-		infoClient, ok := cli.(interface {
-			StorageInfo(context.Context) (int64, int64, int64, error)
-		})
+	case repository.SourceTypeGDrive, repository.SourceTypeTelegram, repository.SourceTypeS3:
+		healthClient, ok := cli.(sourcecap.HealthProber)
 		if !ok {
 			return SourceHealth{}, ErrUnsupportedSourceType
 		}
-		total, used, free, err := infoClient.StorageInfo(ctx)
-		if err != nil {
-			return finish(SourceHealthUnhealthy, "probe_failed", "Google Drive metadata probe failed."), nil
+		result, err := healthClient.ProbeSourceHealth(ctx)
+		if errors.Is(err, sourcecap.ErrUnsupportedCapability) {
+			return SourceHealth{}, ErrUnsupportedSourceType
 		}
-		if total > 0 {
-			health.Quota = SourceQuota{TotalBytes: &total, UsedBytes: &used, FreeBytes: &free}
-			if free <= 0 {
-				return finish(SourceHealthUnhealthy, "quota_exhausted", "Google Drive quota is exhausted."), nil
-			}
-			if free*100/total < 5 {
-				return finish(SourceHealthDegraded, "quota_low", "Google Drive quota is nearly exhausted."), nil
+		if err != nil && result.ReasonCode == "" {
+			result = sourcecap.Health{
+				Status:     sourcecap.HealthUnhealthy,
+				ReasonCode: "probe_failed",
+				Message:    "Source health probe failed.",
 			}
 		}
-		return finish(SourceHealthHealthy, "ok", "Google Drive metadata is reachable."), nil
-	case repository.SourceTypeTelegram:
-		healthClient, ok := cli.(interface {
-			CheckChat(context.Context) error
-		})
-		if !ok {
-			return SourceHealth{}, ErrUnsupportedSourceType
-		}
-		if err := healthClient.CheckChat(ctx); err != nil {
-			return finish(SourceHealthUnhealthy, "probe_failed", "Telegram bot or chat is not reachable."), nil
-		}
-		return finish(SourceHealthHealthy, "ok", "Telegram bot and chat are reachable."), nil
-	case repository.SourceTypeS3:
-		healthClient, ok := cli.(interface {
-			HeadBucket(context.Context) error
-		})
-		if !ok {
-			return SourceHealth{}, ErrUnsupportedSourceType
-		}
-		if err := healthClient.HeadBucket(ctx); err != nil {
-			return finish(SourceHealthUnhealthy, "probe_failed", "S3 bucket metadata probe failed."), nil
-		}
-		return finish(SourceHealthHealthy, "ok", "S3 bucket metadata is reachable."), nil
+		health.Quota = sourceQuotaFromCapability(result.Quota)
+		return finish(sourceHealthStatusFromCapability(result.Status), result.ReasonCode, result.Message), nil
 	default:
 		return SourceHealth{}, ErrUnsupportedSourceType
+	}
+}
+
+func sourceHealthStatusFromCapability(status sourcecap.HealthStatus) SourceHealthStatus {
+	switch status {
+	case sourcecap.HealthDegraded:
+		return SourceHealthDegraded
+	case sourcecap.HealthUnhealthy:
+		return SourceHealthUnhealthy
+	default:
+		return SourceHealthHealthy
+	}
+}
+
+func sourceQuotaFromCapability(quota sourcecap.Quota) SourceQuota {
+	return SourceQuota{
+		TotalBytes: quota.TotalBytes,
+		UsedBytes:  quota.UsedBytes,
+		FreeBytes:  quota.FreeBytes,
 	}
 }
 

--- a/api-go/internal/manager/source_health_test.go
+++ b/api-go/internal/manager/source_health_test.go
@@ -8,20 +8,14 @@ import (
 	"testing"
 
 	"github.com/example/sfree/api-go/internal/repository"
-	"github.com/example/sfree/api-go/internal/s3compat"
+	"github.com/example/sfree/api-go/internal/sourcecap"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
 type healthTestClient struct {
-	storageTotal int64
-	storageUsed  int64
-	storageFree  int64
-	storageErr   error
-	headErr      error
-	chatErr      error
-	headCalls    int
-	chatCalls    int
-	listCalls    int
+	health     sourcecap.Health
+	healthErr  error
+	probeCalls int
 }
 
 func (c *healthTestClient) Upload(context.Context, string, io.Reader) (string, error) {
@@ -36,28 +30,20 @@ func (c *healthTestClient) Delete(context.Context, string) error {
 	return nil
 }
 
-func (c *healthTestClient) StorageInfo(context.Context) (int64, int64, int64, error) {
-	return c.storageTotal, c.storageUsed, c.storageFree, c.storageErr
-}
-
-func (c *healthTestClient) HeadBucket(context.Context) error {
-	c.headCalls++
-	return c.headErr
-}
-
-func (c *healthTestClient) CheckChat(context.Context) error {
-	c.chatCalls++
-	return c.chatErr
-}
-
-func (c *healthTestClient) ListObjects(context.Context) ([]s3compat.ObjectInfo, int64, error) {
-	c.listCalls++
-	return nil, 0, nil
+func (c *healthTestClient) ProbeSourceHealth(context.Context) (sourcecap.Health, error) {
+	c.probeCalls++
+	return c.health, c.healthErr
 }
 
 func TestCheckSourceHealthGDriveReturnsQuota(t *testing.T) {
 	t.Parallel()
-	cli := &healthTestClient{storageTotal: 1000, storageUsed: 400, storageFree: 600}
+	total, used, free := int64(1000), int64(400), int64(600)
+	cli := &healthTestClient{health: sourcecap.Health{
+		Status:     sourcecap.HealthHealthy,
+		ReasonCode: "ok",
+		Message:    "Google Drive metadata is reachable.",
+		Quota:      sourcecap.Quota{TotalBytes: &total, UsedBytes: &used, FreeBytes: &free},
+	}}
 	src := &repository.Source{ID: primitive.NewObjectID(), Type: repository.SourceTypeGDrive}
 
 	health, err := CheckSourceHealth(context.Background(), src, func(context.Context, *repository.Source) (SourceClient, error) {
@@ -76,7 +62,11 @@ func TestCheckSourceHealthGDriveReturnsQuota(t *testing.T) {
 
 func TestCheckSourceHealthGDriveLowQuotaIsDegraded(t *testing.T) {
 	t.Parallel()
-	cli := &healthTestClient{storageTotal: 1000, storageUsed: 970, storageFree: 30}
+	cli := &healthTestClient{health: sourcecap.Health{
+		Status:     sourcecap.HealthDegraded,
+		ReasonCode: "quota_low",
+		Message:    "Google Drive quota is nearly exhausted.",
+	}}
 	src := &repository.Source{ID: primitive.NewObjectID(), Type: repository.SourceTypeGDrive}
 
 	health, err := CheckSourceHealth(context.Background(), src, func(context.Context, *repository.Source) (SourceClient, error) {
@@ -92,7 +82,11 @@ func TestCheckSourceHealthGDriveLowQuotaIsDegraded(t *testing.T) {
 
 func TestCheckSourceHealthS3UsesBucketMetadataProbe(t *testing.T) {
 	t.Parallel()
-	cli := &healthTestClient{}
+	cli := &healthTestClient{health: sourcecap.Health{
+		Status:     sourcecap.HealthHealthy,
+		ReasonCode: "ok",
+		Message:    "S3 bucket metadata is reachable.",
+	}}
 	src := &repository.Source{ID: primitive.NewObjectID(), Type: repository.SourceTypeS3}
 
 	health, err := CheckSourceHealth(context.Background(), src, func(context.Context, *repository.Source) (SourceClient, error) {
@@ -104,11 +98,8 @@ func TestCheckSourceHealthS3UsesBucketMetadataProbe(t *testing.T) {
 	if health.Status != SourceHealthHealthy {
 		t.Fatalf("unexpected health: %+v", health)
 	}
-	if cli.headCalls != 1 {
-		t.Fatalf("expected one head bucket call, got %d", cli.headCalls)
-	}
-	if cli.listCalls != 0 {
-		t.Fatalf("health check must not list objects, got %d calls", cli.listCalls)
+	if cli.probeCalls != 1 {
+		t.Fatalf("expected one health probe call, got %d", cli.probeCalls)
 	}
 	if health.Quota.TotalBytes != nil || health.Quota.UsedBytes != nil || health.Quota.FreeBytes != nil {
 		t.Fatalf("expected unknown quota for s3, got %+v", health.Quota)
@@ -117,7 +108,14 @@ func TestCheckSourceHealthS3UsesBucketMetadataProbe(t *testing.T) {
 
 func TestCheckSourceHealthTelegramFailureIsUnhealthy(t *testing.T) {
 	t.Parallel()
-	cli := &healthTestClient{chatErr: errors.New("chat not found")}
+	cli := &healthTestClient{
+		health: sourcecap.Health{
+			Status:     sourcecap.HealthUnhealthy,
+			ReasonCode: "probe_failed",
+			Message:    "Telegram bot or chat is not reachable.",
+		},
+		healthErr: errors.New("chat not found"),
+	}
 	src := &repository.Source{ID: primitive.NewObjectID(), Type: repository.SourceTypeTelegram}
 
 	health, err := CheckSourceHealth(context.Background(), src, func(context.Context, *repository.Source) (SourceClient, error) {
@@ -129,8 +127,8 @@ func TestCheckSourceHealthTelegramFailureIsUnhealthy(t *testing.T) {
 	if health.Status != SourceHealthUnhealthy || health.ReasonCode != "probe_failed" {
 		t.Fatalf("unexpected health: %+v", health)
 	}
-	if cli.chatCalls != 1 {
-		t.Fatalf("expected one chat check, got %d", cli.chatCalls)
+	if cli.probeCalls != 1 {
+		t.Fatalf("expected one health probe call, got %d", cli.probeCalls)
 	}
 }
 

--- a/api-go/internal/resilience/wrapper.go
+++ b/api-go/internal/resilience/wrapper.go
@@ -8,8 +8,7 @@ import (
 	"log/slog"
 	"time"
 
-	"github.com/example/sfree/api-go/internal/gdrive"
-	"github.com/example/sfree/api-go/internal/s3compat"
+	"github.com/example/sfree/api-go/internal/sourcecap"
 )
 
 var ErrUnsupportedOperation = errors.New("unsupported source client operation")
@@ -261,80 +260,32 @@ func (r *cancelOnCloseReadCloser) Close() error {
 	return err
 }
 
-func (w *wrapper) ListFiles(ctx context.Context) ([]gdrive.File, error) {
-	inner, ok := w.inner.(interface {
-		ListFiles(context.Context) ([]gdrive.File, error)
-	})
+func (w *wrapper) SourceInfo(ctx context.Context) (sourcecap.Info, error) {
+	inner, ok := w.inner.(sourcecap.InfoProvider)
 	if !ok {
-		return nil, ErrUnsupportedOperation
+		return sourcecap.Info{}, sourcecap.ErrUnsupportedCapability
 	}
 
-	var files []gdrive.File
-	err := w.withRetry(ctx, "retrying list files", nil, timeoutRetryContext(w.cfg.Timeout), true, nil, func(reqCtx context.Context, cancel context.CancelFunc) error {
+	var info sourcecap.Info
+	err := w.withRetry(ctx, "retrying source info", nil, timeoutRetryContext(w.cfg.Timeout), true, nil, func(reqCtx context.Context, cancel context.CancelFunc) error {
 		var err error
-		files, err = inner.ListFiles(reqCtx)
+		info, err = inner.SourceInfo(reqCtx)
 		return err
 	})
-	return files, err
+	return info, err
 }
 
-func (w *wrapper) StorageInfo(ctx context.Context) (int64, int64, int64, error) {
-	inner, ok := w.inner.(interface {
-		StorageInfo(context.Context) (int64, int64, int64, error)
-	})
+func (w *wrapper) ProbeSourceHealth(ctx context.Context) (sourcecap.Health, error) {
+	inner, ok := w.inner.(sourcecap.HealthProber)
 	if !ok {
-		return 0, 0, 0, ErrUnsupportedOperation
+		return sourcecap.Health{}, sourcecap.ErrUnsupportedCapability
 	}
 
-	var total, used, free int64
-	err := w.withRetry(ctx, "retrying storage info", nil, timeoutRetryContext(w.cfg.Timeout), true, nil, func(reqCtx context.Context, cancel context.CancelFunc) error {
+	var health sourcecap.Health
+	err := w.withRetry(ctx, "retrying source health probe", nil, timeoutRetryContext(w.cfg.Timeout), true, nil, func(reqCtx context.Context, cancel context.CancelFunc) error {
 		var err error
-		total, used, free, err = inner.StorageInfo(reqCtx)
+		health, err = inner.ProbeSourceHealth(reqCtx)
 		return err
 	})
-	return total, used, free, err
-}
-
-func (w *wrapper) ListObjects(ctx context.Context) ([]s3compat.ObjectInfo, int64, error) {
-	inner, ok := w.inner.(interface {
-		ListObjects(context.Context) ([]s3compat.ObjectInfo, int64, error)
-	})
-	if !ok {
-		return nil, 0, ErrUnsupportedOperation
-	}
-
-	var objects []s3compat.ObjectInfo
-	var used int64
-	err := w.withRetry(ctx, "retrying list objects", nil, timeoutRetryContext(w.cfg.Timeout), true, nil, func(reqCtx context.Context, cancel context.CancelFunc) error {
-		var err error
-		objects, used, err = inner.ListObjects(reqCtx)
-		return err
-	})
-	return objects, used, err
-}
-
-func (w *wrapper) HeadBucket(ctx context.Context) error {
-	inner, ok := w.inner.(interface {
-		HeadBucket(context.Context) error
-	})
-	if !ok {
-		return ErrUnsupportedOperation
-	}
-
-	return w.withRetry(ctx, "retrying head bucket", nil, timeoutRetryContext(w.cfg.Timeout), true, nil, func(reqCtx context.Context, cancel context.CancelFunc) error {
-		return inner.HeadBucket(reqCtx)
-	})
-}
-
-func (w *wrapper) CheckChat(ctx context.Context) error {
-	inner, ok := w.inner.(interface {
-		CheckChat(context.Context) error
-	})
-	if !ok {
-		return ErrUnsupportedOperation
-	}
-
-	return w.withRetry(ctx, "retrying telegram chat check", nil, timeoutRetryContext(w.cfg.Timeout), true, nil, func(reqCtx context.Context, cancel context.CancelFunc) error {
-		return inner.CheckChat(reqCtx)
-	})
+	return health, err
 }

--- a/api-go/internal/resilience/wrapper_test.go
+++ b/api-go/internal/resilience/wrapper_test.go
@@ -8,6 +8,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/example/sfree/api-go/internal/sourcecap"
 )
 
 // mockClient is a test double for the source client interface.
@@ -20,6 +22,8 @@ type mockClient struct {
 	uploadCalls   atomic.Int32
 	downloadCalls atomic.Int32
 	deleteCalls   atomic.Int32
+	infoCalls     atomic.Int32
+	healthCalls   atomic.Int32
 }
 
 func (m *mockClient) Upload(ctx context.Context, name string, r io.Reader) (string, error) {
@@ -59,6 +63,16 @@ func (m *mockClient) Delete(ctx context.Context, name string) error {
 		}
 	}
 	return m.deleteErr
+}
+
+func (m *mockClient) SourceInfo(context.Context) (sourcecap.Info, error) {
+	m.infoCalls.Add(1)
+	return sourcecap.Info{Files: []sourcecap.File{{ID: "id", Name: "name", Size: 7}}, StorageUsed: 7}, nil
+}
+
+func (m *mockClient) ProbeSourceHealth(context.Context) (sourcecap.Health, error) {
+	m.healthCalls.Add(1)
+	return sourcecap.Health{Status: sourcecap.HealthHealthy, ReasonCode: "ok", Message: "healthy"}, nil
 }
 
 func TestWrapperPassesThrough(t *testing.T) {
@@ -493,5 +507,34 @@ func TestWrapperRetryZeroMeansNoRetry(t *testing.T) {
 	}
 	if got := int(inner.uploadCalls.Load()); got != 1 {
 		t.Fatalf("expected exactly 1 call with 0 retries, got %d", got)
+	}
+}
+
+func TestWrapperPassesThroughSourceCapabilities(t *testing.T) {
+	inner := &mockClient{}
+	w := Wrap(inner, DefaultWrapperConfig())
+
+	infoClient, ok := w.(sourcecap.InfoProvider)
+	if !ok {
+		t.Fatal("expected wrapped client to expose source info capability")
+	}
+	info, err := infoClient.SourceInfo(context.Background())
+	if err != nil {
+		t.Fatalf("source info: %v", err)
+	}
+	if len(info.Files) != 1 || info.StorageUsed != 7 {
+		t.Fatalf("unexpected source info: %+v", info)
+	}
+
+	healthClient, ok := w.(sourcecap.HealthProber)
+	if !ok {
+		t.Fatal("expected wrapped client to expose source health capability")
+	}
+	health, err := healthClient.ProbeSourceHealth(context.Background())
+	if err != nil {
+		t.Fatalf("source health: %v", err)
+	}
+	if health.Status != sourcecap.HealthHealthy || health.ReasonCode != "ok" {
+		t.Fatalf("unexpected source health: %+v", health)
 	}
 }

--- a/api-go/internal/s3compat/client.go
+++ b/api-go/internal/s3compat/client.go
@@ -10,6 +10,7 @@ import (
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/example/sfree/api-go/internal/sourcecap"
 )
 
 type Config struct {
@@ -137,4 +138,31 @@ func (c *Client) HeadBucket(ctx context.Context) error {
 	}
 	_, err := headFn(ctx, &s3.HeadBucketInput{Bucket: aws.String(c.cfg.Bucket)})
 	return err
+}
+
+func (c *Client) SourceInfo(ctx context.Context) (sourcecap.Info, error) {
+	objects, used, err := c.ListObjects(ctx)
+	if err != nil {
+		return sourcecap.Info{}, err
+	}
+	files := make([]sourcecap.File, 0, len(objects))
+	for _, obj := range objects {
+		files = append(files, sourcecap.File{ID: obj.Key, Name: obj.Key, Size: obj.Size})
+	}
+	return sourcecap.Info{Files: files, StorageUsed: used}, nil
+}
+
+func (c *Client) ProbeSourceHealth(ctx context.Context) (sourcecap.Health, error) {
+	if err := c.HeadBucket(ctx); err != nil {
+		return sourcecap.Health{
+			Status:     sourcecap.HealthUnhealthy,
+			ReasonCode: "probe_failed",
+			Message:    "S3 bucket metadata probe failed.",
+		}, err
+	}
+	return sourcecap.Health{
+		Status:     sourcecap.HealthHealthy,
+		ReasonCode: "ok",
+		Message:    "S3 bucket metadata is reachable.",
+	}, nil
 }

--- a/api-go/internal/s3compat/client_test.go
+++ b/api-go/internal/s3compat/client_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/example/sfree/api-go/internal/sourcecap"
 )
 
 func TestParseConfigRequiresFields(t *testing.T) {
@@ -94,6 +95,58 @@ func TestHeadBucketUsesBucketMetadataProbe(t *testing.T) {
 
 	if err := cli.HeadBucket(context.Background()); err != nil {
 		t.Fatalf("head bucket: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("unexpected calls count: %d", calls)
+	}
+}
+
+func TestSourceInfoMapsObjects(t *testing.T) {
+	t.Parallel()
+	cli := &Client{cfg: Config{Bucket: "bucket"}}
+	cli.listObjectsV2 = func(_ context.Context, input *s3.ListObjectsV2Input, _ ...func(*s3.Options)) (*s3.ListObjectsV2Output, error) {
+		if aws.ToString(input.Bucket) != "bucket" {
+			t.Fatalf("unexpected bucket: %s", aws.ToString(input.Bucket))
+		}
+		return &s3.ListObjectsV2Output{
+			Contents: []types.Object{{Key: aws.String("object-key"), Size: aws.Int64(12)}},
+		}, nil
+	}
+
+	info, err := cli.SourceInfo(context.Background())
+	if err != nil {
+		t.Fatalf("source info: %v", err)
+	}
+	if len(info.Files) != 1 || info.Files[0].ID != "object-key" || info.Files[0].Name != "object-key" || info.Files[0].Size != 12 {
+		t.Fatalf("unexpected files: %+v", info.Files)
+	}
+	if info.StorageUsed != 12 || info.StorageTotal != 0 || info.StorageFree != 0 {
+		t.Fatalf("unexpected storage info: %+v", info)
+	}
+}
+
+func TestProbeSourceHealthUsesBucketMetadataProbe(t *testing.T) {
+	t.Parallel()
+	cli := &Client{cfg: Config{Bucket: "bucket"}}
+	calls := 0
+	cli.headBucket = func(_ context.Context, input *s3.HeadBucketInput, _ ...func(*s3.Options)) (*s3.HeadBucketOutput, error) {
+		calls++
+		if aws.ToString(input.Bucket) != "bucket" {
+			t.Fatalf("unexpected bucket: %s", aws.ToString(input.Bucket))
+		}
+		return &s3.HeadBucketOutput{}, nil
+	}
+	cli.listObjectsV2 = func(context.Context, *s3.ListObjectsV2Input, ...func(*s3.Options)) (*s3.ListObjectsV2Output, error) {
+		t.Fatal("health probe must not list objects")
+		return nil, nil
+	}
+
+	health, err := cli.ProbeSourceHealth(context.Background())
+	if err != nil {
+		t.Fatalf("source health: %v", err)
+	}
+	if health.Status != sourcecap.HealthHealthy || health.ReasonCode != "ok" {
+		t.Fatalf("unexpected health: %+v", health)
 	}
 	if calls != 1 {
 		t.Fatalf("unexpected calls count: %d", calls)

--- a/api-go/internal/sourcecap/capabilities.go
+++ b/api-go/internal/sourcecap/capabilities.go
@@ -1,0 +1,50 @@
+package sourcecap
+
+import (
+	"context"
+	"errors"
+)
+
+var ErrUnsupportedCapability = errors.New("unsupported source capability")
+
+type File struct {
+	ID   string
+	Name string
+	Size int64
+}
+
+type Info struct {
+	Files        []File
+	StorageTotal int64
+	StorageUsed  int64
+	StorageFree  int64
+}
+
+type InfoProvider interface {
+	SourceInfo(context.Context) (Info, error)
+}
+
+type HealthStatus string
+
+const (
+	HealthHealthy   HealthStatus = "healthy"
+	HealthDegraded  HealthStatus = "degraded"
+	HealthUnhealthy HealthStatus = "unhealthy"
+)
+
+type Quota struct {
+	TotalBytes *int64
+	UsedBytes  *int64
+	FreeBytes  *int64
+}
+
+type Health struct {
+	Status     HealthStatus
+	ReasonCode string
+	Message    string
+	Quota      Quota
+}
+
+type HealthProber interface {
+	ProbeSourceHealth(context.Context) (Health, error)
+}

--- a/api-go/internal/telegram/client.go
+++ b/api-go/internal/telegram/client.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+
+	"github.com/example/sfree/api-go/internal/sourcecap"
 )
 
 type Config struct {
@@ -243,4 +245,19 @@ func (c *Client) CheckChat(ctx context.Context) error {
 		return fmt.Errorf("telegram getChat invalid response")
 	}
 	return nil
+}
+
+func (c *Client) ProbeSourceHealth(ctx context.Context) (sourcecap.Health, error) {
+	if err := c.CheckChat(ctx); err != nil {
+		return sourcecap.Health{
+			Status:     sourcecap.HealthUnhealthy,
+			ReasonCode: "probe_failed",
+			Message:    "Telegram bot or chat is not reachable.",
+		}, err
+	}
+	return sourcecap.Health{
+		Status:     sourcecap.HealthHealthy,
+		ReasonCode: "ok",
+		Message:    "Telegram bot and chat are reachable.",
+	}, nil
 }

--- a/api-go/internal/telegram/client_test.go
+++ b/api-go/internal/telegram/client_test.go
@@ -8,6 +8,8 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/example/sfree/api-go/internal/sourcecap"
 )
 
 func TestClientUploadDownloadDelete(t *testing.T) {
@@ -129,5 +131,35 @@ func TestCheckChat(t *testing.T) {
 	}
 	if err := cli.CheckChat(context.Background()); err != nil {
 		t.Fatalf("check chat: %v", err)
+	}
+}
+
+func TestProbeSourceHealth(t *testing.T) {
+	t.Parallel()
+	const (
+		token  = "token123"
+		chatID = "-100123"
+	)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/bot"+token+"/getChat", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		if got := r.FormValue("chat_id"); got != chatID {
+			t.Fatalf("unexpected chat_id: %s", got)
+		}
+		_, _ = w.Write([]byte(`{"ok":true,"result":{"id":-100123}}`))
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	cli, err := NewClientWithBaseURL(Config{Token: token, ChatID: chatID}, ts.URL)
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	health, err := cli.ProbeSourceHealth(context.Background())
+	if err != nil {
+		t.Fatalf("source health: %v", err)
+	}
+	if health.Status != sourcecap.HealthHealthy || health.ReasonCode != "ok" {
+		t.Fatalf("unexpected health: %+v", health)
 	}
 }


### PR DESCRIPTION
## Summary
- adds provider-neutral source capability contracts for source info and health probes
- moves Google Drive, S3-compatible, and Telegram info/health mappings behind provider implementations
- updates manager and resilience code to depend on neutral capability interfaces instead of provider DTO packages

## Validation
- git diff --check
- rg confirmed manager/source.go and resilience/wrapper.go no longer import provider packages or reference provider-specific optional methods
- Local make test/golangci-lint not run because this agent is instructed to leave CPU-bound validation to Woodpecker CI.