### PR TITLE
THE-643 Extract owned source lookup helper

### DIFF
--- a/api-go/internal/handlers/source.go
+++ b/api-go/internal/handlers/source.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"reflect"
 	"strings"
 	"time"
 
@@ -79,6 +80,51 @@ type sourceHealthResponse struct {
 
 type sourceGetter interface {
 	GetByID(ctx context.Context, id primitive.ObjectID) (*repository.Source, error)
+}
+
+func ownedSourceFromRoute(c *gin.Context, repo sourceGetter, operation string) (*repository.Source, bool) {
+	ctx := c.Request.Context()
+	if nilSourceGetter(repo) {
+		slog.ErrorContext(ctx, operation+": repository is nil")
+		c.Status(http.StatusServiceUnavailable)
+		return nil, false
+	}
+	userID, ok := authenticatedUserID(c)
+	if !ok {
+		return nil, false
+	}
+	id, ok := routeObjectID(c, "id")
+	if !ok {
+		return nil, false
+	}
+	src, err := repo.GetByID(ctx, id)
+	if err != nil {
+		if err == mongo.ErrNoDocuments {
+			c.Status(http.StatusNotFound)
+			return nil, false
+		}
+		slog.ErrorContext(ctx, operation+": get source", slog.String("error", err.Error()))
+		c.Status(http.StatusInternalServerError)
+		return nil, false
+	}
+	if src.UserID != userID {
+		c.Status(http.StatusNotFound)
+		return nil, false
+	}
+	return src, true
+}
+
+func nilSourceGetter(repo sourceGetter) bool {
+	if repo == nil {
+		return true
+	}
+	value := reflect.ValueOf(repo)
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return value.IsNil()
+	default:
+		return false
+	}
 }
 
 // CreateGDriveSource godoc
@@ -329,31 +375,8 @@ func GetSourceInfo(repo *repository.SourceRepository) gin.HandlerFunc {
 func getSourceInfo(repo *repository.SourceRepository, factory manager.SourceClientFactory) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		ctx := c.Request.Context()
-		if repo == nil {
-			slog.ErrorContext(ctx, "get source info: repository is nil")
-			c.Status(http.StatusServiceUnavailable)
-			return
-		}
-		userID, ok := authenticatedUserID(c)
+		src, ok := ownedSourceFromRoute(c, repo, "get source info")
 		if !ok {
-			return
-		}
-		id, ok := routeObjectID(c, "id")
-		if !ok {
-			return
-		}
-		src, err := repo.GetByID(c.Request.Context(), id)
-		if err != nil {
-			if err == mongo.ErrNoDocuments {
-				c.Status(http.StatusNotFound)
-				return
-			}
-			slog.ErrorContext(ctx, "get source info: get source", slog.String("error", err.Error()))
-			c.Status(http.StatusInternalServerError)
-			return
-		}
-		if src.UserID != userID {
-			c.Status(http.StatusNotFound)
 			return
 		}
 		info, err := manager.InspectSource(c.Request.Context(), src, factory)
@@ -401,31 +424,8 @@ func GetSourceHealth(repo *repository.SourceRepository) gin.HandlerFunc {
 func getSourceHealth(repo sourceGetter, factory manager.SourceClientFactory) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		ctx := c.Request.Context()
-		if repo == nil {
-			slog.ErrorContext(ctx, "get source health: repository is nil")
-			c.Status(http.StatusServiceUnavailable)
-			return
-		}
-		userID, ok := authenticatedUserID(c)
+		src, ok := ownedSourceFromRoute(c, repo, "get source health")
 		if !ok {
-			return
-		}
-		id, ok := routeObjectID(c, "id")
-		if !ok {
-			return
-		}
-		src, err := repo.GetByID(c.Request.Context(), id)
-		if err != nil {
-			if err == mongo.ErrNoDocuments {
-				c.Status(http.StatusNotFound)
-				return
-			}
-			slog.ErrorContext(ctx, "get source health: get source", slog.String("error", err.Error()))
-			c.Status(http.StatusInternalServerError)
-			return
-		}
-		if src.UserID != userID {
-			c.Status(http.StatusNotFound)
 			return
 		}
 		health, err := manager.CheckSourceHealth(c.Request.Context(), src, factory)
@@ -475,36 +475,13 @@ func DownloadSourceFile(sourceRepo *repository.SourceRepository) gin.HandlerFunc
 
 func downloadSourceFile(sourceRepo sourceGetter, factory manager.SourceClientFactory) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		if sourceRepo == nil {
-			slog.ErrorContext(c.Request.Context(), "download source file: repository is nil")
-			c.Status(http.StatusServiceUnavailable)
-			return
-		}
-		userID, ok := authenticatedUserID(c)
-		if !ok {
-			return
-		}
-		id, ok := routeObjectID(c, "id")
+		src, ok := ownedSourceFromRoute(c, sourceRepo, "download source file")
 		if !ok {
 			return
 		}
 		fileID := c.Param("file_id")
 		if fileID == "" {
 			c.Status(http.StatusBadRequest)
-			return
-		}
-		src, err := sourceRepo.GetByID(c.Request.Context(), id)
-		if err != nil {
-			if err == mongo.ErrNoDocuments {
-				c.Status(http.StatusNotFound)
-				return
-			}
-			slog.ErrorContext(c.Request.Context(), "download source file: get source", slog.String("error", err.Error()))
-			c.Status(http.StatusInternalServerError)
-			return
-		}
-		if src.UserID != userID {
-			c.Status(http.StatusNotFound)
 			return
 		}
 

--- a/api-go/internal/handlers/source_health_test.go
+++ b/api-go/internal/handlers/source_health_test.go
@@ -77,6 +77,35 @@ func TestGetSourceHealthMissingSource(t *testing.T) {
 	}
 }
 
+func TestGetSourceHealthTypedNilRepository(t *testing.T) {
+	t.Parallel()
+	var repo *repository.SourceRepository
+	r := gin.New()
+	r.GET("/sources/:id/health", setUserID(validUserID()), getSourceHealth(repo, nil))
+
+	req, _ := http.NewRequest(http.MethodGet, "/sources/"+primitive.NewObjectID().Hex()+"/health", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d", w.Code)
+	}
+}
+
+func TestGetSourceHealthRepositoryError(t *testing.T) {
+	t.Parallel()
+	r := gin.New()
+	r.GET("/sources/:id/health", setUserID(validUserID()), getSourceHealth(fakeSourceGetter{err: errors.New("database unavailable")}, nil))
+
+	req, _ := http.NewRequest(http.MethodGet, "/sources/"+primitive.NewObjectID().Hex()+"/health", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", w.Code)
+	}
+}
+
 func TestGetSourceHealthNonOwnedSource(t *testing.T) {
 	t.Parallel()
 	source := &repository.Source{


### PR DESCRIPTION
## Summary
- Add a shared `ownedSourceFromRoute` helper for authenticated owned-source lookup in source routes.
- Use the helper from source info, source health, and source file download handlers.
- Add focused health-handler coverage for repository failures so helper-backed lookup paths cover bad ID, missing source, non-owned source, and repository error cases.

`DeleteSource` is intentionally left separate because its delete path includes the bucket-reference check before deletion.

## Validation
- `git diff --check`
- Local Go tests not run per limited-resource agent policy; Woodpecker should run backend validation.