### PR TITLE
THE-718: Remove wall-clock sleeps from unit tests

### DIFF
--- a/api-go/internal/ratelimit/ratelimit.go
+++ b/api-go/internal/ratelimit/ratelimit.go
@@ -11,6 +11,7 @@ type Limiter struct {
 	buckets map[string]*bucket
 	rate    float64 // tokens per second
 	burst   int     // max tokens (bucket capacity)
+	now     func() time.Time
 }
 
 type bucket struct {
@@ -21,10 +22,15 @@ type bucket struct {
 // NewLimiter creates a rate limiter that allows reqsPerMin requests per minute
 // with a burst size equal to reqsPerMin.
 func NewLimiter(reqsPerMin int) *Limiter {
+	return newLimiterWithClock(reqsPerMin, time.Now)
+}
+
+func newLimiterWithClock(reqsPerMin int, now func() time.Time) *Limiter {
 	return &Limiter{
 		buckets: make(map[string]*bucket),
 		rate:    float64(reqsPerMin) / 60.0,
 		burst:   reqsPerMin,
+		now:     now,
 	}
 }
 
@@ -35,7 +41,7 @@ func (l *Limiter) Allow(key string) (ok bool, retryAfter float64) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
-	now := time.Now()
+	now := l.now()
 	b, exists := l.buckets[key]
 	if !exists {
 		b = &bucket{tokens: float64(l.burst), lastTime: now}
@@ -64,7 +70,7 @@ func (l *Limiter) Cleanup(maxAge time.Duration) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
-	cutoff := time.Now().Add(-maxAge)
+	cutoff := l.now().Add(-maxAge)
 	for key, b := range l.buckets {
 		if b.lastTime.Before(cutoff) {
 			delete(l.buckets, key)

--- a/api-go/internal/ratelimit/ratelimit_test.go
+++ b/api-go/internal/ratelimit/ratelimit_test.go
@@ -5,6 +5,22 @@ import (
 	"time"
 )
 
+type fakeClock struct {
+	t time.Time
+}
+
+func newFakeClock() *fakeClock {
+	return &fakeClock{t: time.Date(2026, 4, 22, 0, 0, 0, 0, time.UTC)}
+}
+
+func (c *fakeClock) Now() time.Time {
+	return c.t
+}
+
+func (c *fakeClock) Advance(d time.Duration) {
+	c.t = c.t.Add(d)
+}
+
 func TestLimiterAllow(t *testing.T) {
 	l := NewLimiter(60) // 60 req/min = 1 req/sec
 
@@ -49,7 +65,8 @@ func TestLimiterSeparateKeys(t *testing.T) {
 }
 
 func TestLimiterRefill(t *testing.T) {
-	l := NewLimiter(600) // 600 req/min = 10 req/sec
+	clock := newFakeClock()
+	l := newLimiterWithClock(600, clock.Now) // 600 req/min = 10 req/sec
 
 	// Exhaust all tokens.
 	for i := 0; i < 600; i++ {
@@ -61,8 +78,7 @@ func TestLimiterRefill(t *testing.T) {
 		t.Fatal("should be denied after exhausting tokens")
 	}
 
-	// Wait enough time for at least 1 token to refill (need 0.1s for 1 token at 10/sec).
-	time.Sleep(150 * time.Millisecond)
+	clock.Advance(100 * time.Millisecond)
 
 	ok, _ = l.Allow("refill")
 	if !ok {

--- a/api-go/internal/resilience/circuitbreaker.go
+++ b/api-go/internal/resilience/circuitbreaker.go
@@ -29,12 +29,17 @@ type CircuitBreaker struct {
 	failureThreshold int
 	recoveryTimeout  time.Duration
 	openedAt         time.Time
+	now              func() time.Time
 }
 
 // NewCircuitBreaker creates a circuit breaker with the given parameters.
 // failureThreshold is the number of consecutive failures before opening.
 // recoveryTimeout is how long the circuit stays open before allowing a probe.
 func NewCircuitBreaker(failureThreshold int, recoveryTimeout time.Duration) *CircuitBreaker {
+	return newCircuitBreakerWithClock(failureThreshold, recoveryTimeout, time.Now)
+}
+
+func newCircuitBreakerWithClock(failureThreshold int, recoveryTimeout time.Duration, now func() time.Time) *CircuitBreaker {
 	if failureThreshold <= 0 {
 		failureThreshold = 5
 	}
@@ -45,6 +50,7 @@ func NewCircuitBreaker(failureThreshold int, recoveryTimeout time.Duration) *Cir
 		state:            stateClosed,
 		failureThreshold: failureThreshold,
 		recoveryTimeout:  recoveryTimeout,
+		now:              now,
 	}
 }
 
@@ -58,7 +64,7 @@ func (cb *CircuitBreaker) Allow() error {
 	case stateClosed:
 		return nil
 	case stateOpen:
-		if time.Since(cb.openedAt) >= cb.recoveryTimeout {
+		if cb.now().Sub(cb.openedAt) >= cb.recoveryTimeout {
 			cb.state = stateHalfOpen
 			return nil
 		}
@@ -86,6 +92,6 @@ func (cb *CircuitBreaker) RecordFailure() {
 	cb.failures++
 	if cb.failures >= cb.failureThreshold {
 		cb.state = stateOpen
-		cb.openedAt = time.Now()
+		cb.openedAt = cb.now()
 	}
 }

--- a/api-go/internal/resilience/circuitbreaker_test.go
+++ b/api-go/internal/resilience/circuitbreaker_test.go
@@ -5,6 +5,22 @@ import (
 	"time"
 )
 
+type fakeClock struct {
+	t time.Time
+}
+
+func newFakeClock() *fakeClock {
+	return &fakeClock{t: time.Date(2026, 4, 22, 0, 0, 0, 0, time.UTC)}
+}
+
+func (c *fakeClock) Now() time.Time {
+	return c.t
+}
+
+func (c *fakeClock) Advance(d time.Duration) {
+	c.t = c.t.Add(d)
+}
+
 func TestCircuitBreakerStartsClosed(t *testing.T) {
 	cb := NewCircuitBreaker(3, 100*time.Millisecond)
 	if err := cb.Allow(); err != nil {
@@ -51,7 +67,8 @@ func TestCircuitBreakerResetOnSuccess(t *testing.T) {
 }
 
 func TestCircuitBreakerHalfOpen(t *testing.T) {
-	cb := NewCircuitBreaker(2, 50*time.Millisecond)
+	clock := newFakeClock()
+	cb := newCircuitBreakerWithClock(2, 50*time.Millisecond, clock.Now)
 
 	cb.RecordFailure()
 	cb.RecordFailure()
@@ -61,8 +78,7 @@ func TestCircuitBreakerHalfOpen(t *testing.T) {
 		t.Fatalf("expected ErrCircuitOpen, got %v", err)
 	}
 
-	// Wait for recovery timeout.
-	time.Sleep(60 * time.Millisecond)
+	clock.Advance(50 * time.Millisecond)
 
 	// First call should be allowed (half-open probe).
 	if err := cb.Allow(); err != nil {
@@ -76,12 +92,13 @@ func TestCircuitBreakerHalfOpen(t *testing.T) {
 }
 
 func TestCircuitBreakerClosesAfterHalfOpenSuccess(t *testing.T) {
-	cb := NewCircuitBreaker(2, 50*time.Millisecond)
+	clock := newFakeClock()
+	cb := newCircuitBreakerWithClock(2, 50*time.Millisecond, clock.Now)
 
 	cb.RecordFailure()
 	cb.RecordFailure()
 
-	time.Sleep(60 * time.Millisecond)
+	clock.Advance(50 * time.Millisecond)
 
 	// Half-open probe.
 	_ = cb.Allow()
@@ -94,12 +111,13 @@ func TestCircuitBreakerClosesAfterHalfOpenSuccess(t *testing.T) {
 }
 
 func TestCircuitBreakerReopensAfterHalfOpenFailure(t *testing.T) {
-	cb := NewCircuitBreaker(2, 50*time.Millisecond)
+	clock := newFakeClock()
+	cb := newCircuitBreakerWithClock(2, 50*time.Millisecond, clock.Now)
 
 	cb.RecordFailure()
 	cb.RecordFailure()
 
-	time.Sleep(60 * time.Millisecond)
+	clock.Advance(50 * time.Millisecond)
 
 	// Half-open probe.
 	_ = cb.Allow()

--- a/api-go/internal/resilience/wrapper_test.go
+++ b/api-go/internal/resilience/wrapper_test.go
@@ -138,6 +138,8 @@ func TestWrapperCircuitBreakerRecovers(t *testing.T) {
 		MaxRetries:       0,
 	}
 	w := Wrap(inner, cfg)
+	clock := newFakeClock()
+	w.(*wrapper).cb = newCircuitBreakerWithClock(cfg.FailureThreshold, cfg.RecoveryTimeout, clock.Now)
 
 	ctx := context.Background()
 	for i := 0; i < 2; i++ {
@@ -155,7 +157,7 @@ func TestWrapperCircuitBreakerRecovers(t *testing.T) {
 
 	// Fix the backend.
 	inner.uploadErr = nil
-	time.Sleep(60 * time.Millisecond)
+	clock.Advance(50 * time.Millisecond)
 
 	// Should succeed (half-open probe).
 	name, err := w.Upload(ctx, "ok.txt", strings.NewReader("data"))


### PR DESCRIPTION
## Summary
- add package-private clock injection for circuit breaker and rate limiter time checks
- update resilience and ratelimit unit tests to advance fake clocks instead of sleeping
- keep public constructors unchanged for existing callers

## Validation
- go test ./internal/resilience ./internal/ratelimit
- rg -n "time\.Sleep|Sleep\(" api-go/internal/resilience api-go/internal/ratelimit