### PR TITLE
THE-725 Harden Woodpecker smoke image pulls

### DIFF
--- a/.woodpecker/smoke.yml
+++ b/.woodpecker/smoke.yml
@@ -32,6 +32,8 @@ steps:
       MONGO_IMAGE: public.ecr.aws/docker/library/mongo:7.0.32-rc2-jammy
       MINIO_IMAGE: quay.io/minio/minio:RELEASE.2025-01-20T14-49-07Z
       MINIO_MC_IMAGE: quay.io/minio/mc:latest
+      MINIO_IMAGE_FALLBACK: minio/minio:RELEASE.2025-01-20T14-49-07Z
+      MINIO_MC_IMAGE_FALLBACK: minio/mc:latest
     commands:
       - apk add --no-cache aws-cli curl docker-cli docker-cli-compose jq
       - chmod +x scripts/woodpecker-smoke.sh

--- a/api-go/Dockerfile
+++ b/api-go/Dockerfile
@@ -1,4 +1,3 @@
-# syntax=docker/dockerfile:1
 ARG GO_IMAGE=golang:1.24
 FROM ${GO_IMAGE} AS builder
 WORKDIR /app

--- a/scripts/woodpecker-smoke.sh
+++ b/scripts/woodpecker-smoke.sh
@@ -26,6 +26,39 @@ fail() {
 	exit 1
 }
 
+pull_image() {
+	image="$1"
+	for i in $(seq 1 4); do
+		if docker pull "$image"; then
+			return 0
+		fi
+		sleep $((i * 10))
+	done
+	return 1
+}
+
+pull_image_or_fallback() {
+	target_var="$1"
+	primary="$2"
+	fallback="$3"
+
+	if pull_image "$primary"; then
+		return 0
+	fi
+
+	if [ -n "$fallback" ] && [ "$fallback" != "$primary" ] && pull_image "$fallback"; then
+		case "$target_var" in
+			MINIO_IMAGE | MINIO_MC_IMAGE) ;;
+			*) fail "Invalid fallback target $target_var" ;;
+		esac
+		eval "$target_var=\$fallback"
+		export "$target_var"
+		return 0
+	fi
+
+	fail "Unable to pull $primary"
+}
+
 cleanup() {
 	status=$?
 	if [ "$status" -ne 0 ]; then
@@ -56,17 +89,13 @@ step "Build CLI"
 pass "sfree CLI builds"
 
 step "Start Compose stack"
-for image in "$GO_IMAGE" "$NODE_IMAGE" "$NGINX_IMAGE" "$MONGO_IMAGE" "$MINIO_IMAGE" "$MINIO_MC_IMAGE"; do
-	for i in $(seq 1 4); do
-		if docker pull "$image"; then
-			break
-		fi
-		if [ "$i" -eq 4 ]; then
-			fail "Unable to pull $image"
-		fi
-		sleep $((i * 10))
-	done
+for image in "$GO_IMAGE" "$NODE_IMAGE" "$NGINX_IMAGE" "$MONGO_IMAGE"; do
+	if ! pull_image "$image"; then
+		fail "Unable to pull $image"
+	fi
 done
+pull_image_or_fallback MINIO_IMAGE "$MINIO_IMAGE" "${MINIO_IMAGE_FALLBACK:-minio/minio:RELEASE.2025-01-20T14-49-07Z}"
+pull_image_or_fallback MINIO_MC_IMAGE "$MINIO_MC_IMAGE" "${MINIO_MC_IMAGE_FALLBACK:-minio/mc:latest}"
 compose up -d --pull never --build
 pass "Woodpecker starts the root Compose stack"
 


### PR DESCRIPTION
## Summary
- Remove the `api-go/Dockerfile` frontend syntax directive so smoke builds no longer have to resolve `docker.io/docker/dockerfile:1` during Compose startup.
- Add retryable MinIO image fallback support in `scripts/woodpecker-smoke.sh`.
- Configure Woodpecker smoke fallbacks from Quay MinIO images to Docker Hub MinIO images when Quay TLS handshakes fail.

## Validation
- Not run locally: Docker, Compose, smoke, and CPU-heavy validation are reserved for Woodpecker on this constrained machine.

Blocks/addresses THE-725.