### PR TITLE
THE-731 avoid decrypting source keys in list endpoint

### DIFF
--- a/api-go/internal/handlers/source.go
+++ b/api-go/internal/handlers/source.go
@@ -241,7 +241,7 @@ func ListSources(repo *repository.SourceRepository) gin.HandlerFunc {
 		if !ok {
 			return
 		}
-		sources, err := repo.ListByUser(c.Request.Context(), userID)
+		sources, err := repo.ListMetadataByUser(c.Request.Context(), userID)
 		if err != nil {
 			slog.ErrorContext(ctx, "list sources: failed to list", slog.String("error", err.Error()))
 			c.Status(http.StatusInternalServerError)

--- a/api-go/internal/repository/source.go
+++ b/api-go/internal/repository/source.go
@@ -9,6 +9,7 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
 type SourceType string
@@ -147,6 +148,26 @@ func (r *SourceRepository) ListByUser(ctx context.Context, userID primitive.Obje
 		}
 		s.Key, err = r.decryptKey(s.Key)
 		if err != nil {
+			return nil, err
+		}
+		sources = append(sources, s)
+	}
+	if err := cursor.Err(); err != nil {
+		return nil, err
+	}
+	return sources, nil
+}
+
+func (r *SourceRepository) ListMetadataByUser(ctx context.Context, userID primitive.ObjectID) ([]Source, error) {
+	cursor, err := r.coll.Find(ctx, bson.M{"user_id": userID}, options.Find().SetProjection(bson.M{"key": 0}))
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = cursor.Close(ctx) }()
+	var sources []Source
+	for cursor.Next(ctx) {
+		var s Source
+		if err := cursor.Decode(&s); err != nil {
 			return nil, err
 		}
 		sources = append(sources, s)

--- a/api-go/internal/repository/source_test.go
+++ b/api-go/internal/repository/source_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/example/sfree/api-go/internal/config"
 	"github.com/example/sfree/api-go/internal/db"
+	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
@@ -46,5 +47,56 @@ func TestCreateSource(t *testing.T) {
 	}
 	if stored.Name != src.Name || stored.Key != src.Key || stored.Type != src.Type {
 		t.Fatalf("unexpected stored source: %+v", stored)
+	}
+}
+
+func TestListMetadataByUserDoesNotDecryptKeys(t *testing.T) {
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	mongoConn, err := db.Connect(context.Background(), cfg.Mongo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo, err := NewSourceRepository(mongoConn.DB, "test-secret")
+	if err != nil {
+		t.Fatal(err)
+	}
+	userID := primitive.NewObjectID()
+	sourceID := primitive.NewObjectID()
+	_, err = repo.coll.InsertOne(context.Background(), Source{
+		ID:        sourceID,
+		UserID:    userID,
+		Type:      SourceTypeS3,
+		Name:      "metadata-only",
+		Key:       "not-valid-ciphertext",
+		CreatedAt: time.Now().UTC(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_, _ = repo.coll.DeleteMany(context.Background(), bson.M{"user_id": userID})
+	})
+
+	sources, err := repo.ListMetadataByUser(context.Background(), userID)
+	if err != nil {
+		t.Fatalf("metadata listing should not decrypt keys: %v", err)
+	}
+	if len(sources) != 1 {
+		t.Fatalf("expected one source, got %d", len(sources))
+	}
+	if sources[0].ID != sourceID || sources[0].Name != "metadata-only" || sources[0].Type != SourceTypeS3 {
+		t.Fatalf("unexpected source metadata: %+v", sources[0])
+	}
+	if sources[0].Key != "" {
+		t.Fatalf("expected projected key to be empty, got %q", sources[0].Key)
+	}
+	if _, err := repo.GetByID(context.Background(), sourceID); err == nil {
+		t.Fatalf("expected GetByID to decrypt key material")
+	}
+	if _, err := repo.ListByIDs(context.Background(), []primitive.ObjectID{sourceID}); err == nil {
+		t.Fatalf("expected ListByIDs to decrypt key material")
 	}
 }


### PR DESCRIPTION
## Summary
- add a metadata-only source repository listing path that projects out provider keys
- route GET /api/v1/sources through the metadata-only listing
- add focused repository coverage showing malformed encrypted key material does not break metadata listing while credential-reading paths still decrypt

## Validation
- gofmt api-go/internal/repository/source.go api-go/internal/repository/source_test.go api-go/internal/handlers/source.go
- git diff --check

Full backend validation is left to Woodpecker per task guidance.