### PR TITLE
THE-730 reorder bucket deletion cleanup

### DIFF
--- a/api-go/internal/manager/s3_object.go
+++ b/api-go/internal/manager/s3_object.go
@@ -299,9 +299,6 @@ func (s *ObjectService) DeleteBucketContents(ctx context.Context, bucketID primi
 	}
 
 	chunks := bucketCleanupChunks(files, uploads)
-	if err := s.deleteBucketChunksIfUnreferenced(ctx, bucketID, chunks); err != nil {
-		return DeleteBucketContentsResult{}, err
-	}
 	if err := s.files.DeleteByBucket(ctx, bucketID); err != nil {
 		return DeleteBucketContentsResult{}, err
 	}
@@ -309,6 +306,9 @@ func (s *ObjectService) DeleteBucketContents(ctx context.Context, bucketID primi
 		if err := s.multipart.DeleteByBucket(ctx, bucketID); err != nil {
 			return DeleteBucketContentsResult{}, err
 		}
+	}
+	if err := s.deleteBucketChunksIfUnreferenced(ctx, bucketID, chunks); err != nil {
+		return DeleteBucketContentsResult{}, err
 	}
 	return DeleteBucketContentsResult{
 		FilesDeleted:            len(files),

--- a/api-go/internal/manager/s3_object_test.go
+++ b/api-go/internal/manager/s3_object_test.go
@@ -32,6 +32,7 @@ type fakeObjectFiles struct {
 	replaceErr error
 	deleteErr  error
 	listErr    error
+	events     *[]string
 }
 
 func newFakeObjectFiles(files ...repository.File) *fakeObjectFiles {
@@ -107,6 +108,9 @@ func (f *fakeObjectFiles) ListByBucket(_ context.Context, bucketID primitive.Obj
 }
 
 func (f *fakeObjectFiles) DeleteByBucket(_ context.Context, bucketID primitive.ObjectID) error {
+	if f.events != nil {
+		*f.events = append(*f.events, "delete file metadata")
+	}
 	if f.deleteErr != nil {
 		return f.deleteErr
 	}
@@ -254,6 +258,9 @@ func (f *fakeMultipartUploads) CountByPartChunkExcludingBucket(_ context.Context
 }
 
 func (f *fakeMultipartUploads) DeleteByBucket(_ context.Context, bucketID primitive.ObjectID) error {
+	if f.events != nil {
+		*f.events = append(*f.events, "delete multipart metadata")
+	}
 	if f.delErr != nil {
 		return f.delErr
 	}
@@ -588,6 +595,7 @@ func TestObjectServiceDeleteBucketContentsRemovesMetadataAndUnreferencedChunks(t
 	bucketID := primitive.NewObjectID()
 	otherBucketID := primitive.NewObjectID()
 	sourceID := primitive.NewObjectID()
+	var events []string
 	fileOnlyChunk := repository.FileChunk{SourceID: sourceID, Name: "file-only", Size: 3}
 	fileSharedChunk := repository.FileChunk{SourceID: sourceID, Name: "file-shared", Size: 5}
 	partOnlyChunk := repository.FileChunk{SourceID: sourceID, Name: "part-only", Size: 7}
@@ -596,6 +604,7 @@ func TestObjectServiceDeleteBucketContentsRemovesMetadataAndUnreferencedChunks(t
 		repository.File{ID: primitive.NewObjectID(), BucketID: bucketID, Name: "object.txt", Chunks: []repository.FileChunk{fileOnlyChunk, fileSharedChunk}},
 		repository.File{ID: primitive.NewObjectID(), BucketID: otherBucketID, Name: "survivor.txt", Chunks: []repository.FileChunk{fileSharedChunk}},
 	)
+	files.events = &events
 	uploads := &fakeMultipartUploads{uploads: map[string]repository.MultipartUpload{
 		"delete-upload": {
 			BucketID:  bucketID,
@@ -614,9 +623,17 @@ func TestObjectServiceDeleteBucketContentsRemovesMetadataAndUnreferencedChunks(t
 			},
 		},
 	}}
+	uploads.events = &events
 	var deleted []repository.FileChunk
 	svc := testObjectService(files, &deleted)
 	svc.multipart = uploads
+	svc.deleteChunks = func(_ context.Context, chunks []repository.FileChunk) error {
+		deleted = append(deleted, chunks...)
+		for _, chunk := range chunks {
+			events = append(events, "delete chunk "+chunk.Name)
+		}
+		return nil
+	}
 
 	result, err := svc.DeleteBucketContents(context.Background(), bucketID)
 	if err != nil {
@@ -647,20 +664,28 @@ func TestObjectServiceDeleteBucketContentsRemovesMetadataAndUnreferencedChunks(t
 	if deletedNames[fileSharedChunk.Name] || deletedNames[partSharedChunk.Name] {
 		t.Fatalf("expected shared chunks to remain, got %#v", deleted)
 	}
+	if len(events) < 2 || events[0] != "delete file metadata" || events[1] != "delete multipart metadata" {
+		t.Fatalf("expected metadata deletion before chunk cleanup, got %#v", events)
+	}
 }
 
 func TestObjectServiceDeleteBucketContentsReturnsChunkCleanupError(t *testing.T) {
 	bucketID := primitive.NewObjectID()
 	cleanupErr := errors.New("delete chunks failed")
+	var events []string
 	files := newFakeObjectFiles(repository.File{
 		ID:       primitive.NewObjectID(),
 		BucketID: bucketID,
 		Name:     "object.txt",
 		Chunks:   []repository.FileChunk{{SourceID: primitive.NewObjectID(), Name: "delete-me", Size: 3}},
 	})
+	files.events = &events
 	var deleted []repository.FileChunk
 	svc := testObjectService(files, &deleted)
-	svc.deleteChunks = func(context.Context, []repository.FileChunk) error {
+	svc.deleteChunks = func(_ context.Context, chunks []repository.FileChunk) error {
+		for _, chunk := range chunks {
+			events = append(events, "delete chunk "+chunk.Name)
+		}
 		return cleanupErr
 	}
 
@@ -668,8 +693,11 @@ func TestObjectServiceDeleteBucketContentsReturnsChunkCleanupError(t *testing.T)
 	if !errors.Is(err, cleanupErr) {
 		t.Fatalf("expected cleanup error, got %v", err)
 	}
-	if _, err := files.GetByName(context.Background(), bucketID, "object.txt"); err != nil {
-		t.Fatalf("expected file metadata to remain after cleanup failure, got %v", err)
+	if _, err := files.GetByName(context.Background(), bucketID, "object.txt"); !errors.Is(err, mongo.ErrNoDocuments) {
+		t.Fatalf("expected file metadata removed before cleanup failure, got %v", err)
+	}
+	if len(events) != 2 || events[0] != "delete file metadata" || events[1] != "delete chunk delete-me" {
+		t.Fatalf("expected chunk cleanup after metadata deletion, got %#v", events)
 	}
 }
 
@@ -690,8 +718,8 @@ func TestObjectServiceDeleteBucketContentsReturnsFileMetadataDeleteError(t *test
 	if !errors.Is(err, deleteErr) {
 		t.Fatalf("expected file metadata delete error, got %v", err)
 	}
-	if len(deleted) != 1 || deleted[0].Name != "delete-me" {
-		t.Fatalf("expected chunk cleanup before metadata delete failure, got %#v", deleted)
+	if len(deleted) != 0 {
+		t.Fatalf("expected no chunk cleanup after metadata delete failure, got %#v", deleted)
 	}
 	if _, err := files.GetByName(context.Background(), bucketID, "object.txt"); err != nil {
 		t.Fatalf("expected file metadata to remain after delete failure, got %v", err)
@@ -724,6 +752,9 @@ func TestObjectServiceDeleteBucketContentsReturnsMultipartMetadataDeleteError(t 
 	_, err := svc.DeleteBucketContents(context.Background(), bucketID)
 	if !errors.Is(err, deleteErr) {
 		t.Fatalf("expected multipart metadata delete error, got %v", err)
+	}
+	if len(deleted) != 0 {
+		t.Fatalf("expected no chunk cleanup after multipart metadata delete failure, got %#v", deleted)
 	}
 	if _, err := files.GetByName(context.Background(), bucketID, "object.txt"); !errors.Is(err, mongo.ErrNoDocuments) {
 		t.Fatalf("expected file metadata deleted before multipart delete failure, got %v", err)


### PR DESCRIPTION
## Summary

- Delete bucket file and multipart metadata before remote chunk cleanup.
- Keep cleanup candidate collection before metadata deletion so unreferenced chunks can still be removed after metadata is gone.
- Update focused manager tests so metadata delete failures prove chunk cleanup is not attempted.

## Validation

- `gofmt -w api-go/internal/manager/s3_object.go api-go/internal/manager/s3_object_test.go`
- `git diff --check`
- Full backend validation intentionally left to Woodpecker per task/resource policy.