### PR TITLE
THE-739 Surface create bucket source-load failures

### DIFF
--- a/webui/e2e/buckets.spec.ts
+++ b/webui/e2e/buckets.spec.ts
@@ -75,6 +75,36 @@ test.describe("Bucket creation flow", () => {
     await expect(dialog.getByText("My Drive", { exact: true })).toBeVisible();
   });
 
+  test("Add Bucket dialog surfaces source loading failures and retries", async ({ page }) => {
+    await injectAuth(page);
+    await mockGet(page, "/buckets", []);
+    let sourceRequests = 0;
+    await page.route("**/api/v1/sources", async (route) => {
+      if (route.request().method() !== "GET") {
+        await route.continue();
+        return;
+      }
+      sourceRequests += 1;
+      if (sourceRequests === 1) {
+        await route.fulfill({ status: 500, json: { error: "Source service unavailable" } });
+        return;
+      }
+      await route.fulfill({ status: 200, json: [MOCK_SOURCE] });
+    });
+
+    await page.goto("/buckets");
+    const dialog = page.getByRole("dialog");
+
+    await page.getByRole("button", { name: "Add Bucket" }).first().click();
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByText("Sources could not be loaded. Retry to try again.")).toBeVisible();
+    await expect(dialog.getByText("Source service unavailable")).toBeVisible();
+    await expect(dialog.getByText("Create at least one source before creating a bucket.")).not.toBeVisible();
+
+    await dialog.getByRole("button", { name: "Retry" }).click();
+    await expect(dialog.getByText("My Drive", { exact: true })).toBeVisible();
+  });
+
   test("creating a bucket shows S3 credentials", async ({ page }) => {
     await injectAuth(page);
     await mockGet(page, "/buckets", []);

--- a/webui/src/features/bucket/ui/create-bucket-dialog.tsx
+++ b/webui/src/features/bucket/ui/create-bucket-dialog.tsx
@@ -1,6 +1,6 @@
 import {Button, Checkbox, CheckboxGroup, Input, Modal, ModalBody, ModalContent, ModalFooter, ModalHeader, Snippet} from "@heroui/react";
 import {addToast} from "@heroui/toast";
-import {useEffect, useMemo, useState} from "react";
+import {useCallback, useEffect, useMemo, useRef, useState} from "react";
 import {createBucket} from "../../../shared/api/buckets";
 import {listSources} from "../../../shared/api/sources";
 import type {Source} from "../../../shared/api/sources";
@@ -15,50 +15,59 @@ export function CreateBucketDialog({isOpen, onOpenChange, onCreated}: Props) {
   const [creds, setCreds] = useState<{accessKey: string; accessSecret: string} | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [isSourcesLoading, setIsSourcesLoading] = useState(false);
+  const [sourceLoadError, setSourceLoadError] = useState<string | null>(null);
+  const sourceLoadRequestId = useRef(0);
+
+  const loadSources = useCallback(async () => {
+    const requestId = sourceLoadRequestId.current + 1;
+    sourceLoadRequestId.current = requestId;
+    setIsSourcesLoading(true);
+    setSourceLoadError(null);
+    try {
+      const nextSources = await listSources();
+      if (sourceLoadRequestId.current !== requestId) return;
+      const nextSourceIds = new Set(nextSources.map((source) => source.id));
+      setSources(nextSources);
+      setSelectedSourceIds((current) => current.filter((id) => nextSourceIds.has(id)));
+    } catch (err) {
+      if (sourceLoadRequestId.current !== requestId) return;
+      setSources([]);
+      setSelectedSourceIds([]);
+      setSourceLoadError(err instanceof Error ? err.message : "Failed to load sources");
+      showErrorToast(err);
+    } finally {
+      if (sourceLoadRequestId.current === requestId) {
+        setIsSourcesLoading(false);
+      }
+    }
+  }, []);
 
   useEffect(() => {
     if (!isOpen || creds) return;
-
-    let isActive = true;
-
-    async function loadSources() {
-      setIsSourcesLoading(true);
-      try {
-        const nextSources = await listSources();
-        if (!isActive) return;
-        setSources(nextSources);
-      } finally {
-        if (isActive) {
-          setIsSourcesLoading(false);
-        }
-      }
-    }
-
-    loadSources();
-
-    return () => {
-      isActive = false;
-    };
-  }, [creds, isOpen]);
+    void loadSources();
+  }, [creds, isOpen, loadSources]);
 
   const hasSources = sources.length > 0;
   const canCreate = key.trim() !== "" && selectedSourceIds.length > 0;
   const helperText = useMemo(() => {
     if (isSourcesLoading) return "Loading sources...";
+    if (sourceLoadError) return "Sources could not be loaded. Retry to try again.";
     if (!hasSources) return "Create at least one source before creating a bucket.";
     return "Choose which sources this bucket is allowed to use for uploads.";
-  }, [hasSources, isSourcesLoading]);
+  }, [hasSources, isSourcesLoading, sourceLoadError]);
 
   return (
     <Modal
       isOpen={isOpen}
       onOpenChange={(open) => {
         if (!open) {
+          sourceLoadRequestId.current += 1;
           setKey("");
           setSources([]);
           setSelectedSourceIds([]);
           setCreds(null);
           setIsSourcesLoading(false);
+          setSourceLoadError(null);
         }
         onOpenChange(open);
       }}
@@ -81,7 +90,15 @@ export function CreateBucketDialog({isOpen, onOpenChange, onCreated}: Props) {
                   <Input label="Key" value={key} onChange={(e) => setKey(e.target.value)} />
                   <div className="flex flex-col gap-2">
                     <p className="text-sm font-medium">Allowed sources</p>
-                    <p className="text-sm text-default-500">{helperText}</p>
+                    <p className={`text-sm ${sourceLoadError ? "text-danger" : "text-default-500"}`}>{helperText}</p>
+                    {sourceLoadError ? (
+                      <div className="flex flex-col items-start gap-2">
+                        <p className="text-sm text-danger">{sourceLoadError}</p>
+                        <Button size="sm" variant="flat" color="danger" isLoading={isSourcesLoading} onPress={() => void loadSources()}>
+                          Retry
+                        </Button>
+                      </div>
+                    ) : null}
                     {hasSources ? (
                       <CheckboxGroup
                         value={selectedSourceIds}


### PR DESCRIPTION
## Summary
- catch source-list failures in the create bucket dialog
- show inline failure text and a Retry action instead of the empty-sources helper
- add a focused bucket E2E assertion for source-load failure and retry recovery

## Validation
- `git diff --check`
- Not run locally per task constraints: Playwright, Docker, package build, and other CPU-heavy validation. Woodpecker should run frontend validation.