### PR TITLE
THE-738 thread source client resilience through factories

### DIFF
--- a/api-go/cmd/server/main.go
+++ b/api-go/cmd/server/main.go
@@ -11,15 +11,11 @@ import (
 	"log/slog"
 	"os"
 
-	"time"
-
 	"github.com/example/sfree/api-go/internal/app"
 	"github.com/example/sfree/api-go/internal/config"
 	"github.com/example/sfree/api-go/internal/db"
 	_ "github.com/example/sfree/api-go/internal/docs"
-	"github.com/example/sfree/api-go/internal/manager"
 	"github.com/example/sfree/api-go/internal/observability"
-	"github.com/example/sfree/api-go/internal/resilience"
 	"github.com/example/sfree/api-go/internal/telemetry"
 )
 
@@ -43,28 +39,6 @@ func main() {
 			slog.Error("failed to shutdown tracer", slog.String("error", err.Error()))
 		}
 	}()
-
-	// Apply source client resilience settings from config.
-	rcfg := resilience.DefaultWrapperConfig()
-	if cfg.SourceClient.TimeoutSeconds > 0 {
-		rcfg.Timeout = time.Duration(cfg.SourceClient.TimeoutSeconds) * time.Second
-	}
-	if cfg.SourceClient.FailureThreshold > 0 {
-		rcfg.FailureThreshold = cfg.SourceClient.FailureThreshold
-	}
-	if cfg.SourceClient.RecoverySeconds > 0 {
-		rcfg.RecoveryTimeout = time.Duration(cfg.SourceClient.RecoverySeconds) * time.Second
-	}
-	if cfg.SourceClient.MaxRetries > 0 {
-		rcfg.MaxRetries = cfg.SourceClient.MaxRetries
-	}
-	if cfg.SourceClient.RetryBaseDelayMs > 0 {
-		rcfg.RetryBaseDelay = time.Duration(cfg.SourceClient.RetryBaseDelayMs) * time.Millisecond
-	}
-	if cfg.SourceClient.RetryMaxDelayMs > 0 {
-		rcfg.RetryMaxDelay = time.Duration(cfg.SourceClient.RetryMaxDelayMs) * time.Millisecond
-	}
-	manager.ResilienceConfig = rcfg
 
 	mongoConn, err := db.Connect(ctx, cfg.Mongo)
 	if err != nil {

--- a/api-go/internal/app/router_dependencies.go
+++ b/api-go/internal/app/router_dependencies.go
@@ -2,11 +2,14 @@ package app
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/example/sfree/api-go/internal/config"
 	"github.com/example/sfree/api-go/internal/db"
 	"github.com/example/sfree/api-go/internal/handlers"
+	"github.com/example/sfree/api-go/internal/manager"
 	"github.com/example/sfree/api-go/internal/repository"
+	"github.com/example/sfree/api-go/internal/resilience"
 	"github.com/gin-gonic/gin"
 )
 
@@ -29,10 +32,11 @@ type routerDependencies struct {
 	shareLinkRepo *repository.ShareLinkRepository
 	mpRepo        *repository.MultipartUploadRepository
 	grantRepo     *repository.BucketGrantRepository
+	sourceFactory manager.SourceClientFactory
 }
 
 func newRouterDependencies(m *db.Mongo, cfg *config.Config) (*routerDependencies, error) {
-	deps := &routerDependencies{}
+	deps := &routerDependencies{sourceFactory: routerSourceClientFactory(cfg)}
 	if m == nil {
 		return deps, nil
 	}
@@ -94,4 +98,34 @@ func routerUploadChunkSize(cfg *config.Config) int {
 		return 0
 	}
 	return cfg.Upload.ChunkSize
+}
+
+func routerSourceClientFactory(cfg *config.Config) manager.SourceClientFactory {
+	return manager.NewSourceClientFactory(routerSourceClientResilienceConfig(cfg))
+}
+
+func routerSourceClientResilienceConfig(cfg *config.Config) resilience.WrapperConfig {
+	rcfg := resilience.DefaultWrapperConfig()
+	if cfg == nil {
+		return rcfg
+	}
+	if cfg.SourceClient.TimeoutSeconds > 0 {
+		rcfg.Timeout = time.Duration(cfg.SourceClient.TimeoutSeconds) * time.Second
+	}
+	if cfg.SourceClient.FailureThreshold > 0 {
+		rcfg.FailureThreshold = cfg.SourceClient.FailureThreshold
+	}
+	if cfg.SourceClient.RecoverySeconds > 0 {
+		rcfg.RecoveryTimeout = time.Duration(cfg.SourceClient.RecoverySeconds) * time.Second
+	}
+	if cfg.SourceClient.MaxRetries > 0 {
+		rcfg.MaxRetries = cfg.SourceClient.MaxRetries
+	}
+	if cfg.SourceClient.RetryBaseDelayMs > 0 {
+		rcfg.RetryBaseDelay = time.Duration(cfg.SourceClient.RetryBaseDelayMs) * time.Millisecond
+	}
+	if cfg.SourceClient.RetryMaxDelayMs > 0 {
+		rcfg.RetryMaxDelay = time.Duration(cfg.SourceClient.RetryMaxDelayMs) * time.Millisecond
+	}
+	return rcfg
 }

--- a/api-go/internal/app/router_routes.go
+++ b/api-go/internal/app/router_routes.go
@@ -53,7 +53,7 @@ func registerBucketRoutes(router *gin.Engine, cfg *config.Config, deps *routerDe
 	}
 	router.POST("/api/v1/buckets", deps.auth, handlers.CreateBucket(deps.bucketRepo, deps.sourceRepo, routerAccessSecret(cfg)))
 	router.GET("/api/v1/buckets", deps.auth, handlers.ListBuckets(deps.bucketRepo, deps.grantRepo))
-	router.DELETE("/api/v1/buckets/:id", deps.auth, handlers.DeleteBucket(deps.bucketRepo, deps.sourceRepo, deps.fileRepo, deps.mpRepo, deps.grantRepo))
+	router.DELETE("/api/v1/buckets/:id", deps.auth, handlers.DeleteBucketWithFactory(deps.bucketRepo, deps.sourceRepo, deps.fileRepo, deps.mpRepo, deps.grantRepo, deps.sourceFactory))
 	router.PATCH("/api/v1/buckets/:id/distribution", deps.auth, handlers.UpdateBucketDistribution(deps.bucketRepo, deps.grantRepo))
 
 	registerBucketGrantRoutes(router, deps)
@@ -74,10 +74,10 @@ func registerBucketFileRoutes(router *gin.Engine, cfg *config.Config, deps *rout
 	if deps.sourceRepo == nil || deps.fileRepo == nil {
 		return
 	}
-	router.POST("/api/v1/buckets/:id/upload", deps.auth, handlers.UploadFile(deps.bucketRepo, deps.sourceRepo, deps.fileRepo, deps.grantRepo, routerUploadChunkSize(cfg)))
+	router.POST("/api/v1/buckets/:id/upload", deps.auth, handlers.UploadFileWithFactory(deps.bucketRepo, deps.sourceRepo, deps.fileRepo, deps.grantRepo, routerUploadChunkSize(cfg), deps.sourceFactory))
 	router.GET("/api/v1/buckets/:id/files", deps.auth, handlers.ListFiles(deps.bucketRepo, deps.fileRepo, deps.grantRepo))
-	router.GET("/api/v1/buckets/:id/files/:file_id/download", deps.auth, handlers.DownloadFile(deps.bucketRepo, deps.sourceRepo, deps.fileRepo, deps.grantRepo))
-	router.DELETE("/api/v1/buckets/:id/files/:file_id", deps.auth, handlers.DeleteFile(deps.bucketRepo, deps.sourceRepo, deps.fileRepo, deps.grantRepo))
+	router.GET("/api/v1/buckets/:id/files/:file_id/download", deps.auth, handlers.DownloadFileWithFactory(deps.bucketRepo, deps.sourceRepo, deps.fileRepo, deps.grantRepo, deps.sourceFactory))
+	router.DELETE("/api/v1/buckets/:id/files/:file_id", deps.auth, handlers.DeleteFileWithFactory(deps.bucketRepo, deps.sourceRepo, deps.fileRepo, deps.grantRepo, deps.sourceFactory))
 	if deps.shareLinkRepo == nil {
 		return
 	}
@@ -94,9 +94,9 @@ func registerSourceRoutes(router *gin.Engine, deps *routerDependencies) {
 	router.POST("/api/v1/sources/telegram", deps.auth, handlers.CreateTelegramSource(deps.sourceRepo))
 	router.POST("/api/v1/sources/s3", deps.auth, handlers.CreateS3Source(deps.sourceRepo))
 	router.GET("/api/v1/sources", deps.auth, handlers.ListSources(deps.sourceRepo))
-	router.GET("/api/v1/sources/:id/health", deps.auth, handlers.GetSourceHealth(deps.sourceRepo))
-	router.GET("/api/v1/sources/:id/info", deps.auth, handlers.GetSourceInfo(deps.sourceRepo))
-	router.GET("/api/v1/sources/:id/files/:file_id/download", deps.auth, handlers.DownloadSourceFile(deps.sourceRepo))
+	router.GET("/api/v1/sources/:id/health", deps.auth, handlers.GetSourceHealthWithFactory(deps.sourceRepo, deps.sourceFactory))
+	router.GET("/api/v1/sources/:id/info", deps.auth, handlers.GetSourceInfoWithFactory(deps.sourceRepo, deps.sourceFactory))
+	router.GET("/api/v1/sources/:id/files/:file_id/download", deps.auth, handlers.DownloadSourceFileWithFactory(deps.sourceRepo, deps.sourceFactory))
 	router.DELETE("/api/v1/sources/:id", deps.auth, handlers.DeleteSource(deps.sourceRepo, deps.bucketRepo))
 }
 
@@ -104,7 +104,7 @@ func registerPublicShareRoutes(router *gin.Engine, deps *routerDependencies) {
 	if deps.shareLinkRepo == nil || deps.bucketRepo == nil || deps.sourceRepo == nil || deps.fileRepo == nil {
 		return
 	}
-	router.GET("/share/:token", handlers.GetSharedFile(deps.shareLinkRepo, deps.bucketRepo, deps.sourceRepo, deps.fileRepo))
+	router.GET("/share/:token", handlers.GetSharedFileWithFactory(deps.shareLinkRepo, deps.bucketRepo, deps.sourceRepo, deps.fileRepo, deps.sourceFactory))
 }
 
 func registerDocsMetricsRoutes(router *gin.Engine) {
@@ -125,10 +125,10 @@ func registerS3Routes(router *gin.Engine, cfg *config.Config, deps *routerDepend
 	}
 	s3Auth := handlers.AWS4Auth(deps.bucketRepo, routerAccessSecret(cfg))
 	router.HEAD("/api/s3/:bucket/*object", s3Auth, handlers.HeadObject(deps.bucketRepo, deps.fileRepo))
-	router.GET("/api/s3/:bucket/*object", s3Auth, handlers.GetObjectOrParts(deps.bucketRepo, deps.sourceRepo, deps.fileRepo, deps.mpRepo))
+	router.GET("/api/s3/:bucket/*object", s3Auth, handlers.GetObjectOrPartsWithFactory(deps.bucketRepo, deps.sourceRepo, deps.fileRepo, deps.mpRepo, deps.sourceFactory))
 	router.GET("/api/s3/:bucket", s3Auth, handlers.ListObjectsOrUploads(deps.bucketRepo, deps.fileRepo, deps.mpRepo))
-	router.PUT("/api/s3/:bucket/*object", s3Auth, handlers.PutObjectOrPart(deps.bucketRepo, deps.sourceRepo, deps.fileRepo, deps.mpRepo, routerUploadChunkSize(cfg)))
-	router.POST("/api/s3/:bucket", s3Auth, handlers.PostBucket(deps.bucketRepo, deps.sourceRepo, deps.fileRepo))
-	router.POST("/api/s3/:bucket/*object", s3Auth, handlers.PostObject(deps.bucketRepo, deps.sourceRepo, deps.fileRepo, deps.mpRepo, routerUploadChunkSize(cfg)))
-	router.DELETE("/api/s3/:bucket/*object", s3Auth, handlers.DeleteObjectOrAbort(deps.bucketRepo, deps.sourceRepo, deps.fileRepo, deps.mpRepo))
+	router.PUT("/api/s3/:bucket/*object", s3Auth, handlers.PutObjectOrPartWithFactory(deps.bucketRepo, deps.sourceRepo, deps.fileRepo, deps.mpRepo, routerUploadChunkSize(cfg), deps.sourceFactory))
+	router.POST("/api/s3/:bucket", s3Auth, handlers.PostBucketWithFactory(deps.bucketRepo, deps.sourceRepo, deps.fileRepo, deps.sourceFactory))
+	router.POST("/api/s3/:bucket/*object", s3Auth, handlers.PostObjectWithFactory(deps.bucketRepo, deps.sourceRepo, deps.fileRepo, deps.mpRepo, routerUploadChunkSize(cfg), deps.sourceFactory))
+	router.DELETE("/api/s3/:bucket/*object", s3Auth, handlers.DeleteObjectOrAbortWithFactory(deps.bucketRepo, deps.sourceRepo, deps.fileRepo, deps.mpRepo, deps.sourceFactory))
 }

--- a/api-go/internal/app/router_test.go
+++ b/api-go/internal/app/router_test.go
@@ -7,9 +7,12 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/example/sfree/api-go/internal/config"
 	"github.com/example/sfree/api-go/internal/db"
 	"github.com/example/sfree/api-go/internal/repository"
+	"github.com/example/sfree/api-go/internal/resilience"
 	"github.com/gin-gonic/gin"
 	"go.mongodb.org/mongo-driver/mongo"
 )
@@ -205,6 +208,46 @@ func TestNewRouterDependenciesReturnsRepositoryErrors(t *testing.T) {
 				t.Fatalf("expected repository name in error, got %v", err)
 			}
 		})
+	}
+}
+
+func TestRouterSourceClientResilienceConfigUsesOverrides(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.SourceClient.TimeoutSeconds = 7
+	cfg.SourceClient.FailureThreshold = 3
+	cfg.SourceClient.RecoverySeconds = 11
+	cfg.SourceClient.MaxRetries = 4
+	cfg.SourceClient.RetryBaseDelayMs = 25
+	cfg.SourceClient.RetryMaxDelayMs = 250
+
+	got := routerSourceClientResilienceConfig(cfg)
+
+	if got.Timeout != 7*time.Second {
+		t.Fatalf("expected timeout override, got %s", got.Timeout)
+	}
+	if got.FailureThreshold != 3 {
+		t.Fatalf("expected failure threshold override, got %d", got.FailureThreshold)
+	}
+	if got.RecoveryTimeout != 11*time.Second {
+		t.Fatalf("expected recovery timeout override, got %s", got.RecoveryTimeout)
+	}
+	if got.MaxRetries != 4 {
+		t.Fatalf("expected max retries override, got %d", got.MaxRetries)
+	}
+	if got.RetryBaseDelay != 25*time.Millisecond {
+		t.Fatalf("expected retry base delay override, got %s", got.RetryBaseDelay)
+	}
+	if got.RetryMaxDelay != 250*time.Millisecond {
+		t.Fatalf("expected retry max delay override, got %s", got.RetryMaxDelay)
+	}
+}
+
+func TestRouterSourceClientResilienceConfigKeepsDefaultsForZeroValues(t *testing.T) {
+	got := routerSourceClientResilienceConfig(&config.Config{})
+	want := resilience.DefaultWrapperConfig()
+
+	if got != want {
+		t.Fatalf("expected default resilience config, got %#v want %#v", got, want)
 	}
 }
 

--- a/api-go/internal/handlers/bucket.go
+++ b/api-go/internal/handlers/bucket.go
@@ -284,6 +284,10 @@ func ListBuckets(repo *repository.BucketRepository, grantRepo *repository.Bucket
 // @Security BasicAuth
 // @Router /api/v1/buckets/{id} [delete]
 func DeleteBucket(repo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository, mpRepo *repository.MultipartUploadRepository, grantRepo *repository.BucketGrantRepository) gin.HandlerFunc {
+	return DeleteBucketWithFactory(repo, sourceRepo, fileRepo, mpRepo, grantRepo, nil)
+}
+
+func DeleteBucketWithFactory(repo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository, mpRepo *repository.MultipartUploadRepository, grantRepo *repository.BucketGrantRepository, factory manager.SourceClientFactory) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		ctx := c.Request.Context()
 		if repo == nil {
@@ -302,7 +306,7 @@ func DeleteBucket(repo *repository.BucketRepository, sourceRepo *repository.Sour
 			c.Status(http.StatusServiceUnavailable)
 			return
 		}
-		objectSvc := manager.NewObjectService(sourceRepo, fileRepo, mpRepo)
+		objectSvc := manager.NewObjectServiceWithSourceClientFactory(sourceRepo, fileRepo, mpRepo, factory)
 		if _, err := objectSvc.DeleteBucketContents(ctx, acc.Bucket.ID); err != nil {
 			slog.ErrorContext(ctx, "delete bucket: cleanup contents", slog.String("error", err.Error()))
 			c.Status(http.StatusInternalServerError)
@@ -403,7 +407,11 @@ type uploadFileResponse struct {
 // @Security BasicAuth
 // @Router /api/v1/buckets/{id}/upload [post]
 func UploadFile(bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository, grantRepo *repository.BucketGrantRepository, chunkSize int) gin.HandlerFunc {
-	objectSvc := manager.NewObjectService(sourceRepo, fileRepo, nil)
+	return UploadFileWithFactory(bucketRepo, sourceRepo, fileRepo, grantRepo, chunkSize, nil)
+}
+
+func UploadFileWithFactory(bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository, grantRepo *repository.BucketGrantRepository, chunkSize int, factory manager.SourceClientFactory) gin.HandlerFunc {
+	objectSvc := manager.NewObjectServiceWithSourceClientFactory(sourceRepo, fileRepo, nil, factory)
 	return func(c *gin.Context) {
 		ctx := c.Request.Context()
 		if bucketRepo == nil || sourceRepo == nil || fileRepo == nil {
@@ -516,6 +524,10 @@ func ListFiles(bucketRepo *repository.BucketRepository, fileRepo *repository.Fil
 // @Security BasicAuth
 // @Router /api/v1/buckets/{id}/files/{file_id}/download [get]
 func DownloadFile(bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository, grantRepo *repository.BucketGrantRepository) gin.HandlerFunc {
+	return DownloadFileWithFactory(bucketRepo, sourceRepo, fileRepo, grantRepo, nil)
+}
+
+func DownloadFileWithFactory(bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository, grantRepo *repository.BucketGrantRepository, factory manager.SourceClientFactory) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		ctx := c.Request.Context()
 		if bucketRepo == nil || sourceRepo == nil || fileRepo == nil {
@@ -527,11 +539,13 @@ func DownloadFile(bucketRepo *repository.BucketRepository, sourceRepo *repositor
 		if grantRepo != nil {
 			grantReader = grantRepo
 		}
-		downloadFile(bucketRepo, sourceRepo, fileRepo, grantReader)(c)
+		downloadFile(bucketRepo, sourceRepo, fileRepo, grantReader, factory)(c)
 	}
 }
 
-func downloadFile(bucketRepo bucketAccessBucketReader, sourceRepo *repository.SourceRepository, fileRepo fileByIDReader, grantRepo bucketAccessGrantReader) gin.HandlerFunc {
+func downloadFile(bucketRepo bucketAccessBucketReader, sourceRepo *repository.SourceRepository, fileRepo fileByIDReader, grantRepo bucketAccessGrantReader, factory manager.SourceClientFactory) gin.HandlerFunc {
+	streamFile := fileStreamFuncForFactory(factory)
+	streamRange := fileRangeStreamFuncForFactory(factory)
 	return func(c *gin.Context) {
 		ctx := c.Request.Context()
 		if bucketRepo == nil || sourceRepo == nil || fileRepo == nil {
@@ -565,14 +579,14 @@ func downloadFile(bucketRepo bucketAccessBucketReader, sourceRepo *repository.So
 			return
 		}
 		total := fileContentLength(fileDoc)
-		if err := preflightFile(ctx, sourceRepo, fileDoc, total, streamDownloadFileRange); err != nil {
+		if err := preflightFile(ctx, sourceRepo, fileDoc, total, streamRange); err != nil {
 			slog.ErrorContext(ctx, "download file: stream failed", slog.String("error", err.Error()))
 			c.Status(http.StatusInternalServerError)
 			return
 		}
 		setAttachmentDownloadHeaders(c, fileDoc.Name, total)
 		c.Status(http.StatusOK)
-		if err := streamDownloadFile(c.Request.Context(), sourceRepo, fileDoc, c.Writer); err != nil {
+		if err := streamFile(c.Request.Context(), sourceRepo, fileDoc, c.Writer); err != nil {
 			slog.ErrorContext(ctx, "download file: stream failed after response commit", slog.String("error", err.Error()))
 		}
 	}
@@ -591,7 +605,11 @@ func downloadFile(bucketRepo bucketAccessBucketReader, sourceRepo *repository.So
 // @Security BasicAuth
 // @Router /api/v1/buckets/{id}/files/{file_id} [delete]
 func DeleteFile(bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository, grantRepo *repository.BucketGrantRepository) gin.HandlerFunc {
-	objectSvc := manager.NewObjectService(sourceRepo, fileRepo, nil)
+	return DeleteFileWithFactory(bucketRepo, sourceRepo, fileRepo, grantRepo, nil)
+}
+
+func DeleteFileWithFactory(bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository, grantRepo *repository.BucketGrantRepository, factory manager.SourceClientFactory) gin.HandlerFunc {
+	objectSvc := manager.NewObjectServiceWithSourceClientFactory(sourceRepo, fileRepo, nil, factory)
 	return func(c *gin.Context) {
 		ctx := c.Request.Context()
 		if bucketRepo == nil || sourceRepo == nil || fileRepo == nil {

--- a/api-go/internal/handlers/download_stream.go
+++ b/api-go/internal/handlers/download_stream.go
@@ -30,6 +30,24 @@ var (
 	streamDownloadFileRange fileRangeStreamFunc = manager.StreamFileRange
 )
 
+func fileStreamFuncForFactory(factory manager.SourceClientFactory) fileStreamFunc {
+	if factory == nil {
+		return streamDownloadFile
+	}
+	return func(ctx context.Context, sourceRepo *repository.SourceRepository, fileDoc *repository.File, w io.Writer) error {
+		return manager.StreamFileWithFactory(ctx, sourceRepo, fileDoc, w, factory)
+	}
+}
+
+func fileRangeStreamFuncForFactory(factory manager.SourceClientFactory) fileRangeStreamFunc {
+	if factory == nil {
+		return streamDownloadFileRange
+	}
+	return func(ctx context.Context, sourceRepo *repository.SourceRepository, fileDoc *repository.File, w io.Writer, start, end int64) error {
+		return manager.StreamFileRangeWithFactory(ctx, sourceRepo, fileDoc, w, start, end, factory)
+	}
+}
+
 func fileContentLength(fileDoc *repository.File) int64 {
 	var total int64
 	for _, ch := range fileDoc.Chunks {

--- a/api-go/internal/handlers/download_stream_test.go
+++ b/api-go/internal/handlers/download_stream_test.go
@@ -87,7 +87,7 @@ func TestDownloadFileStreamFailureReturnsErrorBeforeSuccessHeaders(t *testing.T)
 	r.GET(
 		"/buckets/:id/files/:file_id/download",
 		setUserID(userID.Hex()),
-		downloadFile(fakeBucketByIDReader{bucket: bucket}, &repository.SourceRepository{}, fakeFileByIDReader{file: file}, nil),
+		downloadFile(fakeBucketByIDReader{bucket: bucket}, &repository.SourceRepository{}, fakeFileByIDReader{file: file}, nil, nil),
 	)
 
 	req := httptest.NewRequest(http.MethodGet, "/buckets/"+bucket.ID.Hex()+"/files/"+file.ID.Hex()+"/download", nil)
@@ -141,7 +141,7 @@ func TestGetSharedFileStreamFailureReturnsErrorBeforeSuccessHeaders(t *testing.T
 		CreatedAt: time.Now().UTC(),
 	}
 	r := gin.New()
-	r.GET("/share/:token", getSharedFile(fakeShareLinkByTokenReader{link: link}, &repository.SourceRepository{}, fakeFileByIDReader{file: file}))
+	r.GET("/share/:token", getSharedFile(fakeShareLinkByTokenReader{link: link}, &repository.SourceRepository{}, fakeFileByIDReader{file: file}, nil))
 
 	req := httptest.NewRequest(http.MethodGet, "/share/token", nil)
 	w := httptest.NewRecorder()
@@ -184,7 +184,7 @@ func TestDownloadFileStreamsBodyAfterBoundedPreflight(t *testing.T) {
 	r.GET(
 		"/buckets/:id/files/:file_id/download",
 		setUserID(userID.Hex()),
-		downloadFile(fakeBucketByIDReader{bucket: bucket}, &repository.SourceRepository{}, fakeFileByIDReader{file: file}, nil),
+		downloadFile(fakeBucketByIDReader{bucket: bucket}, &repository.SourceRepository{}, fakeFileByIDReader{file: file}, nil, nil),
 	)
 
 	req := httptest.NewRequest(http.MethodGet, "/buckets/"+bucket.ID.Hex()+"/files/"+file.ID.Hex()+"/download", nil)

--- a/api-go/internal/handlers/s3.go
+++ b/api-go/internal/handlers/s3.go
@@ -344,8 +344,8 @@ func requestObjectUserMetadata(r *http.Request) map[string]string {
 // committed. Later source failures are logged and surface to clients as an
 // incomplete body under the declared Content-Length, which preserves large
 // object streaming without staging the full response in memory or on disk.
-func preflightObjectRange(ctx context.Context, sourceRepo *repository.SourceRepository, fileDoc *repository.File, start, end int64) error {
-	return preflightFileRange(ctx, sourceRepo, fileDoc, start, end, streamS3ObjectRange)
+func preflightObjectRange(ctx context.Context, sourceRepo *repository.SourceRepository, fileDoc *repository.File, start, end int64, streamRange fileRangeStreamFunc) error {
+	return preflightFileRange(ctx, sourceRepo, fileDoc, start, end, streamRange)
 }
 
 // HeadObject godoc
@@ -383,15 +383,29 @@ func HeadObject(bucketRepo *repository.BucketRepository, fileRepo *repository.Fi
 // @Failure 500 {string} string ""
 // @Router /api/s3/{bucket}/{object} [get]
 func GetObject(bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository) gin.HandlerFunc {
+	return GetObjectWithFactory(bucketRepo, sourceRepo, fileRepo, nil)
+}
+
+func GetObjectWithFactory(bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository, factory manager.SourceClientFactory) gin.HandlerFunc {
 	if bucketRepo == nil || sourceRepo == nil || fileRepo == nil {
 		return func(c *gin.Context) {
 			c.Status(http.StatusServiceUnavailable)
 		}
 	}
-	return getObject(bucketRepo, sourceRepo, fileRepo)
+	return getObject(bucketRepo, sourceRepo, fileRepo, factory)
 }
 
-func getObject(bucketRepo objectBucketReader, sourceRepo *repository.SourceRepository, fileRepo objectFileReader) gin.HandlerFunc {
+func getObject(bucketRepo objectBucketReader, sourceRepo *repository.SourceRepository, fileRepo objectFileReader, factory manager.SourceClientFactory) gin.HandlerFunc {
+	streamFile := streamS3Object
+	streamRange := streamS3ObjectRange
+	if factory != nil {
+		streamFile = func(ctx context.Context, sourceRepo *repository.SourceRepository, fileDoc *repository.File, w io.Writer) error {
+			return manager.StreamFileWithFactory(ctx, sourceRepo, fileDoc, w, factory)
+		}
+		streamRange = func(ctx context.Context, sourceRepo *repository.SourceRepository, fileDoc *repository.File, w io.Writer, start, end int64) error {
+			return manager.StreamFileRangeWithFactory(ctx, sourceRepo, fileDoc, w, start, end, factory)
+		}
+	}
 	return func(c *gin.Context) {
 		if bucketRepo == nil || sourceRepo == nil || fileRepo == nil {
 			c.Status(http.StatusServiceUnavailable)
@@ -403,14 +417,14 @@ func getObject(bucketRepo objectBucketReader, sourceRepo *repository.SourceRepos
 		}
 		rangeHeader := c.GetHeader("Range")
 		if rangeHeader == "" {
-			if err := preflightObjectRange(c.Request.Context(), sourceRepo, fileDoc, 0, total-1); err != nil {
+			if err := preflightObjectRange(c.Request.Context(), sourceRepo, fileDoc, 0, total-1, streamRange); err != nil {
 				slog.ErrorContext(c.Request.Context(), "get object: stream failed", slog.String("error", err.Error()))
 				writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
 				return
 			}
 			setObjectHeaders(c, fileDoc, total)
 			c.Status(http.StatusOK)
-			if err := streamS3Object(c.Request.Context(), sourceRepo, fileDoc, c.Writer); err != nil {
+			if err := streamFile(c.Request.Context(), sourceRepo, fileDoc, c.Writer); err != nil {
 				slog.ErrorContext(c.Request.Context(), "get object: stream failed after response commit", slog.String("error", err.Error()))
 			}
 			return
@@ -423,7 +437,7 @@ func getObject(bucketRepo objectBucketReader, sourceRepo *repository.SourceRepos
 			writeS3Error(c, http.StatusRequestedRangeNotSatisfiable, "InvalidRange", "The requested range is not satisfiable")
 			return
 		}
-		if err := preflightObjectRange(c.Request.Context(), sourceRepo, fileDoc, objRange.start, objRange.end); err != nil {
+		if err := preflightObjectRange(c.Request.Context(), sourceRepo, fileDoc, objRange.start, objRange.end, streamRange); err != nil {
 			slog.ErrorContext(c.Request.Context(), "get object: stream failed", slog.String("error", err.Error()))
 			writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
 			return
@@ -432,7 +446,7 @@ func getObject(bucketRepo objectBucketReader, sourceRepo *repository.SourceRepos
 		c.Header("Content-Length", strconv.FormatInt(objRange.end-objRange.start+1, 10))
 		c.Header("Content-Range", "bytes "+strconv.FormatInt(objRange.start, 10)+"-"+strconv.FormatInt(objRange.end, 10)+"/"+strconv.FormatInt(total, 10))
 		c.Status(http.StatusPartialContent)
-		if err := streamS3ObjectRange(c.Request.Context(), sourceRepo, fileDoc, c.Writer, objRange.start, objRange.end); err != nil {
+		if err := streamRange(c.Request.Context(), sourceRepo, fileDoc, c.Writer, objRange.start, objRange.end); err != nil {
 			slog.ErrorContext(c.Request.Context(), "get object: stream failed after response commit", slog.String("error", err.Error()))
 		}
 	}
@@ -451,7 +465,11 @@ func getObject(bucketRepo objectBucketReader, sourceRepo *repository.SourceRepos
 // @Failure 500 {string} string ""
 // @Router /api/s3/{bucket}/{object} [put]
 func PutObject(bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository, chunkSize int) gin.HandlerFunc {
-	objectSvc := manager.NewObjectService(sourceRepo, fileRepo, nil)
+	return PutObjectWithFactory(bucketRepo, sourceRepo, fileRepo, chunkSize, nil)
+}
+
+func PutObjectWithFactory(bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository, chunkSize int, factory manager.SourceClientFactory) gin.HandlerFunc {
+	objectSvc := manager.NewObjectServiceWithSourceClientFactory(sourceRepo, fileRepo, nil, factory)
 	return func(c *gin.Context) {
 		ctx := c.Request.Context()
 		if bucketRepo == nil || sourceRepo == nil || fileRepo == nil {
@@ -495,7 +513,11 @@ func PutObject(bucketRepo *repository.BucketRepository, sourceRepo *repository.S
 // @Failure 500 {string} string ""
 // @Router /api/s3/{bucket}/{object} [put]
 func CopyObject(bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository) gin.HandlerFunc {
-	objectSvc := manager.NewObjectService(sourceRepo, fileRepo, nil)
+	return CopyObjectWithFactory(bucketRepo, sourceRepo, fileRepo, nil)
+}
+
+func CopyObjectWithFactory(bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository, factory manager.SourceClientFactory) gin.HandlerFunc {
+	objectSvc := manager.NewObjectServiceWithSourceClientFactory(sourceRepo, fileRepo, nil, factory)
 	return func(c *gin.Context) {
 		ctx := c.Request.Context()
 		if bucketRepo == nil || sourceRepo == nil || fileRepo == nil {
@@ -568,7 +590,11 @@ func CopyObject(bucketRepo *repository.BucketRepository, sourceRepo *repository.
 // @Failure 500 {string} string ""
 // @Router /api/s3/{bucket}/{object} [delete]
 func DeleteObject(bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository) gin.HandlerFunc {
-	objectSvc := manager.NewObjectService(sourceRepo, fileRepo, nil)
+	return DeleteObjectWithFactory(bucketRepo, sourceRepo, fileRepo, nil)
+}
+
+func DeleteObjectWithFactory(bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository, factory manager.SourceClientFactory) gin.HandlerFunc {
+	objectSvc := manager.NewObjectServiceWithSourceClientFactory(sourceRepo, fileRepo, nil, factory)
 	return func(c *gin.Context) {
 		ctx := c.Request.Context()
 		if bucketRepo == nil || sourceRepo == nil || fileRepo == nil {
@@ -598,7 +624,11 @@ func DeleteObject(bucketRepo *repository.BucketRepository, sourceRepo *repositor
 }
 
 func DeleteObjects(bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository) gin.HandlerFunc {
-	objectSvc := manager.NewObjectService(sourceRepo, fileRepo, nil)
+	return DeleteObjectsWithFactory(bucketRepo, sourceRepo, fileRepo, nil)
+}
+
+func DeleteObjectsWithFactory(bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository, factory manager.SourceClientFactory) gin.HandlerFunc {
+	objectSvc := manager.NewObjectServiceWithSourceClientFactory(sourceRepo, fileRepo, nil, factory)
 	return func(c *gin.Context) {
 		ctx := c.Request.Context()
 		if bucketRepo == nil || sourceRepo == nil || fileRepo == nil {

--- a/api-go/internal/handlers/s3_get_test.go
+++ b/api-go/internal/handlers/s3_get_test.go
@@ -137,7 +137,7 @@ func getObjectFailureTestHandler(t *testing.T) gin.HandlerFunc {
 	}
 	sourceRepo := &repository.SourceRepository{}
 
-	return getObject(bucketRepo, sourceRepo, fileRepo)
+	return getObject(bucketRepo, sourceRepo, fileRepo, nil)
 }
 
 func TestGetObjectStreamFailureReturnsS3ErrorBeforeSuccess(t *testing.T) {

--- a/api-go/internal/handlers/s3_multipart.go
+++ b/api-go/internal/handlers/s3_multipart.go
@@ -87,6 +87,10 @@ type multipartUploadAbortStore interface {
 // ?uploads → CreateMultipartUpload
 // ?uploadId=X → CompleteMultipartUpload
 func PostObject(bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository, mpRepo *repository.MultipartUploadRepository, chunkSize int) gin.HandlerFunc {
+	return PostObjectWithFactory(bucketRepo, sourceRepo, fileRepo, mpRepo, chunkSize, nil)
+}
+
+func PostObjectWithFactory(bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository, mpRepo *repository.MultipartUploadRepository, chunkSize int, factory manager.SourceClientFactory) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		if bucketRepo == nil || sourceRepo == nil || fileRepo == nil || mpRepo == nil {
 			c.Status(http.StatusServiceUnavailable)
@@ -97,7 +101,7 @@ func PostObject(bucketRepo *repository.BucketRepository, sourceRepo *repository.
 			return
 		}
 		if _, ok := c.GetQuery("uploadId"); ok {
-			completeMultipartUpload(c, bucketRepo, sourceRepo, fileRepo, mpRepo)
+			completeMultipartUpload(c, bucketRepo, sourceRepo, fileRepo, mpRepo, factory)
 			return
 		}
 		writeS3Error(c, http.StatusBadRequest, "InvalidRequest", "missing uploads or uploadId parameter")
@@ -107,7 +111,11 @@ func PostObject(bucketRepo *repository.BucketRepository, sourceRepo *repository.
 // PostBucket dispatches POST requests on S3 bucket paths.
 // ?delete -> DeleteObjects
 func PostBucket(bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository) gin.HandlerFunc {
-	deleteObjectsHandler := DeleteObjects(bucketRepo, sourceRepo, fileRepo)
+	return PostBucketWithFactory(bucketRepo, sourceRepo, fileRepo, nil)
+}
+
+func PostBucketWithFactory(bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository, factory manager.SourceClientFactory) gin.HandlerFunc {
+	deleteObjectsHandler := DeleteObjectsWithFactory(bucketRepo, sourceRepo, fileRepo, factory)
 	return func(c *gin.Context) {
 		if _, ok := c.GetQuery("delete"); ok {
 			deleteObjectsHandler(c)
@@ -122,8 +130,12 @@ func PostBucket(bucketRepo *repository.BucketRepository, sourceRepo *repository.
 // ?uploadId=X&partNumber=N → UploadPart
 // otherwise → PutObject
 func PutObjectOrPart(bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository, mpRepo *repository.MultipartUploadRepository, chunkSize int) gin.HandlerFunc {
-	putHandler := PutObject(bucketRepo, sourceRepo, fileRepo, chunkSize)
-	copyHandler := CopyObject(bucketRepo, sourceRepo, fileRepo)
+	return PutObjectOrPartWithFactory(bucketRepo, sourceRepo, fileRepo, mpRepo, chunkSize, nil)
+}
+
+func PutObjectOrPartWithFactory(bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository, mpRepo *repository.MultipartUploadRepository, chunkSize int, factory manager.SourceClientFactory) gin.HandlerFunc {
+	putHandler := PutObjectWithFactory(bucketRepo, sourceRepo, fileRepo, chunkSize, factory)
+	copyHandler := CopyObjectWithFactory(bucketRepo, sourceRepo, fileRepo, factory)
 	return func(c *gin.Context) {
 		if c.GetHeader("x-amz-copy-source") != "" {
 			if _, ok := c.GetQuery("uploadId"); ok {
@@ -135,7 +147,7 @@ func PutObjectOrPart(bucketRepo *repository.BucketRepository, sourceRepo *reposi
 		}
 		if mpRepo != nil {
 			if _, ok := c.GetQuery("uploadId"); ok {
-				uploadPart(c, bucketRepo, sourceRepo, mpRepo, chunkSize)
+				uploadPart(c, bucketRepo, sourceRepo, mpRepo, chunkSize, factory)
 				return
 			}
 		}
@@ -147,11 +159,15 @@ func PutObjectOrPart(bucketRepo *repository.BucketRepository, sourceRepo *reposi
 // ?uploadId=X → AbortMultipartUpload
 // otherwise → DeleteObject
 func DeleteObjectOrAbort(bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository, mpRepo *repository.MultipartUploadRepository) gin.HandlerFunc {
-	deleteHandler := DeleteObject(bucketRepo, sourceRepo, fileRepo)
+	return DeleteObjectOrAbortWithFactory(bucketRepo, sourceRepo, fileRepo, mpRepo, nil)
+}
+
+func DeleteObjectOrAbortWithFactory(bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository, mpRepo *repository.MultipartUploadRepository, factory manager.SourceClientFactory) gin.HandlerFunc {
+	deleteHandler := DeleteObjectWithFactory(bucketRepo, sourceRepo, fileRepo, factory)
 	return func(c *gin.Context) {
 		if mpRepo != nil {
 			if _, ok := c.GetQuery("uploadId"); ok {
-				abortMultipartUpload(c, bucketRepo, sourceRepo, mpRepo)
+				abortMultipartUpload(c, bucketRepo, sourceRepo, mpRepo, factory)
 				return
 			}
 		}
@@ -163,7 +179,11 @@ func DeleteObjectOrAbort(bucketRepo *repository.BucketRepository, sourceRepo *re
 // ?uploadId=X → ListParts
 // otherwise → GetObject
 func GetObjectOrParts(bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository, mpRepo *repository.MultipartUploadRepository) gin.HandlerFunc {
-	getHandler := GetObject(bucketRepo, sourceRepo, fileRepo)
+	return GetObjectOrPartsWithFactory(bucketRepo, sourceRepo, fileRepo, mpRepo, nil)
+}
+
+func GetObjectOrPartsWithFactory(bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository, mpRepo *repository.MultipartUploadRepository, factory manager.SourceClientFactory) gin.HandlerFunc {
+	getHandler := GetObjectWithFactory(bucketRepo, sourceRepo, fileRepo, factory)
 	return func(c *gin.Context) {
 		if mpRepo != nil {
 			if _, ok := c.GetQuery("uploadId"); ok {
@@ -230,7 +250,7 @@ func createMultipartUpload(c *gin.Context, bucketRepo *repository.BucketReposito
 	})
 }
 
-func uploadPart(c *gin.Context, bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, mpRepo *repository.MultipartUploadRepository, chunkSize int) {
+func uploadPart(c *gin.Context, bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, mpRepo *repository.MultipartUploadRepository, chunkSize int, factory manager.SourceClientFactory) {
 	ctx := c.Request.Context()
 	uploadID := c.Query("uploadId")
 	partNumStr := c.Query("partNumber")
@@ -260,7 +280,7 @@ func uploadPart(c *gin.Context, bucketRepo *repository.BucketRepository, sourceR
 		return
 	}
 
-	objectSvc := manager.NewObjectService(sourceRepo, nil, mpRepo)
+	objectSvc := manager.NewObjectServiceWithSourceClientFactory(sourceRepo, nil, mpRepo, factory)
 	result, err := objectSvc.UploadMultipartPartRecord(ctx, bucketDoc, mu, partNum, c.Request.Body, chunkSize)
 	if err != nil {
 		switch {
@@ -282,7 +302,7 @@ func uploadPart(c *gin.Context, bucketRepo *repository.BucketRepository, sourceR
 	c.Status(http.StatusOK)
 }
 
-func completeMultipartUpload(c *gin.Context, bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository, mpRepo *repository.MultipartUploadRepository) {
+func completeMultipartUpload(c *gin.Context, bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository, mpRepo *repository.MultipartUploadRepository, factory manager.SourceClientFactory) {
 	ctx := c.Request.Context()
 	uploadID := c.Query("uploadId")
 
@@ -312,7 +332,7 @@ func completeMultipartUpload(c *gin.Context, bucketRepo *repository.BucketReposi
 		requestedParts = append(requestedParts, manager.CompleteMultipartPart{PartNumber: rp.PartNumber, ETag: rp.ETag})
 	}
 
-	objectSvc := manager.NewObjectService(sourceRepo, fileRepo, mpRepo)
+	objectSvc := manager.NewObjectServiceWithSourceClientFactory(sourceRepo, fileRepo, mpRepo, factory)
 	result, err := objectSvc.CompleteMultipartUploadRecord(ctx, bucketDoc.ID, mu, requestedParts)
 	if err != nil {
 		switch {
@@ -351,7 +371,7 @@ func completeMultipartUpload(c *gin.Context, bucketRepo *repository.BucketReposi
 	})
 }
 
-func abortMultipartUpload(c *gin.Context, bucketRepo objectBucketReader, sourceRepo *repository.SourceRepository, mpRepo multipartUploadAbortStore) {
+func abortMultipartUpload(c *gin.Context, bucketRepo objectBucketReader, sourceRepo *repository.SourceRepository, mpRepo multipartUploadAbortStore, factory manager.SourceClientFactory) {
 	ctx := c.Request.Context()
 	uploadID := c.Query("uploadId")
 
@@ -376,7 +396,7 @@ func abortMultipartUpload(c *gin.Context, bucketRepo objectBucketReader, sourceR
 	}
 
 	for _, p := range mu.Parts {
-		if delErr := manager.DeleteFileChunks(ctx, sourceRepo, p.Chunks); delErr != nil {
+		if delErr := manager.DeleteFileChunksWithFactory(ctx, sourceRepo, p.Chunks, factory); delErr != nil {
 			slog.WarnContext(ctx, "abort multipart: delete part chunks",
 				slog.Int("part_number", p.PartNumber),
 				slog.String("error", delErr.Error()),

--- a/api-go/internal/handlers/s3_multipart_test.go
+++ b/api-go/internal/handlers/s3_multipart_test.go
@@ -287,7 +287,7 @@ func TestAbortMultipartUploadRejectsOtherBucketUpload(t *testing.T) {
 			Key:       "route-bucket",
 			AccessKey: "route-access",
 		},
-	}, &repository.SourceRepository{}, store)
+	}, &repository.SourceRepository{}, store, nil)
 
 	if w.Code != http.StatusNotFound {
 		t.Fatalf("expected 404, got %d", w.Code)
@@ -311,7 +311,7 @@ func TestAbortMultipartUploadUnknownUploadKeepsNoSuchUpload(t *testing.T) {
 		{Key: "object", Value: "/object.txt"},
 	}
 
-	abortMultipartUpload(c, fakeObjectBucketReader{}, &repository.SourceRepository{}, store)
+	abortMultipartUpload(c, fakeObjectBucketReader{}, &repository.SourceRepository{}, store, nil)
 
 	if w.Code != http.StatusNotFound {
 		t.Fatalf("expected 404, got %d", w.Code)

--- a/api-go/internal/handlers/sharelink.go
+++ b/api-go/internal/handlers/sharelink.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/example/sfree/api-go/internal/cryptoutil"
+	"github.com/example/sfree/api-go/internal/manager"
 	"github.com/example/sfree/api-go/internal/repository"
 	"github.com/gin-gonic/gin"
 	"go.mongodb.org/mongo-driver/mongo"
@@ -141,6 +142,10 @@ func CreateShareLink(bucketRepo *repository.BucketRepository, fileRepo *reposito
 // @Failure 500 {string} string ""
 // @Router /share/{token} [get]
 func GetSharedFile(shareLinkRepo *repository.ShareLinkRepository, bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository) gin.HandlerFunc {
+	return GetSharedFileWithFactory(shareLinkRepo, bucketRepo, sourceRepo, fileRepo, nil)
+}
+
+func GetSharedFileWithFactory(shareLinkRepo *repository.ShareLinkRepository, bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository, factory manager.SourceClientFactory) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		ctx := c.Request.Context()
 		if shareLinkRepo == nil || bucketRepo == nil || sourceRepo == nil || fileRepo == nil {
@@ -148,11 +153,13 @@ func GetSharedFile(shareLinkRepo *repository.ShareLinkRepository, bucketRepo *re
 			c.Status(http.StatusServiceUnavailable)
 			return
 		}
-		getSharedFile(shareLinkRepo, sourceRepo, fileRepo)(c)
+		getSharedFile(shareLinkRepo, sourceRepo, fileRepo, factory)(c)
 	}
 }
 
-func getSharedFile(shareLinkRepo shareLinkByTokenReader, sourceRepo *repository.SourceRepository, fileRepo fileByIDReader) gin.HandlerFunc {
+func getSharedFile(shareLinkRepo shareLinkByTokenReader, sourceRepo *repository.SourceRepository, fileRepo fileByIDReader, factory manager.SourceClientFactory) gin.HandlerFunc {
+	streamFile := fileStreamFuncForFactory(factory)
+	streamRange := fileRangeStreamFuncForFactory(factory)
 	return func(c *gin.Context) {
 		ctx := c.Request.Context()
 		if shareLinkRepo == nil || sourceRepo == nil || fileRepo == nil {
@@ -195,14 +202,14 @@ func getSharedFile(shareLinkRepo shareLinkByTokenReader, sourceRepo *repository.
 		}
 
 		total := fileContentLength(fileDoc)
-		if err := preflightFile(ctx, sourceRepo, fileDoc, total, streamDownloadFileRange); err != nil {
+		if err := preflightFile(ctx, sourceRepo, fileDoc, total, streamRange); err != nil {
 			slog.ErrorContext(ctx, "get shared file: stream", slog.String("error", err.Error()))
 			c.Status(http.StatusInternalServerError)
 			return
 		}
 		setAttachmentDownloadHeaders(c, fileDoc.Name, total)
 		c.Status(http.StatusOK)
-		if err := streamDownloadFile(ctx, sourceRepo, fileDoc, c.Writer); err != nil {
+		if err := streamFile(ctx, sourceRepo, fileDoc, c.Writer); err != nil {
 			slog.ErrorContext(ctx, "get shared file: stream failed after response commit", slog.String("error", err.Error()))
 		}
 	}

--- a/api-go/internal/handlers/source.go
+++ b/api-go/internal/handlers/source.go
@@ -326,6 +326,10 @@ func GetSourceInfo(repo *repository.SourceRepository) gin.HandlerFunc {
 	return getSourceInfo(repo, nil)
 }
 
+func GetSourceInfoWithFactory(repo *repository.SourceRepository, factory manager.SourceClientFactory) gin.HandlerFunc {
+	return getSourceInfo(repo, factory)
+}
+
 func getSourceInfo(repo *repository.SourceRepository, factory manager.SourceClientFactory) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		ctx := c.Request.Context()
@@ -396,6 +400,10 @@ func getSourceInfo(repo *repository.SourceRepository, factory manager.SourceClie
 // @Router /api/v1/sources/{id}/health [get]
 func GetSourceHealth(repo *repository.SourceRepository) gin.HandlerFunc {
 	return getSourceHealth(repo, nil)
+}
+
+func GetSourceHealthWithFactory(repo *repository.SourceRepository, factory manager.SourceClientFactory) gin.HandlerFunc {
+	return getSourceHealth(repo, factory)
 }
 
 func getSourceHealth(repo sourceGetter, factory manager.SourceClientFactory) gin.HandlerFunc {
@@ -471,6 +479,13 @@ func DownloadSourceFile(sourceRepo *repository.SourceRepository) gin.HandlerFunc
 		return downloadSourceFile(nil, nil)
 	}
 	return downloadSourceFile(sourceRepo, nil)
+}
+
+func DownloadSourceFileWithFactory(sourceRepo *repository.SourceRepository, factory manager.SourceClientFactory) gin.HandlerFunc {
+	if sourceRepo == nil {
+		return downloadSourceFile(nil, factory)
+	}
+	return downloadSourceFile(sourceRepo, factory)
 }
 
 func downloadSourceFile(sourceRepo sourceGetter, factory manager.SourceClientFactory) gin.HandlerFunc {

--- a/api-go/internal/manager/chunk_delete.go
+++ b/api-go/internal/manager/chunk_delete.go
@@ -10,7 +10,11 @@ import (
 )
 
 func DeleteFileChunks(ctx context.Context, srcRepo *repository.SourceRepository, chunks []repository.FileChunk) error {
-	return deleteFileChunksWithFactory(ctx, chunks, sourceClientFactoryFromRepository(srcRepo))
+	return DeleteFileChunksWithFactory(ctx, srcRepo, chunks, nil)
+}
+
+func DeleteFileChunksWithFactory(ctx context.Context, srcRepo *repository.SourceRepository, chunks []repository.FileChunk, factory SourceClientFactory) error {
+	return deleteFileChunksWithFactory(ctx, chunks, sourceClientFactoryFromRepository(srcRepo, factory))
 }
 
 func deleteFileChunksWithFactory(ctx context.Context, chunks []repository.FileChunk, factory SourceClientFactory) error {

--- a/api-go/internal/manager/chunk_stream.go
+++ b/api-go/internal/manager/chunk_stream.go
@@ -19,11 +19,19 @@ import (
 var ErrChecksumMismatch = errors.New("checksum mismatch")
 
 func StreamFile(ctx context.Context, srcRepo *repository.SourceRepository, f *repository.File, w io.Writer) error {
-	return streamFileWithFactory(ctx, f, w, sourceClientFactoryFromRepository(srcRepo))
+	return StreamFileWithFactory(ctx, srcRepo, f, w, nil)
 }
 
 func StreamFileRange(ctx context.Context, srcRepo *repository.SourceRepository, f *repository.File, w io.Writer, start, end int64) error {
-	return streamFileRangeWithFactory(ctx, f, w, start, end, sourceClientFactoryFromRepository(srcRepo))
+	return StreamFileRangeWithFactory(ctx, srcRepo, f, w, start, end, nil)
+}
+
+func StreamFileWithFactory(ctx context.Context, srcRepo *repository.SourceRepository, f *repository.File, w io.Writer, factory SourceClientFactory) error {
+	return streamFileWithFactory(ctx, f, w, sourceClientFactoryFromRepository(srcRepo, factory))
+}
+
+func StreamFileRangeWithFactory(ctx context.Context, srcRepo *repository.SourceRepository, f *repository.File, w io.Writer, start, end int64, factory SourceClientFactory) error {
+	return streamFileRangeWithFactory(ctx, f, w, start, end, sourceClientFactoryFromRepository(srcRepo, factory))
 }
 
 // streamFileWithFactory is the testable core of StreamFile. The factory receives

--- a/api-go/internal/manager/s3_object.go
+++ b/api-go/internal/manager/s3_object.go
@@ -124,11 +124,15 @@ type ObjectService struct {
 }
 
 func NewObjectService(sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository, mpRepo *repository.MultipartUploadRepository) *ObjectService {
+	return NewObjectServiceWithSourceClientFactory(sourceRepo, fileRepo, mpRepo, nil)
+}
+
+func NewObjectServiceWithSourceClientFactory(sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository, mpRepo *repository.MultipartUploadRepository, factory SourceClientFactory) *ObjectService {
 	svc := &ObjectService{
 		sources: sourceRepo,
 		files:   fileRepo,
 		uploadChunks: func(ctx context.Context, r io.Reader, sources []repository.Source, chunkSize int, selector SourceSelector) ([]repository.FileChunk, error) {
-			return UploadFileChunksWithStrategy(ctx, r, sources, chunkSize, nil, selector)
+			return UploadFileChunksWithStrategy(ctx, r, sources, chunkSize, factory, selector)
 		},
 		now: func() time.Time {
 			return time.Now().UTC()
@@ -138,7 +142,7 @@ func NewObjectService(sourceRepo *repository.SourceRepository, fileRepo *reposit
 		svc.multipart = mpRepo
 	}
 	svc.deleteChunks = func(ctx context.Context, chunks []repository.FileChunk) error {
-		return DeleteFileChunks(ctx, sourceRepo, chunks)
+		return DeleteFileChunksWithFactory(ctx, sourceRepo, chunks, factory)
 	}
 	return svc
 }
@@ -436,8 +440,12 @@ func (s *ObjectService) deleteBucketChunksIfUnreferenced(ctx context.Context, bu
 }
 
 func DeleteFileChunksIfUnreferenced(ctx context.Context, sourceRepo *repository.SourceRepository, fileStore ChunkReferenceCounter, chunks []repository.FileChunk) error {
+	return DeleteFileChunksIfUnreferencedWithFactory(ctx, sourceRepo, fileStore, chunks, nil)
+}
+
+func DeleteFileChunksIfUnreferencedWithFactory(ctx context.Context, sourceRepo *repository.SourceRepository, fileStore ChunkReferenceCounter, chunks []repository.FileChunk, factory SourceClientFactory) error {
 	return deleteFileChunksIfUnreferenced(ctx, fileStore, func(ctx context.Context, chunks []repository.FileChunk) error {
-		return DeleteFileChunks(ctx, sourceRepo, chunks)
+		return DeleteFileChunksWithFactory(ctx, sourceRepo, chunks, factory)
 	}, chunks)
 }
 

--- a/api-go/internal/manager/s3_object_test.go
+++ b/api-go/internal/manager/s3_object_test.go
@@ -408,6 +408,31 @@ func testObjectService(files *fakeObjectFiles, deleted *[]repository.FileChunk) 
 	}
 }
 
+func TestNewObjectServiceWithSourceClientFactoryUsesFactoryForUploads(t *testing.T) {
+	t.Parallel()
+
+	sourceID := primitive.NewObjectID()
+	calls := 0
+	svc := NewObjectServiceWithSourceClientFactory(nil, nil, nil, func(_ context.Context, src *repository.Source) (SourceClient, error) {
+		calls++
+		if src.ID != sourceID {
+			t.Fatalf("expected source %s, got %s", sourceID.Hex(), src.ID.Hex())
+		}
+		return &stubSourceClient{}, nil
+	})
+
+	chunks, err := svc.uploadChunks(context.Background(), bytes.NewReader([]byte("payload")), []repository.Source{{ID: sourceID}}, len("payload"), &RoundRobinSelector{})
+	if err != nil {
+		t.Fatalf("upload chunks: %v", err)
+	}
+	if len(chunks) != 1 {
+		t.Fatalf("expected one chunk, got %d", len(chunks))
+	}
+	if calls != 1 {
+		t.Fatalf("expected factory to be called once, got %d", calls)
+	}
+}
+
 func TestObjectServicePutObjectUpdatesFileAndDeletesOldChunks(t *testing.T) {
 	bucketID := primitive.NewObjectID()
 	oldSourceID := primitive.NewObjectID()

--- a/api-go/internal/manager/source_client.go
+++ b/api-go/internal/manager/source_client.go
@@ -53,9 +53,11 @@ func (c *sourceClientCache) get(ctx context.Context, src repository.Source) (sou
 	return cli, nil
 }
 
-var ResilienceConfig = resilience.DefaultWrapperConfig()
-
 func NewSourceClient(ctx context.Context, src *repository.Source) (SourceClient, error) {
+	return NewSourceClientWithConfig(ctx, src, resilience.DefaultWrapperConfig())
+}
+
+func NewSourceClientWithConfig(ctx context.Context, src *repository.Source, resilienceConfig resilience.WrapperConfig) (SourceClient, error) {
 	if src == nil {
 		return nil, errors.New("nil source")
 	}
@@ -86,15 +88,24 @@ func NewSourceClient(ctx context.Context, src *repository.Source) (SourceClient,
 	if err != nil {
 		return nil, err
 	}
-	return resilience.Wrap(cli, ResilienceConfig), nil
+	return resilience.Wrap(cli, resilienceConfig), nil
 }
 
-func sourceClientFactoryFromRepository(srcRepo *repository.SourceRepository) SourceClientFactory {
+func NewSourceClientFactory(resilienceConfig resilience.WrapperConfig) SourceClientFactory {
+	return func(ctx context.Context, src *repository.Source) (SourceClient, error) {
+		return NewSourceClientWithConfig(ctx, src, resilienceConfig)
+	}
+}
+
+func sourceClientFactoryFromRepository(srcRepo *repository.SourceRepository, factory SourceClientFactory) SourceClientFactory {
+	if factory == nil {
+		factory = NewSourceClient
+	}
 	return func(ctx context.Context, src *repository.Source) (sourceClient, error) {
 		fullSrc, err := srcRepo.GetByID(ctx, src.ID)
 		if err != nil {
 			return nil, err
 		}
-		return NewSourceClient(ctx, fullSrc)
+		return factory(ctx, fullSrc)
 	}
 }


### PR DESCRIPTION
## Summary
- remove manager-level mutable source client resilience config
- add explicit source client factory/config constructors in manager
- thread configured factories through app router dependencies, REST handlers, S3 flows, and object service cleanup/upload paths
- add focused tests for router config mapping and object-service factory upload wiring

## Validation
- `gofmt` on touched Go files
- `git diff --check HEAD~1..HEAD`

Full Go test/lint validation was not run locally per heartbeat resource policy; Woodpecker should run backend validation.