### PR TITLE
THE-747 Persist canonical S3 object ETags

### DIFF
--- a/api-go/internal/handlers/s3_get_test.go
+++ b/api-go/internal/handlers/s3_get_test.go
@@ -128,6 +128,7 @@ func getObjectFailureTestHandler(t *testing.T) gin.HandlerFunc {
 			BucketID:     bucketID,
 			Name:         "object.txt",
 			CreatedAt:    time.Unix(1700000000, 0).UTC(),
+			ETag:         `"persisted-etag"`,
 			ContentType:  "text/plain",
 			UserMetadata: map[string]string{"owner": "alice", "trace-id": "abc-123"},
 			Chunks: []repository.FileChunk{
@@ -257,6 +258,9 @@ func TestGetObjectStreamsBodyAfterBoundedPreflight(t *testing.T) {
 	if got := w.Header().Get("Content-Type"); got != "text/plain" {
 		t.Fatalf("expected stored Content-Type, got %q", got)
 	}
+	if got := w.Header().Get("ETag"); got != `"persisted-etag"` {
+		t.Fatalf("expected persisted ETag header, got %q", got)
+	}
 	if got := w.Header().Get("x-amz-meta-owner"); got != "alice" {
 		t.Fatalf("expected stored owner metadata, got %q", got)
 	}
@@ -298,6 +302,9 @@ func TestGetObjectRangeReturnsStoredMetadataHeaders(t *testing.T) {
 	}
 	if got := w.Header().Get("Content-Type"); got != "text/plain" {
 		t.Fatalf("expected stored Content-Type, got %q", got)
+	}
+	if got := w.Header().Get("ETag"); got != `"persisted-etag"` {
+		t.Fatalf("expected persisted ETag header, got %q", got)
 	}
 	if got := w.Header().Get("x-amz-meta-owner"); got != "alice" {
 		t.Fatalf("expected stored metadata, got %q", got)

--- a/api-go/internal/handlers/s3_test.go
+++ b/api-go/internal/handlers/s3_test.go
@@ -251,6 +251,17 @@ func TestFileListBucketEntryAndObjectETag(t *testing.T) {
 	if manager.ObjectETag(changed) == entry.ETag {
 		t.Fatal("expected ETag to change when chunk metadata changes")
 	}
+
+	file.ETag = `"persisted-etag"`
+	entry = fileListBucketEntry(file)
+	if entry.ETag != file.ETag {
+		t.Fatalf("expected list entry to use persisted ETag %s, got %s", file.ETag, entry.ETag)
+	}
+	changed = file
+	changed.Chunks[1].Size = 6
+	if manager.ObjectETag(changed) != file.ETag {
+		t.Fatal("expected persisted ETag to remain stable when lifecycle metadata changes")
+	}
 }
 
 func TestBuildListBucketPageDelimiterCommonPrefixes(t *testing.T) {

--- a/api-go/internal/manager/s3_object.go
+++ b/api-go/internal/manager/s3_object.go
@@ -169,6 +169,7 @@ func (s *ObjectService) PutObject(ctx context.Context, bucket *repository.Bucket
 		ContentType:  contentType,
 		UserMetadata: cloneStringMap(userMetadata),
 	}
+	fileDoc.ETag = newObjectETag(fileDoc)
 	currentFile, previousFile, err := s.files.ReplaceByName(ctx, fileDoc)
 	if err != nil {
 		_ = s.deleteChunks(ctx, chunks)
@@ -248,6 +249,7 @@ func (s *ObjectService) CopyObject(ctx context.Context, sourceBucket, destBucket
 		ContentType:  sourceFile.ContentType,
 		UserMetadata: cloneStringMap(sourceFile.UserMetadata),
 	}
+	copyFile.ETag = copyObjectETag(*sourceFile)
 	currentFile, previousFile, err := s.files.ReplaceByName(ctx, copyFile)
 	if err != nil {
 		return CopyObjectResult{}, err
@@ -388,11 +390,13 @@ func (s *ObjectService) CompleteMultipartUploadRecord(ctx context.Context, bucke
 		}
 	}
 
+	etag := multipartETag(requestedParts, partMap)
 	fileDoc := repository.File{
 		BucketID:     bucketID,
 		Name:         mu.ObjectKey,
 		CreatedAt:    s.now(),
 		Chunks:       allChunks,
+		ETag:         etag,
 		ContentType:  mu.ContentType,
 		UserMetadata: cloneStringMap(mu.UserMetadata),
 	}
@@ -426,7 +430,7 @@ func (s *ObjectService) CompleteMultipartUploadRecord(ctx context.Context, bucke
 	return CompleteMultipartUploadResult{
 		File:        *saved,
 		Upload:      *mu,
-		ETag:        multipartETag(requestedParts, partMap),
+		ETag:        etag,
 		CleanupErrs: cleanupErrs,
 	}, nil
 }
@@ -516,6 +520,44 @@ func bucketCleanupChunks(files []repository.File, uploads []repository.Multipart
 }
 
 func ObjectETag(file repository.File) string {
+	if file.ETag != "" {
+		return file.ETag
+	}
+	return legacyObjectETag(file)
+}
+
+func newObjectETag(file repository.File) string {
+	if etag, ok := checksumObjectETag(file.Chunks); ok {
+		return etag
+	}
+	return legacyObjectETag(file)
+}
+
+func copyObjectETag(source repository.File) string {
+	if source.ETag != "" {
+		return source.ETag
+	}
+	if etag, ok := checksumObjectETag(source.Chunks); ok {
+		return etag
+	}
+	return legacyObjectETag(source)
+}
+
+func checksumObjectETag(chunks []repository.FileChunk) (string, bool) {
+	h := sha256.New()
+	for _, chunk := range chunks {
+		if chunk.Checksum == "" {
+			return "", false
+		}
+		_, _ = h.Write([]byte(chunk.Checksum))
+		_, _ = h.Write([]byte(":"))
+		_, _ = h.Write([]byte(strconv.FormatInt(chunk.Size, 10)))
+		_, _ = h.Write([]byte(";"))
+	}
+	return "\"" + hex.EncodeToString(h.Sum(nil)) + "\"", true
+}
+
+func legacyObjectETag(file repository.File) string {
 	h := sha256.New()
 	_, _ = h.Write([]byte(file.Name))
 	_, _ = h.Write([]byte(file.CreatedAt.UTC().Format(time.RFC3339Nano)))

--- a/api-go/internal/manager/s3_object_test.go
+++ b/api-go/internal/manager/s3_object_test.go
@@ -465,6 +465,52 @@ func TestObjectServicePutObjectUpdatesFileAndDeletesOldChunks(t *testing.T) {
 	}
 }
 
+func TestObjectServicePutObjectPersistsChecksumETagIndependentOfLifecycleMetadata(t *testing.T) {
+	bucketID := primitive.NewObjectID()
+	sourceID := primitive.NewObjectID()
+	files := newFakeObjectFiles()
+	var deleted []repository.FileChunk
+	svc := testObjectService(files, &deleted)
+	names := []string{"first-provider-name", "second-provider-name"}
+	uploadCalls := 0
+	svc.uploadChunks = func(_ context.Context, r io.Reader, _ []repository.Source, _ int, _ SourceSelector) ([]repository.FileChunk, error) {
+		if _, err := io.Copy(io.Discard, r); err != nil {
+			return nil, err
+		}
+		name := names[uploadCalls]
+		uploadCalls++
+		return []repository.FileChunk{{SourceID: sourceID, Name: name, Size: 4, Checksum: "same-content-checksum"}}, nil
+	}
+	times := []time.Time{
+		time.Date(2026, 4, 21, 12, 0, 0, 0, time.UTC),
+		time.Date(2026, 4, 22, 12, 0, 0, 0, time.UTC),
+	}
+	nowCalls := 0
+	svc.now = func() time.Time {
+		tm := times[nowCalls]
+		nowCalls++
+		return tm
+	}
+
+	first, err := svc.PutObject(context.Background(), &repository.Bucket{ID: bucketID}, "object.txt", bytes.NewBufferString("data"), 5, "text/plain", nil)
+	if err != nil {
+		t.Fatalf("first PutObject returned error: %v", err)
+	}
+	second, err := svc.PutObject(context.Background(), &repository.Bucket{ID: bucketID}, "object.txt", bytes.NewBufferString("data"), 5, "text/plain", nil)
+	if err != nil {
+		t.Fatalf("second PutObject returned error: %v", err)
+	}
+	if first.File.ETag == "" {
+		t.Fatal("expected first put to persist an ETag")
+	}
+	if second.File.ETag != first.File.ETag {
+		t.Fatalf("expected same content checksum to keep ETag stable, first=%s second=%s", first.File.ETag, second.File.ETag)
+	}
+	if ObjectETag(second.File) != second.File.ETag {
+		t.Fatalf("expected served ETag to use persisted value")
+	}
+}
+
 func TestObjectServicePutObjectOverwriteReplacesMetadata(t *testing.T) {
 	bucketID := primitive.NewObjectID()
 	existing := repository.File{
@@ -535,8 +581,9 @@ func TestObjectServiceCopyObjectPreservesChunksAndCleansOverwrittenDestination(t
 	destBucketID := primitive.NewObjectID()
 	sourceChunk := repository.FileChunk{SourceID: primitive.NewObjectID(), Name: "source-chunk", Size: 12}
 	oldDestChunk := repository.FileChunk{SourceID: primitive.NewObjectID(), Name: "old-dest-chunk", Size: 8}
+	sourceETag := `"source-etag"`
 	files := newFakeObjectFiles(
-		repository.File{ID: primitive.NewObjectID(), BucketID: sourceBucketID, Name: "source.txt", ContentType: "image/png", UserMetadata: map[string]string{"owner": "alice"}, Chunks: []repository.FileChunk{sourceChunk}},
+		repository.File{ID: primitive.NewObjectID(), BucketID: sourceBucketID, Name: "source.txt", ETag: sourceETag, ContentType: "image/png", UserMetadata: map[string]string{"owner": "alice"}, Chunks: []repository.FileChunk{sourceChunk}},
 		repository.File{ID: primitive.NewObjectID(), BucketID: destBucketID, Name: "dest.txt", Chunks: []repository.FileChunk{oldDestChunk}},
 	)
 	var deleted []repository.FileChunk
@@ -558,8 +605,44 @@ func TestObjectServiceCopyObjectPreservesChunksAndCleansOverwrittenDestination(t
 	if result.File.ContentType != "image/png" || result.File.UserMetadata["owner"] != "alice" {
 		t.Fatalf("expected copied metadata, got content_type=%q metadata=%#v", result.File.ContentType, result.File.UserMetadata)
 	}
+	if result.File.ETag != sourceETag {
+		t.Fatalf("expected copy to preserve source ETag, got %s", result.File.ETag)
+	}
 	if len(deleted) != 1 || deleted[0].Name != oldDestChunk.Name {
 		t.Fatalf("expected overwritten destination chunk cleanup, got %#v", deleted)
+	}
+}
+
+func TestObjectServiceCopyObjectDerivesChecksumETagForLegacySource(t *testing.T) {
+	userID := primitive.NewObjectID()
+	sourceBucketID := primitive.NewObjectID()
+	destBucketID := primitive.NewObjectID()
+	sourceChunk := repository.FileChunk{SourceID: primitive.NewObjectID(), Name: "source-provider-name", Size: 12, Checksum: "content-checksum"}
+	files := newFakeObjectFiles(
+		repository.File{
+			ID:        primitive.NewObjectID(),
+			BucketID:  sourceBucketID,
+			Name:      "source.txt",
+			CreatedAt: time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC),
+			Chunks:    []repository.FileChunk{sourceChunk},
+		},
+	)
+	var deleted []repository.FileChunk
+	svc := testObjectService(files, &deleted)
+
+	result, err := svc.CopyObject(
+		context.Background(),
+		&repository.Bucket{ID: sourceBucketID, UserID: userID},
+		&repository.Bucket{ID: destBucketID, UserID: userID},
+		"source.txt",
+		"dest.txt",
+	)
+	if err != nil {
+		t.Fatalf("CopyObject returned error: %v", err)
+	}
+	want := newObjectETag(repository.File{Chunks: []repository.FileChunk{sourceChunk}})
+	if result.File.ETag != want {
+		t.Fatalf("expected checksum-derived destination ETag %s, got %s", want, result.File.ETag)
 	}
 }
 
@@ -853,6 +936,12 @@ func TestObjectServiceCompleteMultipartUploadBuildsFinalFileAndCleansUnusedChunk
 	}
 	if !strings.HasSuffix(result.ETag, `-2"`) {
 		t.Fatalf("unexpected multipart etag: %s", result.ETag)
+	}
+	if result.File.ETag != result.ETag {
+		t.Fatalf("expected multipart completion ETag to be persisted, file=%s result=%s", result.File.ETag, result.ETag)
+	}
+	if ObjectETag(result.File) != result.ETag {
+		t.Fatalf("expected served object ETag to match multipart completion ETag")
 	}
 	if _, err := svc.multipart.GetByUploadID(context.Background(), "upload-1"); !errors.Is(err, mongo.ErrNoDocuments) {
 		t.Fatalf("expected multipart upload record cleanup, got %v", err)

--- a/api-go/internal/repository/file.go
+++ b/api-go/internal/repository/file.go
@@ -28,6 +28,7 @@ type File struct {
 	Name         string             `bson:"name"`
 	CreatedAt    time.Time          `bson:"created_at"`
 	Chunks       []FileChunk        `bson:"chunks"`
+	ETag         string             `bson:"etag,omitempty"`
 	ContentType  string             `bson:"content_type,omitempty"`
 	UserMetadata map[string]string  `bson:"user_metadata,omitempty"`
 }
@@ -278,6 +279,7 @@ func (r *FileRepository) UpdateByID(ctx context.Context, f File) (*File, error) 
 		"name":          f.Name,
 		"created_at":    f.CreatedAt,
 		"chunks":        f.Chunks,
+		"etag":          f.ETag,
 		"content_type":  f.ContentType,
 		"user_metadata": f.UserMetadata,
 	}})
@@ -324,6 +326,7 @@ func (r *FileRepository) replaceByName(ctx context.Context, f File, upsert bool)
 			"name":          f.Name,
 			"created_at":    f.CreatedAt,
 			"chunks":        f.Chunks,
+			"etag":          f.ETag,
 			"content_type":  f.ContentType,
 			"user_metadata": f.UserMetadata,
 		},


### PR DESCRIPTION
## Summary

- Persist a canonical `etag` on `repository.File` and reuse it for S3 HEAD/GET/list/CopyObject responses.
- Store checksum-derived ETags for single PUT objects and persist the multipart completion ETag on completed multipart objects.
- Preserve stored source ETags on CopyObject, with checksum-derived ETags for legacy source objects that have chunk checksums and legacy fallback for older rows.
- Add focused manager and handler tests for ETag stability across PUT, CopyObject, multipart completion, GET headers, and list entries.

## Local validation

- `gofmt -w api-go/internal/repository/file.go api-go/internal/manager/s3_object.go api-go/internal/manager/s3_object_test.go api-go/internal/handlers/s3_test.go api-go/internal/handlers/s3_get_test.go`
- `git diff --check`

Go tests were not run locally per the task/resource instruction to avoid CPU-heavy validation; Woodpecker should run the backend validation.