### PR TITLE
THE-748 Reject duplicate bucket source IDs

### DIFF
--- a/api-go/internal/handlers/bucket.go
+++ b/api-go/internal/handlers/bucket.go
@@ -1,10 +1,12 @@
 package handlers
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
+	"reflect"
 	"strings"
 	"time"
 
@@ -28,6 +30,10 @@ type createBucketResponse struct {
 	AccessKey    string    `json:"access_key"`
 	AccessSecret string    `json:"access_secret"`
 	CreatedAt    time.Time `json:"created_at"`
+}
+
+type bucketCreator interface {
+	Create(context.Context, repository.Bucket) (*repository.Bucket, error)
 }
 
 type bucketResponse struct {
@@ -91,6 +97,19 @@ func respondBadSourceWeights(c *gin.Context, err error) bool {
 	return true
 }
 
+func isNilDependency(dep any) bool {
+	if dep == nil {
+		return true
+	}
+	value := reflect.ValueOf(dep)
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice:
+		return value.IsNil()
+	default:
+		return false
+	}
+}
+
 // CreateBucket godoc
 // @Summary Create bucket
 // @Tags buckets
@@ -103,7 +122,7 @@ func respondBadSourceWeights(c *gin.Context, err error) bool {
 // @Failure 409 {string} string ""
 // @Security BasicAuth
 // @Router /api/v1/buckets [post]
-func CreateBucket(repo *repository.BucketRepository, sourceRepo *repository.SourceRepository, secretKey string) gin.HandlerFunc {
+func CreateBucket(repo bucketCreator, sourceRepo sourceGetter, secretKey string) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		ctx := c.Request.Context()
 		var req createBucketRequest
@@ -112,7 +131,7 @@ func CreateBucket(repo *repository.BucketRepository, sourceRepo *repository.Sour
 			c.Status(http.StatusBadRequest)
 			return
 		}
-		if repo == nil || sourceRepo == nil {
+		if isNilDependency(repo) || isNilDependency(sourceRepo) {
 			slog.ErrorContext(ctx, "create bucket: repository is nil")
 			c.Status(http.StatusServiceUnavailable)
 			return
@@ -140,6 +159,7 @@ func CreateBucket(repo *repository.BucketRepository, sourceRepo *repository.Sour
 			return
 		}
 		sourceIDs := make([]primitive.ObjectID, 0, len(req.SourceIDs))
+		seenSourceIDs := make(map[primitive.ObjectID]struct{}, len(req.SourceIDs))
 		for _, sourceIDHex := range req.SourceIDs {
 			sourceID, err := primitive.ObjectIDFromHex(sourceIDHex)
 			if err != nil {
@@ -160,6 +180,11 @@ func CreateBucket(repo *repository.BucketRepository, sourceRepo *repository.Sour
 				c.Status(http.StatusBadRequest)
 				return
 			}
+			if _, ok := seenSourceIDs[sourceID]; ok {
+				c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("source_ids contains duplicate source id %q", sourceIDHex)})
+				return
+			}
+			seenSourceIDs[sourceID] = struct{}{}
 			sourceIDs = append(sourceIDs, sourceID)
 		}
 		strategy := repository.DistributionStrategy(req.DistributionStrategy)

--- a/api-go/internal/handlers/unit_test.go
+++ b/api-go/internal/handlers/unit_test.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -10,10 +11,35 @@ import (
 	"github.com/example/sfree/api-go/internal/repository"
 	"github.com/gin-gonic/gin"
 	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
 )
 
 func init() {
 	gin.SetMode(gin.TestMode)
+}
+
+type fakeBucketCreator struct {
+	createCalls int
+}
+
+func (f *fakeBucketCreator) Create(_ context.Context, bucket repository.Bucket) (*repository.Bucket, error) {
+	f.createCalls++
+	if bucket.ID.IsZero() {
+		bucket.ID = primitive.NewObjectID()
+	}
+	return &bucket, nil
+}
+
+type fakeBucketSourceGetter struct {
+	sources map[primitive.ObjectID]repository.Source
+}
+
+func (f fakeBucketSourceGetter) GetByID(_ context.Context, id primitive.ObjectID) (*repository.Source, error) {
+	source, ok := f.sources[id]
+	if !ok {
+		return nil, mongo.ErrNoDocuments
+	}
+	return &source, nil
 }
 
 // --- Source handler unit tests ---
@@ -335,6 +361,24 @@ func TestCreateBucketNilRepos(t *testing.T) {
 	}
 }
 
+func TestCreateBucketTypedNilRepos(t *testing.T) {
+	t.Parallel()
+	var bucketRepo *repository.BucketRepository
+	var sourceRepo *repository.SourceRepository
+	r := gin.New()
+	r.POST("/buckets", setUserID(validUserID()), CreateBucket(bucketRepo, sourceRepo, "secret"))
+
+	body, _ := json.Marshal(map[string]any{"key": "k", "source_ids": []string{primitive.NewObjectID().Hex()}})
+	req, _ := http.NewRequest(http.MethodPost, "/buckets", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d", w.Code)
+	}
+}
+
 func TestCreateBucketNoUserID(t *testing.T) {
 	t.Parallel()
 	r := gin.New()
@@ -344,6 +388,79 @@ func TestCreateBucketNoUserID(t *testing.T) {
 
 	if w.Code != http.StatusUnauthorized {
 		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestCreateBucketRejectsDuplicateSourceIDs(t *testing.T) {
+	t.Parallel()
+	userID := primitive.NewObjectID()
+	sourceID := primitive.NewObjectID()
+	bucketRepo := &fakeBucketCreator{}
+	sourceRepo := fakeBucketSourceGetter{sources: map[primitive.ObjectID]repository.Source{
+		sourceID: {
+			ID:     sourceID,
+			UserID: userID,
+			Type:   repository.SourceTypeGDrive,
+			Name:   "owned-source",
+			Key:    "{}",
+		},
+	}}
+	r := gin.New()
+	r.POST("/buckets", setUserID(userID.Hex()), CreateBucket(bucketRepo, sourceRepo, "secret"))
+
+	body, _ := json.Marshal(map[string]any{"key": "k", "source_ids": []string{sourceID.Hex(), sourceID.Hex()}})
+	req, _ := http.NewRequest(http.MethodPost, "/buckets", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+	if !bytes.Contains(w.Body.Bytes(), []byte("duplicate source id")) {
+		t.Fatalf("expected duplicate source id error, got %q", w.Body.String())
+	}
+	if bucketRepo.createCalls != 0 {
+		t.Fatalf("expected bucket not to be created, got %d create calls", bucketRepo.createCalls)
+	}
+}
+
+func TestCreateBucketAllowsMultipleDistinctSources(t *testing.T) {
+	t.Parallel()
+	userID := primitive.NewObjectID()
+	firstSourceID := primitive.NewObjectID()
+	secondSourceID := primitive.NewObjectID()
+	bucketRepo := &fakeBucketCreator{}
+	sourceRepo := fakeBucketSourceGetter{sources: map[primitive.ObjectID]repository.Source{
+		firstSourceID: {
+			ID:     firstSourceID,
+			UserID: userID,
+			Type:   repository.SourceTypeGDrive,
+			Name:   "first-source",
+			Key:    "{}",
+		},
+		secondSourceID: {
+			ID:     secondSourceID,
+			UserID: userID,
+			Type:   repository.SourceTypeS3,
+			Name:   "second-source",
+			Key:    "{}",
+		},
+	}}
+	r := gin.New()
+	r.POST("/buckets", setUserID(userID.Hex()), CreateBucket(bucketRepo, sourceRepo, "secret"))
+
+	body, _ := json.Marshal(map[string]any{"key": "k", "source_ids": []string{firstSourceID.Hex(), secondSourceID.Hex()}})
+	req, _ := http.NewRequest(http.MethodPost, "/buckets", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if bucketRepo.createCalls != 1 {
+		t.Fatalf("expected one bucket create call, got %d", bucketRepo.createCalls)
 	}
 }
 

--- a/api-go/internal/manager/s3_object_test.go
+++ b/api-go/internal/manager/s3_object_test.go
@@ -542,7 +542,7 @@ func TestObjectServicePutObjectUpdatesFileAndDeletesOldChunks(t *testing.T) {
 
 func TestObjectServicePutObjectPersistsChecksumETagIndependentOfLifecycleMetadata(t *testing.T) {
 	bucketID := primitive.NewObjectID()
-	sourceID := primitive.NewObjectID()
+	sourceID := objectServiceTestSourceID
 	files := newFakeObjectFiles()
 	var deleted []repository.FileChunk
 	svc := testObjectService(files, &deleted)


### PR DESCRIPTION
## Summary
- reject duplicate `source_ids` during bucket creation with a 400 validation error
- narrow create-bucket handler dependencies to method interfaces for focused handler tests
- add handler coverage for duplicate owned source IDs and distinct multi-source creation
- update one manager test fixture so it uses a configured bucket source under the current source-resolution guard

## Local validation
- `gofmt -w api-go/internal/handlers/bucket.go api-go/internal/handlers/unit_test.go api-go/internal/manager/s3_object_test.go`
- `git diff --check`

Full backend validation is left to Woodpecker per task instructions.