### PR TITLE
THE-753 Add chunk reference Mongo indexes

### DIFF
--- a/api-go/internal/repository/file.go
+++ b/api-go/internal/repository/file.go
@@ -36,17 +36,28 @@ type FileRepository struct {
 	coll *mongo.Collection
 }
 
-const fileBucketNameUniqueIndex = "bucket_id_name_unique"
+const (
+	fileBucketNameUniqueIndex = "bucket_id_name_unique"
+	fileChunkReferenceIndex   = "chunks_source_id_name"
+)
 
 func NewFileRepository(db *mongo.Database) (*FileRepository, error) {
 	coll := db.Collection("files")
-	_, err := coll.Indexes().CreateOne(context.Background(), mongo.IndexModel{
-		Keys: bson.D{{Key: "bucket_id", Value: 1}},
+	ctx := context.Background()
+	_, err := coll.Indexes().CreateMany(ctx, []mongo.IndexModel{
+		{
+			Keys: bson.D{{Key: "bucket_id", Value: 1}},
+		},
+		{
+			Keys: bson.D{{Key: "chunks.source_id", Value: 1}, {Key: "chunks.name", Value: 1}},
+			Options: options.Index().
+				SetName(fileChunkReferenceIndex),
+		},
 	})
 	if err != nil {
 		return nil, err
 	}
-	if err := ensureUniqueFileBucketNameIndex(context.Background(), coll); err != nil {
+	if err := ensureUniqueFileBucketNameIndex(ctx, coll); err != nil {
 		return nil, err
 	}
 	return &FileRepository{coll: coll}, nil

--- a/api-go/internal/repository/file_test.go
+++ b/api-go/internal/repository/file_test.go
@@ -128,6 +128,14 @@ func TestFileRepositoryMigratesLegacyBucketNameIndex(t *testing.T) {
 	}
 }
 
+func TestFileRepositoryCreatesChunkReferenceIndex(t *testing.T) {
+	testDB, _ := newFileRepositoryTestDB(t)
+	assertMongoIndex(t, testDB.Collection("files"), fileChunkReferenceIndex, bson.D{
+		{Key: "chunks.source_id", Value: 1},
+		{Key: "chunks.name", Value: 1},
+	})
+}
+
 func TestFileRepositoryListByBucketByNameQuery(t *testing.T) {
 	_, repo := newFileRepositoryTestDB(t)
 	ctx := context.Background()
@@ -190,6 +198,48 @@ func newFileRepositoryTestDB(t *testing.T) (*mongo.Database, *FileRepository) {
 		t.Fatal(err)
 	}
 	return testDB, repo
+}
+
+func assertMongoIndex(t *testing.T, coll *mongo.Collection, name string, want bson.D) {
+	t.Helper()
+	cursor, err := coll.Indexes().List(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = cursor.Close(context.Background()) }()
+
+	for cursor.Next(context.Background()) {
+		var idx indexInfo
+		if err := cursor.Decode(&idx); err != nil {
+			t.Fatal(err)
+		}
+		if idx.Name != name {
+			continue
+		}
+		if !indexKeysEqual(idx.Key, want) {
+			t.Fatalf("index %q keys: got %v, want %v", name, idx.Key, want)
+		}
+		return
+	}
+	if err := cursor.Err(); err != nil {
+		t.Fatal(err)
+	}
+	t.Fatalf("missing index %q", name)
+}
+
+func indexKeysEqual(got, want bson.D) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range want {
+		if got[i].Key != want[i].Key {
+			return false
+		}
+		if !indexValueIsOne(got[i].Value) || !indexValueIsOne(want[i].Value) {
+			return false
+		}
+	}
+	return true
 }
 
 func assertFileNames(t *testing.T, files []File, want []string) {

--- a/api-go/internal/repository/multipart.go
+++ b/api-go/internal/repository/multipart.go
@@ -32,6 +32,8 @@ type MultipartUploadRepository struct {
 	coll *mongo.Collection
 }
 
+const multipartPartChunkNameBucketIndex = "parts_chunks_name_bucket_id"
+
 func NewMultipartUploadRepository(db *mongo.Database) (*MultipartUploadRepository, error) {
 	coll := db.Collection("multipart_uploads")
 	_, err := coll.Indexes().CreateMany(context.Background(), []mongo.IndexModel{
@@ -41,6 +43,11 @@ func NewMultipartUploadRepository(db *mongo.Database) (*MultipartUploadRepositor
 		},
 		{
 			Keys: bson.D{{Key: "bucket_id", Value: 1}},
+		},
+		{
+			Keys: bson.D{{Key: "parts.chunks.name", Value: 1}, {Key: "bucket_id", Value: 1}},
+			Options: options.Index().
+				SetName(multipartPartChunkNameBucketIndex),
 		},
 	})
 	if err != nil {

--- a/api-go/internal/repository/multipart_test.go
+++ b/api-go/internal/repository/multipart_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/example/sfree/api-go/internal/config"
 	"github.com/example/sfree/api-go/internal/db"
+	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 )
@@ -107,6 +108,14 @@ func TestMultipartUploadRepositorySetPartReplacesWithoutDroppingParts(t *testing
 	if err != mongo.ErrNoDocuments {
 		t.Fatalf("expected ErrNoDocuments for missing upload, got %v", err)
 	}
+}
+
+func TestMultipartUploadRepositoryCreatesPartChunkReferenceIndex(t *testing.T) {
+	testDB, _ := newMultipartRepositoryTestDB(t)
+	assertMongoIndex(t, testDB.Collection("multipart_uploads"), multipartPartChunkNameBucketIndex, bson.D{
+		{Key: "parts.chunks.name", Value: 1},
+		{Key: "bucket_id", Value: 1},
+	})
 }
 
 func assertMultipartPart(t *testing.T, parts []UploadPart, partNumber int, etag string, chunkName string) {


### PR DESCRIPTION
## Summary
- add a compound multikey index for file chunk cleanup lookups on `chunks.source_id` + `chunks.name`
- add a multipart cleanup fallback index on `parts.chunks.name` + `bucket_id`
- add focused integration tests that assert the expected index names and key specs on fresh databases

## Mongo multikey note
MongoDB allows a compound multikey index when the indexed fields share one array of embedded documents, which fits `files.chunks`. The multipart shape nests chunks under `parts[]`, so a compound source/name index risks the multiple-array-field restriction documented for compound multikey indexes. The PR uses `parts.chunks.name` with scalar `bucket_id` as a safe fallback: chunk name narrows the cleanup query candidates while bucket id supports the excluding-bucket path, with source id still applied by the query filter.

## Validation
- `gofmt -w api-go/internal/repository/file.go api-go/internal/repository/file_test.go api-go/internal/repository/multipart.go api-go/internal/repository/multipart_test.go`
- `git diff --check`

Local integration/full backend tests were not run per resource policy; Woodpecker should run backend validation for the PR.

Refs [THE-753](/THE/issues/THE-753).