### PR TITLE
THE-764 Reduce main branch CI load

### DIFF
--- a/.woodpecker/api-go.yml
+++ b/.woodpecker/api-go.yml
@@ -15,18 +15,24 @@ when:
 steps:
   - name: lint
     image: golangci/golangci-lint:v2.11.4-alpine
+    when:
+      - event: pull_request
     commands:
       - cd api-go
       - golangci-lint run
 
   - name: unit tests
     image: public.ecr.aws/docker/library/golang:1.25
+    when:
+      - event: pull_request
     commands:
       - cd api-go
       - go test ./...
 
   - name: dependency audit
     image: public.ecr.aws/docker/library/golang:1.25
+    when:
+      - event: pull_request
     commands:
       - cd api-go
       - go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
@@ -34,12 +40,25 @@ steps:
 
   - name: api docs freshness
     image: public.ecr.aws/docker/library/golang:1.25
+    when:
+      - event: pull_request
     commands:
       - cd api-go
       - make docs-check
 
+  - name: docker
+    image: public.ecr.aws/docker/library/docker:27-dind
+    privileged: true
+    detach: true
+    environment:
+      DOCKER_TLS_CERTDIR: ""
+    when:
+      - event: pull_request
+
   - name: e2e tests
     image: public.ecr.aws/docker/library/docker:27-cli
+    when:
+      - event: pull_request
     environment:
       DOCKER_HOST: tcp://docker:2375
       DOCKER_TLS_CERTDIR: ""
@@ -58,6 +77,8 @@ steps:
 
   - name: go e2e tests (s3)
     image: public.ecr.aws/docker/library/docker:27-cli
+    when:
+      - event: pull_request
     environment:
       DOCKER_HOST: tcp://docker:2375
       DOCKER_TLS_CERTDIR: ""
@@ -86,10 +107,3 @@ steps:
       context: api-go
       dockerfile: api-go/Dockerfile
       tag: main
-
-services:
-  - name: docker
-    image: public.ecr.aws/docker/library/docker:27-dind
-    privileged: true
-    environment:
-      DOCKER_TLS_CERTDIR: ""

--- a/.woodpecker/smoke.yml
+++ b/.woodpecker/smoke.yml
@@ -8,18 +8,6 @@ when:
         - docs/**
         - api-go/**
         - webui/**
-
-  - event: push
-    branch: main
-    path:
-      include:
-        - .woodpecker/smoke.yml
-        - docker-compose.yml
-        - scripts/woodpecker-smoke.sh
-        - docs/**
-        - api-go/**
-        - webui/**
-
 steps:
   - name: stack smoke
     image: public.ecr.aws/docker/library/docker:27-cli

--- a/.woodpecker/webui.yml
+++ b/.woodpecker/webui.yml
@@ -15,6 +15,8 @@ when:
 steps:
   - name: validate
     image: node:20
+    when:
+      - event: pull_request
     commands:
       - cd webui
       - npm ci --include=dev
@@ -24,6 +26,8 @@ steps:
 
   - name: e2e tests
     image: node:20
+    when:
+      - event: pull_request
     commands:
       - cd webui
       - npm ci --include=dev

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -7,9 +7,9 @@ Actions workflows to this repository.
 
 | Pipeline | Paths | `pull_request` | `push` to `main` | Behavior |
 | --- | --- | --- | --- | --- |
-| `.woodpecker/api-go.yml` | `.woodpecker/api-go.yml`, `api-go/**` | Yes | Yes | Runs `golangci-lint run`, Go unit tests, blocking `govulncheck` dependency auditing, generated API docs freshness, and Python and Go E2E suites against the local S3-compatible MinIO source. Pushes to `main` also publish the backend image. |
-| `.woodpecker/webui.yml` | `.woodpecker/webui.yml`, `webui/**` | Yes | Yes | Runs frontend dependency install, `npm audit --audit-level=high`, lint, and production build in `validate`, then runs Chromium Playwright E2E validation in `e2e tests`. Pushes to `main` also publish the frontend image. |
-| `.woodpecker/smoke.yml` | `.woodpecker/smoke.yml`, `docker-compose.yml`, `scripts/woodpecker-smoke.sh`, `api-go/**`, `webui/**` | Yes | Yes | Starts the root Compose stack in Woodpecker, creates a user and MinIO-backed source, creates a bucket, uploads and downloads a file with the CLI, and verifies S3-compatible credential download bytes. |
+| `.woodpecker/api-go.yml` | `.woodpecker/api-go.yml`, `api-go/**` | Yes | Publish only | PRs run `golangci-lint run`, Go unit tests, blocking `govulncheck` dependency auditing, generated API docs freshness, and Python and Go E2E suites against the local S3-compatible MinIO source. Pushes to `main` publish the backend image without rerunning validation. |
+| `.woodpecker/webui.yml` | `.woodpecker/webui.yml`, `webui/**` | Yes | Publish only | PRs run frontend dependency install, `npm audit --audit-level=high`, lint, and production build in `validate`, then run Chromium Playwright E2E validation in `e2e tests`. Pushes to `main` publish the frontend image without rerunning validation. |
+| `.woodpecker/smoke.yml` | `.woodpecker/smoke.yml`, `docker-compose.yml`, `scripts/woodpecker-smoke.sh`, `docs/**`, `api-go/**`, `webui/**` | Yes | No | PRs start the root Compose stack in Woodpecker, create a user and MinIO-backed source, create a bucket, upload and download a file with the CLI, and verify S3-compatible credential download bytes. |
 
 ## Required Secrets
 
@@ -45,8 +45,8 @@ manual or non-blocking validation. Those modes require:
 Do not put live source checks in the required PR path unless the external
 service dependency is deliberately accepted as a merge blocker.
 
-The stack smoke pipeline uses only local Woodpecker services and does not need
-repository secrets.
+The stack smoke pipeline runs only for pull requests. It uses local Woodpecker
+services and does not need repository secrets.
 
 ## Dependency Audits
 
@@ -62,7 +62,8 @@ reproduce the CI failure; otherwise leave dependency auditing to Woodpecker.
 
 ## Published Images
 
-Pushes to `main` publish these images to GitHub Container Registry:
+Pushes to `main` publish these images to GitHub Container Registry without
+rerunning the PR validation suites:
 
 - `ghcr.io/siberianbearofficial/sfree-api-go:main`
 - `ghcr.io/siberianbearofficial/sfree-webui:main`


### PR DESCRIPTION
## Summary
- keep API Go, web UI, and stack smoke validation scoped to pull request events
- keep main-branch GHCR publishing for API Go and web UI images
- update docs/ci.md to describe PR verification versus main publish-only behavior

## Expected Woodpecker behavior
- Pull requests still run API Go lint/unit/docs/E2E, web UI validate/E2E, and stack smoke checks with existing path filters.
- Pushes to main no longer rerun lint/unit/E2E/smoke validation.
- Pushes to main still publish ghcr.io/siberianbearofficial/sfree-api-go:main and ghcr.io/siberianbearofficial/sfree-webui:main.

## Validation
- git diff --check
- Static diff review only for CI behavior. Per task constraints, I did not run Docker, Compose, Playwright, npm, or Go validation locally. No local Woodpecker/YAML linter was installed in the workspace.