### PR TITLE
Fix api-go server time import

### DIFF
--- a/api-go/cmd/server/main.go
+++ b/api-go/cmd/server/main.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/example/sfree/api-go/internal/app"
 	"github.com/example/sfree/api-go/internal/config"


### PR DESCRIPTION
## Summary

- Add the missing `time` import used by `shutdownTimeout` and `runServer` in `api-go/cmd/server/main.go`

## Validation

- Not run locally per resource policy; Woodpecker should validate the server compile path.

Related Paperclip issue: [THE-767](/THE/issues/THE-767)