### PR TITLE
THE-512 Add aiobotocore presigned URL compatibility coverage

### DIFF
--- a/api-go/e2e/sfree_client.py
+++ b/api-go/e2e/sfree_client.py
@@ -242,6 +242,34 @@ class SFreeClient:
                 payload["Metadata"] = metadata
             await s3_client.put_object(**payload)
 
+    async def generate_presigned_url_s3(
+        self,
+        access_key: str,
+        access_secret: str,
+        client_method: str,
+        params: dict[str, Any],
+        expires_in: int = 3600,
+        http_method: str | None = None,
+    ) -> str:
+        session = get_session()
+        async with session.create_client(
+            "s3",
+            **self._s3_client_kwargs(
+                region="us-east-1",
+                endpoint=self.config.s3_url,
+                access_key=access_key,
+                access_secret=access_secret,
+            ),
+        ) as s3_client:
+            payload: dict[str, Any] = {
+                "ClientMethod": client_method,
+                "Params": params,
+                "ExpiresIn": expires_in,
+            }
+            if http_method is not None:
+                payload["HttpMethod"] = http_method
+            return await s3_client.generate_presigned_url(**payload)
+
     async def delete_object_s3(self, access_key: str, access_secret: str, bucket_key: str, object_key: str) -> None:
         session = get_session()
         async with session.create_client(

--- a/api-go/e2e/sfree_client.py
+++ b/api-go/e2e/sfree_client.py
@@ -77,6 +77,7 @@ class SFreeClient:
                 connect_timeout=3,
                 read_timeout=30,
                 retries={"max_attempts": 3, "mode": "standard"},
+                signature_version="s3v4",
             ),
         }
 

--- a/api-go/e2e/test_api_e2e.py
+++ b/api-go/e2e/test_api_e2e.py
@@ -252,6 +252,44 @@ async def test_s3_sdk_head_object_returns_metadata(client, e2e_context):
     assert response["LastModified"]
 
 
+async def test_s3_sdk_presigned_put_and_get_urls(client, e2e_context):
+    filename = f"e2e-sdk-presign-{uuid4().hex[:8]}.txt"
+    payload = b"sfree sdk presign payload"
+
+    presigned_put_url = await client.generate_presigned_url_s3(
+        access_key=e2e_context.access_key,
+        access_secret=e2e_context.access_secret,
+        client_method="put_object",
+        params={"Bucket": e2e_context.bucket_key, "Key": filename},
+        http_method="PUT",
+    )
+    async with client._http.put(presigned_put_url, data=payload) as put_response:
+        assert put_response.status == 200
+        await put_response.read()
+
+    assert await client.download_file_s3(
+        access_key=e2e_context.access_key,
+        access_secret=e2e_context.access_secret,
+        bucket_key=e2e_context.bucket_key,
+        object_key=filename,
+    ) == payload
+
+    presigned_get_url = await client.generate_presigned_url_s3(
+        access_key=e2e_context.access_key,
+        access_secret=e2e_context.access_secret,
+        client_method="get_object",
+        params={"Bucket": e2e_context.bucket_key, "Key": filename},
+        http_method="GET",
+    )
+    async with client._http.get(presigned_get_url) as get_response:
+        body = await get_response.read()
+        assert get_response.status == 200
+        assert body == payload
+        assert get_response.headers["Content-Length"] == str(len(payload))
+        assert get_response.headers["ETag"]
+        assert get_response.headers["Last-Modified"]
+
+
 async def test_s3_sdk_object_content_type_and_user_metadata(client, e2e_context):
     filename = f"e2e-sdk-metadata-{uuid4().hex[:8]}.json"
     payload = b'{"sdk":true}'

--- a/docs/s3-compatibility.md
+++ b/docs/s3-compatibility.md
@@ -1,6 +1,6 @@
 # S3 Compatibility Matrix
 
-Last updated: 2026-04-22
+Last updated: 2026-04-23
 
 Baseline: `origin/main` at `214fdd7dec102fea85c8af4b4ada3e282e9eb183`. SFree exposes its S3-compatible API under `/api/s3` and uses path-style addressing: `/api/s3/{bucket}/{key}`.
 
@@ -14,10 +14,11 @@ Validated v0.2 SDK compatibility scope:
 
 1. ListObjectsV2 plus prefix, delimiter, and pagination support.
 2. Range requests for GetObject.
-3. DeleteObjects multi-delete.
-4. CopyObject for same-user same-bucket and cross-bucket copies.
-5. Multipart upload lifecycle.
-6. PutObject/HeadObject/GetObject preservation for `Content-Type` and `x-amz-meta-*` user metadata.
+3. SDK-generated presigned `PUT` and `GET` URLs for simple object upload/download flows.
+4. DeleteObjects multi-delete.
+5. CopyObject for same-user same-bucket and cross-bucket copies.
+6. Multipart upload lifecycle.
+7. PutObject/HeadObject/GetObject preservation for `Content-Type` and `x-amz-meta-*` user metadata.
 
 Bucket administration APIs, ACLs, versioning, lifecycle, object lock, tagging, and policy APIs are not v0.2.0 targets.
 
@@ -73,7 +74,7 @@ Bucket administration APIs, ACLs, versioning, lifecycle, object lock, tagging, a
 | Feature | Status | Notes |
 | --- | --- | --- |
 | AWS Signature V4 header auth | Implemented | Validates `AWS4-HMAC-SHA256` requests against bucket access credentials. Requests with bodies must send `X-Amz-Content-Sha256`; otherwise validation rejects the request without buffering the body. |
-| AWS Signature V4 presigned URLs | Implemented | Query-string presign validation supports default S3 unsigned payload behavior and a max TTL of seven days. |
+| AWS Signature V4 presigned URLs | Implemented | Query-string presign validation supports default S3 unsigned payload behavior and a max TTL of seven days. Woodpecker-runnable Python SDK coverage now verifies aiobotocore-generated presigned `PUT` and `GET` URLs for simple object upload/download flows. |
 | AWS Signature V2 | Missing | Legacy clients that require V2 are unsupported. |
 | Anonymous access | Missing | S3 API requests require signed bucket credentials. |
 | Virtual-hosted-style addressing | Missing | Only path-style routing under `/api/s3/{bucket}` is supported. |
@@ -128,7 +129,7 @@ These checks are based on the current S3 API surface and known request patterns 
 | `aws s3 cp s3://bucket/key local` | Yes for full-object downloads | GetObject works. |
 | `aws s3 rm s3://bucket/key` | Yes | DeleteObject works. |
 | `aws s3 sync` | Partial | ListObjectsV2, DeleteObjects, CopyObject COPY, and basic metadata behavior are covered; stronger ETag/checksum compatibility remains a gap. |
-| `aws s3 presign s3://bucket/key` | Yes for downloads | Presigned SigV4 requests are supported. |
+| `aws s3 presign s3://bucket/key` | Yes for downloads | Presigned SigV4 downloads are supported, and the same query-signing path now has Woodpecker-runnable aiobotocore GET coverage. |
 
 ### MinIO Client (`mc`)
 
@@ -164,6 +165,7 @@ Covered SDK paths:
 - `test_s3_sdk_list_objects_v2_prefix_delimiter_and_pagination`: `ListObjectsV2` with prefix, delimiter, `MaxKeys`, and continuation token.
 - `test_s3_sdk_get_object_range_returns_partial_content`: `GetObject` with byte `Range`, `ContentRange`, `ContentLength`, and `AcceptRanges`.
 - `test_s3_sdk_head_object_returns_metadata`: `HeadObject` for ETag, LastModified, ContentLength, and ContentType response fields.
+- `test_s3_sdk_presigned_put_and_get_urls`: aiobotocore-generated presigned `PUT` upload and presigned `GET` download with raw HTTP status/body/header verification.
 - `test_s3_sdk_copy_object_compatibility`: `CopyObject` for same-bucket copy, cross-bucket copy, missing-source `NoSuchKey`, and unsupported metadata replacement.
 - `test_s3_sdk_delete_objects_removes_multiple_keys`: `DeleteObjects` for multiple keys plus missing-key idempotency.
 - `test_s3_sdk_multipart_upload_flow`: `CreateMultipartUpload`, `UploadPart`, `ListMultipartUploads`, `ListParts`, and `CompleteMultipartUpload`.


### PR DESCRIPTION
## Summary
- add a focused aiobotocore helper for SDK-generated presigned URLs in the Python E2E client
- cover presigned `PUT` upload and presigned `GET` download through raw HTTP in `api-go/e2e/test_api_e2e.py`
- update the S3 compatibility matrix to document the exact presigned URL scope now covered

## Links
- THE-512
- [THE-509](https://paperclip.local/THE/issues/THE-509)
- Closes https://github.com/siberianbearofficial/sfree/issues/164
- Follow-up to QA audit PR #216

## Validation
- `python3 -m py_compile api-go/e2e/sfree_client.py api-go/e2e/test_api_e2e.py`
- `git diff --check`
- Full E2E execution intentionally left to Woodpecker per repo QA guidance and local CPU limits

## Scope notes
- Tested SDK/version: `aiobotocore==2.21.1` from `api-go/e2e/requirements.txt`
- Covered presigned behavior: simple SigV4 query-presigned `PUT` and `GET` flows against `/api/s3`
- Explicitly out of scope: POST presign, signed header permutations beyond the default SDK flow, multipart presign flows, response header overrides, and non-Python SDK matrices