### PR TITLE
THE-754: add bounded pagination for S3 multipart listings

### DIFF
--- a/api-go/internal/handlers/s3_multipart.go
+++ b/api-go/internal/handlers/s3_multipart.go
@@ -330,10 +330,6 @@ func buildMultipartUploadListPage(ctx context.Context, pager multipartUploadPage
 	}
 	if maxUploads == 0 {
 		page.isTruncated = len(uploads) > 0 || hasMore
-		if len(uploads) > 0 {
-			page.nextKeyMarker = uploads[0].ObjectKey
-			page.nextUploadIDMarker = uploads[0].UploadID
-		}
 		return page, nil
 	}
 
@@ -369,7 +365,6 @@ func buildMultipartPartsPage(mu *repository.MultipartUpload, partNumberMarker, m
 		page := multipartPartsPage{parts: []partXML{}}
 		if start < len(sorted) {
 			page.isTruncated = true
-			page.nextPartNumberMarker = sorted[start].PartNumber
 		}
 		return page
 	}

--- a/api-go/internal/handlers/s3_multipart.go
+++ b/api-go/internal/handlers/s3_multipart.go
@@ -48,11 +48,17 @@ type completionPart struct {
 }
 
 type listMultipartUploadsResult struct {
-	XMLName     xml.Name             `xml:"ListMultipartUploadsResult"`
-	Xmlns       string               `xml:"xmlns,attr"`
-	Bucket      string               `xml:"Bucket"`
-	Upload      []multipartUploadXML `xml:"Upload"`
-	IsTruncated bool                 `xml:"IsTruncated"`
+	XMLName            xml.Name             `xml:"ListMultipartUploadsResult"`
+	Xmlns              string               `xml:"xmlns,attr"`
+	Bucket             string               `xml:"Bucket"`
+	KeyMarker          string               `xml:"KeyMarker,omitempty"`
+	UploadIDMarker     string               `xml:"UploadIdMarker,omitempty"`
+	NextKeyMarker      string               `xml:"NextKeyMarker,omitempty"`
+	NextUploadIDMarker string               `xml:"NextUploadIdMarker,omitempty"`
+	Prefix             string               `xml:"Prefix,omitempty"`
+	MaxUploads         int                  `xml:"MaxUploads"`
+	Upload             []multipartUploadXML `xml:"Upload"`
+	IsTruncated        bool                 `xml:"IsTruncated"`
 }
 
 type multipartUploadXML struct {
@@ -62,13 +68,16 @@ type multipartUploadXML struct {
 }
 
 type listPartsResult struct {
-	XMLName     xml.Name  `xml:"ListPartsResult"`
-	Xmlns       string    `xml:"xmlns,attr"`
-	Bucket      string    `xml:"Bucket"`
-	Key         string    `xml:"Key"`
-	UploadId    string    `xml:"UploadId"`
-	Part        []partXML `xml:"Part"`
-	IsTruncated bool      `xml:"IsTruncated"`
+	XMLName              xml.Name  `xml:"ListPartsResult"`
+	Xmlns                string    `xml:"xmlns,attr"`
+	Bucket               string    `xml:"Bucket"`
+	Key                  string    `xml:"Key"`
+	UploadId             string    `xml:"UploadId"`
+	PartNumberMarker     int       `xml:"PartNumberMarker"`
+	NextPartNumberMarker int       `xml:"NextPartNumberMarker,omitempty"`
+	MaxParts             int       `xml:"MaxParts"`
+	Part                 []partXML `xml:"Part"`
+	IsTruncated          bool      `xml:"IsTruncated"`
 }
 
 type partXML struct {
@@ -81,6 +90,27 @@ type partXML struct {
 type multipartUploadAbortStore interface {
 	GetByUploadID(ctx context.Context, uploadID string) (*repository.MultipartUpload, error)
 	Delete(ctx context.Context, uploadID string) error
+}
+
+type multipartUploadPager interface {
+	ListByBucketPage(ctx context.Context, bucketID primitive.ObjectID, prefix, keyMarker, uploadIDMarker string, limit int) ([]repository.MultipartUpload, bool, error)
+}
+
+type multipartUploadGetter interface {
+	GetByUploadID(ctx context.Context, uploadID string) (*repository.MultipartUpload, error)
+}
+
+type multipartUploadListPage struct {
+	entries            []multipartUploadXML
+	isTruncated        bool
+	nextKeyMarker      string
+	nextUploadIDMarker string
+}
+
+type multipartPartsPage struct {
+	parts                []partXML
+	isTruncated          bool
+	nextPartNumberMarker int
 }
 
 // PostObject dispatches POST requests on S3 object paths.
@@ -250,6 +280,123 @@ func createMultipartUpload(c *gin.Context, bucketRepo *repository.BucketReposito
 	})
 }
 
+func parseMultipartMaxUploads(c *gin.Context) (int, bool) {
+	maxUploads := 1000
+	raw := c.Query("max-uploads")
+	if raw == "" {
+		return maxUploads, true
+	}
+	parsed, err := strconv.Atoi(raw)
+	if err != nil || parsed < 0 {
+		writeS3Error(c, http.StatusBadRequest, "InvalidArgument", "max-uploads must be a non-negative integer")
+		return 0, false
+	}
+	if parsed > maxUploads {
+		parsed = maxUploads
+	}
+	return parsed, true
+}
+
+func parseMultipartMaxParts(c *gin.Context) (int, bool) {
+	maxParts := 1000
+	raw := c.Query("max-parts")
+	if raw == "" {
+		return maxParts, true
+	}
+	parsed, err := strconv.Atoi(raw)
+	if err != nil || parsed < 0 {
+		writeS3Error(c, http.StatusBadRequest, "InvalidArgument", "max-parts must be a non-negative integer")
+		return 0, false
+	}
+	if parsed > maxParts {
+		parsed = maxParts
+	}
+	return parsed, true
+}
+
+func buildMultipartUploadListPage(ctx context.Context, pager multipartUploadPager, bucketID primitive.ObjectID, prefix, keyMarker, uploadIDMarker string, maxUploads int) (multipartUploadListPage, error) {
+	queryLimit := maxUploads
+	if maxUploads == 0 {
+		queryLimit = 1
+	}
+
+	uploads, hasMore, err := pager.ListByBucketPage(ctx, bucketID, prefix, keyMarker, uploadIDMarker, queryLimit)
+	if err != nil {
+		return multipartUploadListPage{}, err
+	}
+
+	page := multipartUploadListPage{
+		entries: make([]multipartUploadXML, 0, len(uploads)),
+	}
+	if maxUploads == 0 {
+		page.isTruncated = len(uploads) > 0 || hasMore
+		if len(uploads) > 0 {
+			page.nextKeyMarker = uploads[0].ObjectKey
+			page.nextUploadIDMarker = uploads[0].UploadID
+		}
+		return page, nil
+	}
+
+	for _, mu := range uploads {
+		page.entries = append(page.entries, multipartUploadXML{
+			Key:       mu.ObjectKey,
+			UploadId:  mu.UploadID,
+			Initiated: mu.CreatedAt.UTC().Format(time.RFC3339),
+		})
+	}
+	page.isTruncated = hasMore
+	if hasMore && len(uploads) > 0 {
+		last := uploads[len(uploads)-1]
+		page.nextKeyMarker = last.ObjectKey
+		page.nextUploadIDMarker = last.UploadID
+	}
+	return page, nil
+}
+
+func buildMultipartPartsPage(mu *repository.MultipartUpload, partNumberMarker, maxParts int) multipartPartsPage {
+	sorted := make([]repository.UploadPart, len(mu.Parts))
+	copy(sorted, mu.Parts)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].PartNumber < sorted[j].PartNumber
+	})
+
+	start := 0
+	for start < len(sorted) && sorted[start].PartNumber <= partNumberMarker {
+		start++
+	}
+
+	if maxParts == 0 {
+		page := multipartPartsPage{parts: []partXML{}}
+		if start < len(sorted) {
+			page.isTruncated = true
+			page.nextPartNumberMarker = sorted[start].PartNumber
+		}
+		return page
+	}
+
+	end := start + maxParts
+	if end > len(sorted) {
+		end = len(sorted)
+	}
+
+	parts := make([]partXML, 0, end-start)
+	for _, p := range sorted[start:end] {
+		parts = append(parts, partXML{
+			PartNumber:   p.PartNumber,
+			ETag:         p.ETag,
+			Size:         p.Size,
+			LastModified: mu.CreatedAt.UTC().Format(time.RFC3339),
+		})
+	}
+
+	page := multipartPartsPage{parts: parts}
+	if end < len(sorted) {
+		page.isTruncated = true
+		page.nextPartNumberMarker = sorted[end-1].PartNumber
+	}
+	return page
+}
+
 func uploadPart(c *gin.Context, bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, mpRepo *repository.MultipartUploadRepository, chunkSize int, factory manager.SourceClientFactory) {
 	ctx := c.Request.Context()
 	uploadID := c.Query("uploadId")
@@ -411,38 +558,51 @@ func abortMultipartUpload(c *gin.Context, bucketRepo objectBucketReader, sourceR
 	c.Status(http.StatusNoContent)
 }
 
-func listMultipartUploads(c *gin.Context, bucketRepo *repository.BucketRepository, mpRepo *repository.MultipartUploadRepository) {
+func listMultipartUploads(c *gin.Context, bucketRepo objectBucketReader, mpRepo multipartUploadPager) {
 	ctx := c.Request.Context()
 	bucketDoc, ok := lookupBucket(c, bucketRepo)
 	if !ok {
 		return
 	}
 
-	uploads, err := mpRepo.ListByBucket(ctx, bucketDoc.ID)
+	maxUploads, ok := parseMultipartMaxUploads(c)
+	if !ok {
+		return
+	}
+	prefix := c.Query("prefix")
+	keyMarker := c.Query("key-marker")
+	uploadIDMarker := c.Query("upload-id-marker")
+	if uploadIDMarker != "" && keyMarker == "" {
+		writeS3Error(c, http.StatusBadRequest, "InvalidArgument", "upload-id-marker requires key-marker")
+		return
+	}
+	if c.Query("delimiter") != "" {
+		writeS3Error(c, http.StatusNotImplemented, "NotImplemented", "delimiter is not supported for ListMultipartUploads")
+		return
+	}
+
+	page, err := buildMultipartUploadListPage(ctx, mpRepo, bucketDoc.ID, prefix, keyMarker, uploadIDMarker, maxUploads)
 	if err != nil {
 		slog.ErrorContext(ctx, "list multipart uploads", slog.String("error", err.Error()))
 		writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
 		return
 	}
 
-	entries := make([]multipartUploadXML, 0, len(uploads))
-	for _, mu := range uploads {
-		entries = append(entries, multipartUploadXML{
-			Key:       mu.ObjectKey,
-			UploadId:  mu.UploadID,
-			Initiated: mu.CreatedAt.UTC().Format(time.RFC3339),
-		})
-	}
-
 	c.XML(http.StatusOK, listMultipartUploadsResult{
-		Xmlns:       "http://s3.amazonaws.com/doc/2006-03-01/",
-		Bucket:      c.Param("bucket"),
-		Upload:      entries,
-		IsTruncated: false,
+		Xmlns:              "http://s3.amazonaws.com/doc/2006-03-01/",
+		Bucket:             c.Param("bucket"),
+		KeyMarker:          keyMarker,
+		UploadIDMarker:     uploadIDMarker,
+		NextKeyMarker:      page.nextKeyMarker,
+		NextUploadIDMarker: page.nextUploadIDMarker,
+		Prefix:             prefix,
+		MaxUploads:         maxUploads,
+		Upload:             page.entries,
+		IsTruncated:        page.isTruncated,
 	})
 }
 
-func listParts(c *gin.Context, bucketRepo *repository.BucketRepository, mpRepo *repository.MultipartUploadRepository) {
+func listParts(c *gin.Context, bucketRepo objectBucketReader, mpRepo multipartUploadGetter) {
 	ctx := c.Request.Context()
 	uploadID := c.Query("uploadId")
 
@@ -465,30 +625,27 @@ func listParts(c *gin.Context, bucketRepo *repository.BucketRepository, mpRepo *
 		writeS3Error(c, http.StatusNotFound, "NoSuchUpload", "")
 		return
 	}
-
-	// Sort parts by part number.
-	sorted := make([]repository.UploadPart, len(mu.Parts))
-	copy(sorted, mu.Parts)
-	sort.Slice(sorted, func(i, j int) bool {
-		return sorted[i].PartNumber < sorted[j].PartNumber
-	})
-
-	parts := make([]partXML, 0, len(sorted))
-	for _, p := range sorted {
-		parts = append(parts, partXML{
-			PartNumber:   p.PartNumber,
-			ETag:         p.ETag,
-			Size:         p.Size,
-			LastModified: mu.CreatedAt.UTC().Format(time.RFC3339),
-		})
+	maxParts, ok := parseMultipartMaxParts(c)
+	if !ok {
+		return
+	}
+	partNumberMarker, err := strconv.Atoi(c.DefaultQuery("part-number-marker", "0"))
+	if err != nil || partNumberMarker < 0 {
+		writeS3Error(c, http.StatusBadRequest, "InvalidArgument", "part-number-marker must be a non-negative integer")
+		return
 	}
 
+	page := buildMultipartPartsPage(mu, partNumberMarker, maxParts)
+
 	c.XML(http.StatusOK, listPartsResult{
-		Xmlns:       "http://s3.amazonaws.com/doc/2006-03-01/",
-		Bucket:      c.Param("bucket"),
-		Key:         mu.ObjectKey,
-		UploadId:    uploadID,
-		Part:        parts,
-		IsTruncated: false,
+		Xmlns:                "http://s3.amazonaws.com/doc/2006-03-01/",
+		Bucket:               c.Param("bucket"),
+		Key:                  mu.ObjectKey,
+		UploadId:             uploadID,
+		PartNumberMarker:     partNumberMarker,
+		NextPartNumberMarker: page.nextPartNumberMarker,
+		MaxParts:             maxParts,
+		Part:                 page.parts,
+		IsTruncated:          page.isTruncated,
 	})
 }

--- a/api-go/internal/handlers/s3_multipart_test.go
+++ b/api-go/internal/handlers/s3_multipart_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/example/sfree/api-go/internal/repository"
 	"github.com/gin-gonic/gin"
@@ -20,6 +21,49 @@ type fakeAbortMultipartStore struct {
 	getErr        error
 	deleteCalls   int
 	deletedUpload string
+}
+
+type fakeMultipartUploadPager struct {
+	uploads []repository.MultipartUpload
+}
+
+func (p fakeMultipartUploadPager) ListByBucketPage(_ context.Context, bucketID primitive.ObjectID, prefix, keyMarker, uploadIDMarker string, limit int) ([]repository.MultipartUpload, bool, error) {
+	filtered := make([]repository.MultipartUpload, 0, len(p.uploads))
+	for _, upload := range p.uploads {
+		if upload.BucketID != bucketID {
+			continue
+		}
+		if prefix != "" && !strings.HasPrefix(upload.ObjectKey, prefix) {
+			continue
+		}
+		if keyMarker != "" {
+			if upload.ObjectKey < keyMarker {
+				continue
+			}
+			if upload.ObjectKey == keyMarker {
+				if uploadIDMarker == "" || upload.UploadID <= uploadIDMarker {
+					continue
+				}
+			}
+		}
+		filtered = append(filtered, upload)
+	}
+	if limit >= 0 && len(filtered) > limit {
+		return filtered[:limit], true, nil
+	}
+	return filtered, false, nil
+}
+
+type fakeMultipartUploadGetter struct {
+	upload *repository.MultipartUpload
+	err    error
+}
+
+func (g fakeMultipartUploadGetter) GetByUploadID(_ context.Context, _ string) (*repository.MultipartUpload, error) {
+	if g.err != nil {
+		return nil, g.err
+	}
+	return g.upload, nil
 }
 
 func (s *fakeAbortMultipartStore) GetByUploadID(_ context.Context, _ string) (*repository.MultipartUpload, error) {
@@ -203,13 +247,18 @@ func TestListMultipartUploadsResultXML(t *testing.T) {
 	t.Parallel()
 
 	result := listMultipartUploadsResult{
-		Xmlns:  "http://s3.amazonaws.com/doc/2006-03-01/",
-		Bucket: "mybucket",
+		Xmlns:              "http://s3.amazonaws.com/doc/2006-03-01/",
+		Bucket:             "mybucket",
+		KeyMarker:          "file1.bin",
+		UploadIDMarker:     "id1",
+		NextKeyMarker:      "file2.bin",
+		NextUploadIDMarker: "id2",
+		MaxUploads:         1,
 		Upload: []multipartUploadXML{
 			{Key: "file1.bin", UploadId: "id1", Initiated: "2026-01-01T00:00:00Z"},
 			{Key: "file2.bin", UploadId: "id2", Initiated: "2026-01-02T00:00:00Z"},
 		},
-		IsTruncated: false,
+		IsTruncated: true,
 	}
 	data, err := xml.Marshal(result)
 	if err != nil {
@@ -222,21 +271,30 @@ func TestListMultipartUploadsResultXML(t *testing.T) {
 	if !bytes.Contains(data, []byte("<UploadId>id2</UploadId>")) {
 		t.Fatalf("missing upload id2: %s", s)
 	}
+	if !bytes.Contains(data, []byte("<NextKeyMarker>file2.bin</NextKeyMarker>")) {
+		t.Fatalf("missing NextKeyMarker: %s", s)
+	}
+	if !bytes.Contains(data, []byte("<NextUploadIdMarker>id2</NextUploadIdMarker>")) {
+		t.Fatalf("missing NextUploadIdMarker: %s", s)
+	}
 }
 
 func TestListPartsResultXML(t *testing.T) {
 	t.Parallel()
 
 	result := listPartsResult{
-		Xmlns:    "http://s3.amazonaws.com/doc/2006-03-01/",
-		Bucket:   "mybucket",
-		Key:      "file1.bin",
-		UploadId: "id1",
+		Xmlns:                "http://s3.amazonaws.com/doc/2006-03-01/",
+		Bucket:               "mybucket",
+		Key:                  "file1.bin",
+		UploadId:             "id1",
+		PartNumberMarker:     1,
+		NextPartNumberMarker: 2,
+		MaxParts:             1,
 		Part: []partXML{
 			{PartNumber: 1, ETag: `"aaa"`, Size: 5242880, LastModified: "2026-01-01T00:00:00Z"},
 			{PartNumber: 2, ETag: `"bbb"`, Size: 1234, LastModified: "2026-01-01T00:00:00Z"},
 		},
-		IsTruncated: false,
+		IsTruncated: true,
 	}
 	data, err := xml.Marshal(result)
 	if err != nil {
@@ -248,6 +306,137 @@ func TestListPartsResultXML(t *testing.T) {
 	}
 	if !bytes.Contains(data, []byte("<PartNumber>2</PartNumber>")) {
 		t.Fatalf("missing part 2: %s", s)
+	}
+	if !bytes.Contains(data, []byte("<NextPartNumberMarker>2</NextPartNumberMarker>")) {
+		t.Fatalf("missing NextPartNumberMarker: %s", s)
+	}
+}
+
+func TestListMultipartUploadsPagination(t *testing.T) {
+	t.Parallel()
+
+	bucketID := primitive.NewObjectID()
+	pager := fakeMultipartUploadPager{
+		uploads: []repository.MultipartUpload{
+			{BucketID: bucketID, ObjectKey: "alpha.txt", UploadID: "u1", CreatedAt: time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)},
+			{BucketID: bucketID, ObjectKey: "alpha.txt", UploadID: "u2", CreatedAt: time.Date(2026, time.January, 2, 0, 0, 0, 0, time.UTC)},
+			{BucketID: bucketID, ObjectKey: "beta.txt", UploadID: "u3", CreatedAt: time.Date(2026, time.January, 3, 0, 0, 0, 0, time.UTC)},
+		},
+	}
+
+	page, err := buildMultipartUploadListPage(context.Background(), pager, bucketID, "", "", "", 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !page.isTruncated {
+		t.Fatal("expected first page to be truncated")
+	}
+	if page.nextKeyMarker != "alpha.txt" || page.nextUploadIDMarker != "u2" {
+		t.Fatalf("unexpected next markers: %+v", page)
+	}
+	if len(page.entries) != 2 || page.entries[0].UploadId != "u1" || page.entries[1].UploadId != "u2" {
+		t.Fatalf("unexpected page entries: %+v", page.entries)
+	}
+
+	page, err = buildMultipartUploadListPage(context.Background(), pager, bucketID, "", "alpha.txt", "u2", 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if page.isTruncated {
+		t.Fatal("expected second page to finish the listing")
+	}
+	if len(page.entries) != 1 || page.entries[0].Key != "beta.txt" {
+		t.Fatalf("unexpected second page entries: %+v", page.entries)
+	}
+}
+
+func TestListMultipartUploadsRejectsUploadIDMarkerWithoutKeyMarker(t *testing.T) {
+	t.Parallel()
+
+	c, w := testS3GinContext("/api/s3/route-bucket?uploads&upload-id-marker=u2")
+	c.Request.Method = http.MethodGet
+	c.Params = gin.Params{{Key: "bucket", Value: "route-bucket"}}
+	c.Set("accessKey", "route-access")
+
+	listMultipartUploads(c, fakeObjectBucketReader{
+		bucket: &repository.Bucket{ID: primitive.NewObjectID(), Key: "route-bucket", AccessKey: "route-access"},
+	}, fakeMultipartUploadPager{})
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+	if body := w.Body.String(); !strings.Contains(body, "<Code>InvalidArgument</Code>") {
+		t.Fatalf("unexpected body: %s", body)
+	}
+}
+
+func TestListMultipartUploadsRejectsDelimiter(t *testing.T) {
+	t.Parallel()
+
+	c, w := testS3GinContext("/api/s3/route-bucket?uploads&delimiter=/")
+	c.Request.Method = http.MethodGet
+	c.Params = gin.Params{{Key: "bucket", Value: "route-bucket"}}
+	c.Set("accessKey", "route-access")
+
+	listMultipartUploads(c, fakeObjectBucketReader{
+		bucket: &repository.Bucket{ID: primitive.NewObjectID(), Key: "route-bucket", AccessKey: "route-access"},
+	}, fakeMultipartUploadPager{})
+
+	if w.Code != http.StatusNotImplemented {
+		t.Fatalf("expected 501, got %d", w.Code)
+	}
+	if body := w.Body.String(); !strings.Contains(body, "<Code>NotImplemented</Code>") {
+		t.Fatalf("unexpected body: %s", body)
+	}
+}
+
+func TestBuildMultipartPartsPage(t *testing.T) {
+	t.Parallel()
+
+	page := buildMultipartPartsPage(&repository.MultipartUpload{
+		CreatedAt: time.Date(2026, time.January, 4, 0, 0, 0, 0, time.UTC),
+		Parts: []repository.UploadPart{
+			{PartNumber: 3, ETag: `"ccc"`, Size: 3},
+			{PartNumber: 1, ETag: `"aaa"`, Size: 1},
+			{PartNumber: 2, ETag: `"bbb"`, Size: 2},
+		},
+	}, 1, 1)
+
+	if !page.isTruncated {
+		t.Fatal("expected paged parts result to be truncated")
+	}
+	if page.nextPartNumberMarker != 2 {
+		t.Fatalf("unexpected next marker: %d", page.nextPartNumberMarker)
+	}
+	if len(page.parts) != 1 || page.parts[0].PartNumber != 2 {
+		t.Fatalf("unexpected page parts: %+v", page.parts)
+	}
+}
+
+func TestListPartsRejectsInvalidMarker(t *testing.T) {
+	t.Parallel()
+
+	bucketID := primitive.NewObjectID()
+	uploadID := primitive.NewObjectID().Hex()
+	c, w := testS3GinContext("/api/s3/route-bucket/object.txt?uploadId=" + uploadID + "&part-number-marker=-1")
+	c.Request.Method = http.MethodGet
+	c.Params = gin.Params{
+		{Key: "bucket", Value: "route-bucket"},
+		{Key: "object", Value: "/object.txt"},
+	}
+	c.Set("accessKey", "route-access")
+
+	listParts(c, fakeObjectBucketReader{
+		bucket: &repository.Bucket{ID: bucketID, Key: "route-bucket", AccessKey: "route-access"},
+	}, fakeMultipartUploadGetter{
+		upload: &repository.MultipartUpload{BucketID: bucketID, ObjectKey: "object.txt", UploadID: uploadID},
+	})
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+	if body := w.Body.String(); !strings.Contains(body, "<Code>InvalidArgument</Code>") {
+		t.Fatalf("unexpected body: %s", body)
 	}
 }
 

--- a/api-go/internal/handlers/s3_multipart_test.go
+++ b/api-go/internal/handlers/s3_multipart_test.go
@@ -350,6 +350,37 @@ func TestListMultipartUploadsPagination(t *testing.T) {
 	}
 }
 
+func TestListMultipartUploadsPaginationMaxZeroKeepsUnseenDataReachable(t *testing.T) {
+	t.Parallel()
+
+	bucketID := primitive.NewObjectID()
+	pager := fakeMultipartUploadPager{
+		uploads: []repository.MultipartUpload{
+			{BucketID: bucketID, ObjectKey: "alpha.txt", UploadID: "u1", CreatedAt: time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)},
+			{BucketID: bucketID, ObjectKey: "alpha.txt", UploadID: "u2", CreatedAt: time.Date(2026, time.January, 2, 0, 0, 0, 0, time.UTC)},
+		},
+	}
+
+	page, err := buildMultipartUploadListPage(context.Background(), pager, bucketID, "", "", "", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !page.isTruncated {
+		t.Fatal("expected zero-sized page to remain truncated when uploads exist")
+	}
+	if page.nextKeyMarker != "" || page.nextUploadIDMarker != "" {
+		t.Fatalf("expected zero-sized page to leave next markers empty, got %+v", page)
+	}
+
+	followUp, err := buildMultipartUploadListPage(context.Background(), pager, bucketID, "", "", "", 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(followUp.entries) != 2 || followUp.entries[0].UploadId != "u1" || followUp.entries[1].UploadId != "u2" {
+		t.Fatalf("expected follow-up page to retain all uploads, got %+v", followUp.entries)
+	}
+}
+
 func TestListMultipartUploadsRejectsUploadIDMarkerWithoutKeyMarker(t *testing.T) {
 	t.Parallel()
 
@@ -410,6 +441,36 @@ func TestBuildMultipartPartsPage(t *testing.T) {
 	}
 	if len(page.parts) != 1 || page.parts[0].PartNumber != 2 {
 		t.Fatalf("unexpected page parts: %+v", page.parts)
+	}
+}
+
+func TestBuildMultipartPartsPageMaxZeroKeepsUnseenDataReachable(t *testing.T) {
+	t.Parallel()
+
+	page := buildMultipartPartsPage(&repository.MultipartUpload{
+		CreatedAt: time.Date(2026, time.January, 4, 0, 0, 0, 0, time.UTC),
+		Parts: []repository.UploadPart{
+			{PartNumber: 1, ETag: `"aaa"`, Size: 1},
+			{PartNumber: 2, ETag: `"bbb"`, Size: 2},
+		},
+	}, 0, 0)
+
+	if !page.isTruncated {
+		t.Fatal("expected zero-sized parts page to remain truncated when parts exist")
+	}
+	if page.nextPartNumberMarker != 0 {
+		t.Fatalf("expected zero-sized parts page to leave next marker empty, got %d", page.nextPartNumberMarker)
+	}
+
+	followUp := buildMultipartPartsPage(&repository.MultipartUpload{
+		CreatedAt: time.Date(2026, time.January, 4, 0, 0, 0, 0, time.UTC),
+		Parts: []repository.UploadPart{
+			{PartNumber: 1, ETag: `"aaa"`, Size: 1},
+			{PartNumber: 2, ETag: `"bbb"`, Size: 2},
+		},
+	}, 0, 2)
+	if len(followUp.parts) != 2 || followUp.parts[0].PartNumber != 1 || followUp.parts[1].PartNumber != 2 {
+		t.Fatalf("expected follow-up page to retain all parts, got %+v", followUp.parts)
 	}
 }
 

--- a/api-go/internal/repository/multipart.go
+++ b/api-go/internal/repository/multipart.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"context"
+	"regexp"
 	"time"
 
 	"go.mongodb.org/mongo-driver/bson"
@@ -33,6 +34,7 @@ type MultipartUploadRepository struct {
 }
 
 const multipartPartChunkNameBucketIndex = "parts_chunks_name_bucket_id"
+const multipartBucketObjectUploadIndex = "bucket_id_object_key_upload_id"
 
 func NewMultipartUploadRepository(db *mongo.Database) (*MultipartUploadRepository, error) {
 	coll := db.Collection("multipart_uploads")
@@ -43,6 +45,11 @@ func NewMultipartUploadRepository(db *mongo.Database) (*MultipartUploadRepositor
 		},
 		{
 			Keys: bson.D{{Key: "bucket_id", Value: 1}},
+		},
+		{
+			Keys: bson.D{{Key: "bucket_id", Value: 1}, {Key: "object_key", Value: 1}, {Key: "upload_id", Value: 1}},
+			Options: options.Index().
+				SetName(multipartBucketObjectUploadIndex),
 		},
 		{
 			Keys: bson.D{{Key: "parts.chunks.name", Value: 1}, {Key: "bucket_id", Value: 1}},
@@ -95,6 +102,59 @@ func (r *MultipartUploadRepository) ListByBucket(ctx context.Context, bucketID p
 		uploads = append(uploads, mu)
 	}
 	return uploads, cursor.Err()
+}
+
+func (r *MultipartUploadRepository) ListByBucketPage(ctx context.Context, bucketID primitive.ObjectID, prefix, keyMarker, uploadIDMarker string, limit int) ([]MultipartUpload, bool, error) {
+	clauses := []bson.M{{"bucket_id": bucketID}}
+	if prefix != "" {
+		clauses = append(clauses, bson.M{"object_key": bson.M{"$regex": "^" + regexp.QuoteMeta(prefix)}})
+	}
+	if keyMarker != "" {
+		if uploadIDMarker != "" {
+			clauses = append(clauses, bson.M{"$or": bson.A{
+				bson.M{"object_key": bson.M{"$gt": keyMarker}},
+				bson.M{"object_key": keyMarker, "upload_id": bson.M{"$gt": uploadIDMarker}},
+			}})
+		} else {
+			clauses = append(clauses, bson.M{"object_key": bson.M{"$gt": keyMarker}})
+		}
+	}
+
+	filter := clauses[0]
+	if len(clauses) > 1 {
+		filter = bson.M{"$and": clauses}
+	}
+
+	findOpts := options.Find().SetSort(bson.D{
+		{Key: "object_key", Value: 1},
+		{Key: "upload_id", Value: 1},
+	})
+	if limit >= 0 {
+		findOpts.SetLimit(int64(limit + 1))
+	}
+	cursor, err := r.coll.Find(ctx, filter, findOpts)
+	if err != nil {
+		return nil, false, err
+	}
+	defer func() { _ = cursor.Close(ctx) }()
+
+	uploads := make([]MultipartUpload, 0, max(limit, 0))
+	for cursor.Next(ctx) {
+		var mu MultipartUpload
+		if err := cursor.Decode(&mu); err != nil {
+			return nil, false, err
+		}
+		uploads = append(uploads, mu)
+	}
+	if err := cursor.Err(); err != nil {
+		return nil, false, err
+	}
+
+	hasMore := limit >= 0 && len(uploads) > limit
+	if hasMore {
+		uploads = uploads[:limit]
+	}
+	return uploads, hasMore, nil
 }
 
 func (r *MultipartUploadRepository) CountByPartChunk(ctx context.Context, sourceID primitive.ObjectID, name string) (int64, error) {

--- a/api-go/internal/repository/multipart_test.go
+++ b/api-go/internal/repository/multipart_test.go
@@ -118,6 +118,72 @@ func TestMultipartUploadRepositoryCreatesPartChunkReferenceIndex(t *testing.T) {
 	})
 }
 
+func TestMultipartUploadRepositoryCreatesPagedListingIndex(t *testing.T) {
+	testDB, _ := newMultipartRepositoryTestDB(t)
+	assertMongoIndex(t, testDB.Collection("multipart_uploads"), multipartBucketObjectUploadIndex, bson.D{
+		{Key: "bucket_id", Value: 1},
+		{Key: "object_key", Value: 1},
+		{Key: "upload_id", Value: 1},
+	})
+}
+
+func TestMultipartUploadRepositoryListByBucketPage(t *testing.T) {
+	_, repo := newMultipartRepositoryTestDB(t)
+
+	ctx := context.Background()
+	bucketID := primitive.NewObjectID()
+	otherBucketID := primitive.NewObjectID()
+	createdAt := time.Date(2026, time.January, 2, 3, 4, 5, 0, time.UTC)
+	fixtures := []MultipartUpload{
+		{BucketID: bucketID, ObjectKey: "alpha.txt", UploadID: "u1", CreatedAt: createdAt},
+		{BucketID: bucketID, ObjectKey: "alpha.txt", UploadID: "u2", CreatedAt: createdAt.Add(time.Second)},
+		{BucketID: bucketID, ObjectKey: "beta.txt", UploadID: "u3", CreatedAt: createdAt.Add(2 * time.Second)},
+		{BucketID: bucketID, ObjectKey: "dir/gamma.txt", UploadID: "u4", CreatedAt: createdAt.Add(3 * time.Second)},
+		{BucketID: otherBucketID, ObjectKey: "alpha.txt", UploadID: "other", CreatedAt: createdAt},
+	}
+	for _, mu := range fixtures {
+		if _, err := repo.Create(ctx, mu); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	page, hasMore, err := repo.ListByBucketPage(ctx, bucketID, "", "", "", 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasMore {
+		t.Fatal("expected first page to be truncated")
+	}
+	assertMultipartUploadPage(t, page, [][2]string{{"alpha.txt", "u1"}, {"alpha.txt", "u2"}})
+
+	page, hasMore, err = repo.ListByBucketPage(ctx, bucketID, "", "alpha.txt", "u2", 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hasMore {
+		t.Fatal("expected second page to finish the result set")
+	}
+	assertMultipartUploadPage(t, page, [][2]string{{"beta.txt", "u3"}, {"dir/gamma.txt", "u4"}})
+
+	page, hasMore, err = repo.ListByBucketPage(ctx, bucketID, "dir/", "", "", 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hasMore {
+		t.Fatal("expected prefix-filtered page to be complete")
+	}
+	assertMultipartUploadPage(t, page, [][2]string{{"dir/gamma.txt", "u4"}})
+
+	page, hasMore, err = repo.ListByBucketPage(ctx, bucketID, "", "alpha.txt", "", 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hasMore {
+		t.Fatal("expected key-marker page to be complete")
+	}
+	assertMultipartUploadPage(t, page, [][2]string{{"beta.txt", "u3"}, {"dir/gamma.txt", "u4"}})
+}
+
 func assertMultipartPart(t *testing.T, parts []UploadPart, partNumber int, etag string, chunkName string) {
 	t.Helper()
 	for _, part := range parts {
@@ -133,6 +199,18 @@ func assertMultipartPart(t *testing.T, parts []UploadPart, partNumber int, etag 
 		return
 	}
 	t.Fatalf("missing part %d in %+v", partNumber, parts)
+}
+
+func assertMultipartUploadPage(t *testing.T, uploads []MultipartUpload, want [][2]string) {
+	t.Helper()
+	if len(uploads) != len(want) {
+		t.Fatalf("expected %d uploads, got %+v", len(want), uploads)
+	}
+	for i, pair := range want {
+		if uploads[i].ObjectKey != pair[0] || uploads[i].UploadID != pair[1] {
+			t.Fatalf("upload %d: got (%q, %q), want (%q, %q)", i, uploads[i].ObjectKey, uploads[i].UploadID, pair[0], pair[1])
+		}
+	}
 }
 
 func newMultipartRepositoryTestDB(t *testing.T) (*mongo.Database, *MultipartUploadRepository) {

--- a/docs/s3-compatibility.md
+++ b/docs/s3-compatibility.md
@@ -54,8 +54,8 @@ Bucket administration APIs, ACLs, versioning, lifecycle, object lock, tagging, a
 | UploadPart | Implemented | `PUT /api/s3/{bucket}/{key}?uploadId=...&partNumber=...`. |
 | CompleteMultipartUpload | Implemented | Validates part existence, ETags, ascending part order, and persists metadata captured during CreateMultipartUpload. |
 | AbortMultipartUpload | Implemented | Deletes uploaded part chunks and the multipart record. |
-| ListMultipartUploads | Partial | Lists active uploads for a bucket but lacks prefix, delimiter, key-marker, upload-id-marker, and pagination support. |
-| ListParts | Partial | Lists uploaded parts but lacks pagination and part-number-marker support. |
+| ListMultipartUploads | Partial | Bounded listing now supports `max-uploads`, `prefix`, `key-marker`, and `upload-id-marker` with S3-style truncation markers. `delimiter` still returns XML `NotImplemented`. |
+| ListParts | Partial | Bounded listing now supports `max-parts` and `part-number-marker` with truncation markers. Other advanced multipart response fields remain minimal. |
 | UploadPartCopy | Missing | Server-side part copy is not implemented. |
 
 ### Bucket Operations


### PR DESCRIPTION
## Summary
- add a bounded multipart upload repository pager with a compound `(bucket_id, object_key, upload_id)` index
- honor `max-uploads`, `prefix`, `key-marker`, and `upload-id-marker` in `ListMultipartUploads` and emit truncation markers
- honor `max-parts` and `part-number-marker` in `ListParts`, add focused handler/repository coverage, and document multipart `delimiter` as explicit `NotImplemented`

## Testing
- `gofmt -w api-go/internal/repository/multipart.go api-go/internal/repository/multipart_test.go api-go/internal/handlers/s3_multipart.go api-go/internal/handlers/s3_multipart_test.go`
- `timeout 60s go test ./internal/handlers -run 'Multipart|List'`
- `timeout 60s go test ./internal/repository`

## Notes
- `ListMultipartUploads` still does not implement delimiter/common-prefix behavior; this PR returns XML `NotImplemented` instead of silently ignoring `delimiter`.
- Integration-tagged repository tests and heavier E2E validation were intentionally left for Woodpecker per task constraints.