### PR TITLE
THE-527 Guard large text file previews in webui

### DIFF
--- a/webui/e2e/files.spec.ts
+++ b/webui/e2e/files.spec.ts
@@ -47,6 +47,13 @@ const MOCK_FILES = [
   },
 ];
 
+const LARGE_TEXT_FILE = {
+  id: "file-3",
+  name: "huge.log",
+  size: 1_500_000,
+  created_at: "2024-01-22T08:15:00Z",
+};
+
 test.describe("File listing and download", () => {
   test("bucket detail shows bucket info", async ({ page }) => {
     await injectAuth(page);
@@ -205,6 +212,34 @@ test.describe("File listing and download", () => {
     await expect(
       page.getByText("The server returned an error. Try again later."),
     ).toBeVisible();
+  });
+
+  test("large text previews do not download the file", async ({ page }) => {
+    await injectAuth(page);
+    await mockGet(page, "/buckets", [MOCK_BUCKET]);
+    await mockGet(page, "/buckets/bkt-1", MOCK_BUCKET);
+    await mockGet(page, "/buckets/bkt-1/files", [LARGE_TEXT_FILE]);
+
+    let previewRequests = 0;
+    await page.route("**/api/v1/buckets/bkt-1/files/file-3/download", async (route) => {
+      previewRequests += 1;
+      await route.fulfill({
+        status: 200,
+        headers: { "Content-Type": "text/plain" },
+        body: "should not load",
+      });
+    });
+
+    await page.goto("/buckets/bkt-1");
+    await page.getByRole("button", { name: "huge.log" }).click();
+
+    await expect(
+      page.getByText("Preview unavailable for large text files"),
+    ).toBeVisible();
+    await expect(
+      page.getByText("Files larger than 1 MB must be downloaded to inspect."),
+    ).toBeVisible();
+    await expect.poll(() => previewRequests).toBe(0);
   });
 
   test("back button is present and navigates back", async ({ page }) => {

--- a/webui/e2e/files.spec.ts
+++ b/webui/e2e/files.spec.ts
@@ -10,6 +10,7 @@
 
 import { test, expect } from "@playwright/test";
 import { injectAuth, mockGet } from "./helpers";
+import { formatSize } from "../src/shared/lib/format";
 
 const MOCK_BUCKET = {
   id: "bkt-1",
@@ -237,7 +238,9 @@ test.describe("File listing and download", () => {
       page.getByText("Preview unavailable for large text files"),
     ).toBeVisible();
     await expect(
-      page.getByText("Files larger than 1 MB must be downloaded to inspect."),
+      page.getByText(
+        `Files larger than ${formatSize(1024 * 1024)} must be downloaded to inspect.`,
+      ),
     ).toBeVisible();
     await expect.poll(() => previewRequests).toBe(0);
   });

--- a/webui/e2e/files.spec.ts
+++ b/webui/e2e/files.spec.ts
@@ -232,7 +232,7 @@ test.describe("File listing and download", () => {
     });
 
     await page.goto("/buckets/bkt-1");
-    await page.getByRole("button", { name: "huge.log" }).click();
+    await page.getByRole("button", { name: "huge.log", exact: true }).click();
 
     await expect(
       page.getByText("Preview unavailable for large text files"),

--- a/webui/src/features/bucket/ui/file-preview-modal.tsx
+++ b/webui/src/features/bucket/ui/file-preview-modal.tsx
@@ -17,6 +17,8 @@ import { formatSize } from "../../../shared/lib/format";
 
 const IMAGE_EXTENSIONS = new Set(["jpg", "jpeg", "png", "gif", "webp", "svg", "bmp", "ico"]);
 const TEXT_EXTENSIONS = new Set(["txt", "json", "yaml", "yml", "md", "csv", "xml", "html", "css", "js", "ts", "tsx", "jsx", "go", "py", "sh", "toml", "ini", "cfg", "log", "env", "dockerfile"]);
+const MAX_TEXT_PREVIEW_FILE_SIZE = 1_000_000;
+const MAX_TEXT_PREVIEW_CONTENT_SIZE = 100_000;
 
 function getExtension(name: string): string {
   const parts = name.toLowerCase().split(".");
@@ -40,6 +42,7 @@ export function FilePreviewModal({ isOpen, onClose, file, bucketId }: Props) {
   const ext = file ? getExtension(file.name) : "";
   const isImage = IMAGE_EXTENSIONS.has(ext);
   const isText = TEXT_EXTENSIONS.has(ext);
+  const textPreviewTooLarge = Boolean(file && isText && file.size > MAX_TEXT_PREVIEW_FILE_SIZE);
 
   async function handleDownload() {
     if (!file) return;
@@ -68,7 +71,11 @@ export function FilePreviewModal({ isOpen, onClose, file, bucketId }: Props) {
         setBlobUrl(url);
       } else if (isText) {
         const text = await blob.text();
-        setTextContent(text.length > 100_000 ? text.slice(0, 100_000) + "\n\n--- truncated ---" : text);
+        setTextContent(
+          text.length > MAX_TEXT_PREVIEW_CONTENT_SIZE
+            ? text.slice(0, MAX_TEXT_PREVIEW_CONTENT_SIZE) + "\n\n--- truncated ---"
+            : text,
+        );
       }
     } catch {
       setError("Failed to load file preview");
@@ -78,8 +85,16 @@ export function FilePreviewModal({ isOpen, onClose, file, bucketId }: Props) {
   }, [file, bucketId, isImage, isText]);
 
   useEffect(() => {
-    if (isOpen && file && (isImage || isText)) {
-      loadPreview();
+    if (blobUrlRef.current) {
+      URL.revokeObjectURL(blobUrlRef.current);
+      blobUrlRef.current = null;
+    }
+    setBlobUrl(null);
+    setTextContent(null);
+    setError(null);
+    setIsLoading(false);
+    if (isOpen && file && (isImage || (isText && !textPreviewTooLarge))) {
+      void loadPreview();
     }
     return () => {
       if (blobUrlRef.current) {
@@ -87,7 +102,7 @@ export function FilePreviewModal({ isOpen, onClose, file, bucketId }: Props) {
         blobUrlRef.current = null;
       }
     };
-  }, [isOpen, file, isImage, isText, loadPreview]);
+  }, [isOpen, file, isImage, isText, loadPreview, textPreviewTooLarge]);
 
   return (
     <Modal isOpen={isOpen} onClose={onClose} size="3xl" scrollBehavior="inside">
@@ -132,7 +147,16 @@ export function FilePreviewModal({ isOpen, onClose, file, bucketId }: Props) {
             </pre>
           )}
 
-          {!isLoading && !error && !isImage && !isText && file && (
+          {!isLoading && !error && textPreviewTooLarge && file && (
+            <div className="text-center py-12 text-default-500">
+              <p className="text-lg mb-2">Preview unavailable for large text files</p>
+              <p>
+                Files larger than {formatSize(MAX_TEXT_PREVIEW_FILE_SIZE)} must be downloaded to inspect.
+              </p>
+            </div>
+          )}
+
+          {!isLoading && !error && !textPreviewTooLarge && !isImage && !isText && file && (
             <div className="text-center py-12 text-default-500">
               <p className="text-lg mb-2">Preview not available for this file type</p>
               <p>Click Download to save the file</p>

--- a/webui/src/features/bucket/ui/file-preview-modal.tsx
+++ b/webui/src/features/bucket/ui/file-preview-modal.tsx
@@ -17,7 +17,7 @@ import { formatSize } from "../../../shared/lib/format";
 
 const IMAGE_EXTENSIONS = new Set(["jpg", "jpeg", "png", "gif", "webp", "svg", "bmp", "ico"]);
 const TEXT_EXTENSIONS = new Set(["txt", "json", "yaml", "yml", "md", "csv", "xml", "html", "css", "js", "ts", "tsx", "jsx", "go", "py", "sh", "toml", "ini", "cfg", "log", "env", "dockerfile"]);
-const MAX_TEXT_PREVIEW_FILE_SIZE = 1_000_000;
+const MAX_TEXT_PREVIEW_FILE_SIZE = 1024 * 1024;
 const MAX_TEXT_PREVIEW_CONTENT_SIZE = 100_000;
 
 function getExtension(name: string): string {


### PR DESCRIPTION
## Summary
- skip bucket text previews when the file is larger than 1 MB so the modal does not download the full object just to truncate it
- keep existing small text and image preview behavior intact
- add a focused Playwright regression that asserts large text previews do not hit the download endpoint

## Testing
- npm exec eslint src/features/bucket/ui/file-preview-modal.tsx e2e/files.spec.ts
- git diff --check

## Notes
- Linked backlog parent: [THE-523](https://paperclip.local/THE/issues/THE-523)
- Threshold chosen: 1 MB, which is conservative enough to avoid large browser downloads while preserving preview support for typical small text files.