### PR TITLE
THE-815 add minimal S3 bucket-discovery APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,13 +144,11 @@ instance for local S3-compatible source testing.
    ```
 3. Create a bucket in the UI (select the MinIO source).
 4. Upload a file through the UI.
-5. Download the same file via aws-cli using the bucket's S3 credentials:
+5. Download the same file via an S3 client using the bucket's S3 credentials:
    ```bash
-   aws s3 ls s3://BUCKET_KEY/ \
-     --endpoint-url http://localhost:8080/api/s3
+   mc alias set --api S3v4 --path on sfree http://localhost:8080 BUCKET_ACCESS_KEY BUCKET_ACCESS_SECRET
 
-   aws s3 cp s3://BUCKET_KEY/OBJECT_KEY ./local-copy \
-     --endpoint-url http://localhost:8080/api/s3
+   mc cat sfree/BUCKET_KEY/OBJECT_KEY > ./local-copy
    ```
 
 ### Manual dev setup (without Docker Compose)

--- a/api-go/cmd/woodpecker-smoke-helper/main.go
+++ b/api-go/cmd/woodpecker-smoke-helper/main.go
@@ -10,11 +10,6 @@ import (
 	"net/http"
 	"os"
 	"time"
-
-	"github.com/aws/aws-sdk-go-v2/aws"
-	awsconfig "github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
-	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
 )
 
 const requestTimeout = 20 * time.Second
@@ -69,11 +64,6 @@ func run(args []string) error {
 			return usage()
 		}
 		return downloadURL(args[1], args[2])
-	case "s3-get":
-		if len(args) != 7 {
-			return usage()
-		}
-		return s3Get(args[1], args[2], args[3], args[4], args[5], args[6])
 	default:
 		return usage()
 	}
@@ -82,7 +72,7 @@ func run(args []string) error {
 }
 
 func usage() error {
-	return errors.New("usage: smoke-helper ready URL | create-user BASE_URL USERNAME | create-source BASE_URL USERNAME PASSWORD SOURCE_NAME | share-url BASE_URL USERNAME PASSWORD BUCKET_ID FILE_ID | download-url URL OUTPUT | s3-get ENDPOINT ACCESS_KEY SECRET_KEY BUCKET KEY OUTPUT")
+	return errors.New("usage: smoke-helper ready URL | create-user BASE_URL USERNAME | create-source BASE_URL USERNAME PASSWORD SOURCE_NAME | share-url BASE_URL USERNAME PASSWORD BUCKET_ID FILE_ID | download-url URL OUTPUT")
 }
 
 func ready(rawURL string) error {
@@ -207,32 +197,6 @@ func downloadURL(rawURL, output string) error {
 		return fmt.Errorf("GET %s returned %s: %s", rawURL, resp.Status, string(responseBody))
 	}
 	return writeFile(output, resp.Body)
-}
-
-func s3Get(endpoint, accessKey, secretKey, bucket, key, output string) error {
-	ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
-	defer cancel()
-
-	cfg, err := awsconfig.LoadDefaultConfig(ctx,
-		awsconfig.WithRegion("us-east-1"),
-		awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(accessKey, secretKey, "")),
-	)
-	if err != nil {
-		return err
-	}
-	client := awss3.NewFromConfig(cfg, func(opts *awss3.Options) {
-		opts.BaseEndpoint = aws.String(endpoint)
-		opts.UsePathStyle = true
-	})
-	result, err := client.GetObject(ctx, &awss3.GetObjectInput{
-		Bucket: aws.String(bucket),
-		Key:    aws.String(key),
-	})
-	if err != nil {
-		return err
-	}
-	defer func() { _ = result.Body.Close() }()
-	return writeFile(output, result.Body)
 }
 
 func writeFile(output string, source io.Reader) error {

--- a/api-go/e2e/README.md
+++ b/api-go/e2e/README.md
@@ -72,7 +72,7 @@ make test-e2e-python
 
 ## CI (Woodpecker)
 
-Pipeline `.woodpecker/api-go.yml` запускает `docker-compose.e2e.yml` через DinD только для `s3`. Этот режим использует локальный MinIO из `docker-compose.e2e.yml` и является обязательным PR-gate.
+Pipeline `.woodpecker/api-go.yml` запускает `docker-compose.e2e.yml` через DinD только для `s3`. Этот режим использует локальный MinIO из `docker-compose.e2e.yml` и является обязательным PR-gate. Отдельный smoke pipeline `.woodpecker/smoke.yml` дополнительно проверяет, что MinIO Client (`mc`) может читать объект через root-style endpoint SFree.
 
 Режимы `gdrive` и `telegram` остаются доступными для ручной или неблокирующей проверки. Для них нужны секреты:
 

--- a/api-go/internal/app/router_routes.go
+++ b/api-go/internal/app/router_routes.go
@@ -133,10 +133,12 @@ func registerS3Routes(router *gin.Engine, cfg *config.Config, deps *routerDepend
 	}
 	for _, prefix := range []string{"", "/api/s3"} {
 		bucketPath, objectPath := s3RoutePaths(prefix)
+		bucketSlashPath := bucketPath + "/"
 		router.HEAD(bucketPath, protectedHandlers(limits, s3Auth, handlers.HeadBucket(deps.bucketRepo))...)
 		router.HEAD(objectPath, protectedHandlers(limits, s3Auth, handlers.HeadObject(deps.bucketRepo, deps.fileRepo))...)
 		router.GET(objectPath, protectedHandlers(limits, s3Auth, handlers.GetObjectOrPartsWithFactory(deps.bucketRepo, deps.sourceRepo, deps.fileRepo, deps.mpRepo, deps.sourceFactory))...)
 		router.GET(bucketPath, protectedHandlers(limits, s3Auth, handlers.ListObjectsOrUploads(deps.bucketRepo, deps.fileRepo, deps.mpRepo))...)
+		router.GET(bucketSlashPath, protectedHandlers(limits, s3Auth, handlers.ListObjectsOrUploads(deps.bucketRepo, deps.fileRepo, deps.mpRepo))...)
 		router.PUT(objectPath, protectedHandlers(limits, s3Auth, handlers.PutObjectOrPartWithFactory(deps.bucketRepo, deps.sourceRepo, deps.fileRepo, deps.mpRepo, uploadChunkSize, deps.sourceFactory))...)
 		router.POST(bucketPath, protectedHandlers(limits, s3Auth, handlers.PostBucketWithFactory(deps.bucketRepo, deps.sourceRepo, deps.fileRepo, deps.sourceFactory))...)
 		router.POST(objectPath, protectedHandlers(limits, s3Auth, handlers.PostObjectWithFactory(deps.bucketRepo, deps.sourceRepo, deps.fileRepo, deps.mpRepo, uploadChunkSize, deps.sourceFactory))...)

--- a/api-go/internal/app/router_routes.go
+++ b/api-go/internal/app/router_routes.go
@@ -128,8 +128,12 @@ func registerS3Routes(router *gin.Engine, cfg *config.Config, deps *routerDepend
 	}
 	s3Auth := handlers.AWS4Auth(deps.bucketRepo, routerAccessSecret(cfg))
 	uploadChunkSize := routerUploadChunkSize(cfg)
+	for _, root := range []string{"/", "/api/s3"} {
+		router.GET(root, protectedHandlers(limits, s3Auth, handlers.ListBucketsS3(deps.bucketRepo))...)
+	}
 	for _, prefix := range []string{"", "/api/s3"} {
 		bucketPath, objectPath := s3RoutePaths(prefix)
+		router.HEAD(bucketPath, protectedHandlers(limits, s3Auth, handlers.HeadBucket(deps.bucketRepo))...)
 		router.HEAD(objectPath, protectedHandlers(limits, s3Auth, handlers.HeadObject(deps.bucketRepo, deps.fileRepo))...)
 		router.GET(objectPath, protectedHandlers(limits, s3Auth, handlers.GetObjectOrPartsWithFactory(deps.bucketRepo, deps.sourceRepo, deps.fileRepo, deps.mpRepo, deps.sourceFactory))...)
 		router.GET(bucketPath, protectedHandlers(limits, s3Auth, handlers.ListObjectsOrUploads(deps.bucketRepo, deps.fileRepo, deps.mpRepo))...)

--- a/api-go/internal/app/router_routes.go
+++ b/api-go/internal/app/router_routes.go
@@ -133,12 +133,10 @@ func registerS3Routes(router *gin.Engine, cfg *config.Config, deps *routerDepend
 	}
 	for _, prefix := range []string{"", "/api/s3"} {
 		bucketPath, objectPath := s3RoutePaths(prefix)
-		bucketSlashPath := bucketPath + "/"
 		router.HEAD(bucketPath, protectedHandlers(limits, s3Auth, handlers.HeadBucket(deps.bucketRepo))...)
 		router.HEAD(objectPath, protectedHandlers(limits, s3Auth, handlers.HeadObject(deps.bucketRepo, deps.fileRepo))...)
 		router.GET(objectPath, protectedHandlers(limits, s3Auth, handlers.GetObjectOrPartsWithFactory(deps.bucketRepo, deps.sourceRepo, deps.fileRepo, deps.mpRepo, deps.sourceFactory))...)
 		router.GET(bucketPath, protectedHandlers(limits, s3Auth, handlers.ListObjectsOrUploads(deps.bucketRepo, deps.fileRepo, deps.mpRepo))...)
-		router.GET(bucketSlashPath, protectedHandlers(limits, s3Auth, handlers.ListObjectsOrUploads(deps.bucketRepo, deps.fileRepo, deps.mpRepo))...)
 		router.PUT(objectPath, protectedHandlers(limits, s3Auth, handlers.PutObjectOrPartWithFactory(deps.bucketRepo, deps.sourceRepo, deps.fileRepo, deps.mpRepo, uploadChunkSize, deps.sourceFactory))...)
 		router.POST(bucketPath, protectedHandlers(limits, s3Auth, handlers.PostBucketWithFactory(deps.bucketRepo, deps.sourceRepo, deps.fileRepo, deps.sourceFactory))...)
 		router.POST(objectPath, protectedHandlers(limits, s3Auth, handlers.PostObjectWithFactory(deps.bucketRepo, deps.sourceRepo, deps.fileRepo, deps.mpRepo, uploadChunkSize, deps.sourceFactory))...)

--- a/api-go/internal/app/router_test.go
+++ b/api-go/internal/app/router_test.go
@@ -149,6 +149,9 @@ func TestRegisterS3RoutesIncludesRootAndLegacyEndpoints(t *testing.T) {
 		method string
 		path   string
 	}{
+		{http.MethodGet, "/"},
+		{http.MethodGet, "/api/s3"},
+		{http.MethodHead, "/:bucket"},
 		{http.MethodGet, "/:bucket"},
 		{http.MethodHead, "/:bucket/*object"},
 		{http.MethodGet, "/:bucket/*object"},
@@ -156,6 +159,7 @@ func TestRegisterS3RoutesIncludesRootAndLegacyEndpoints(t *testing.T) {
 		{http.MethodPost, "/:bucket"},
 		{http.MethodPost, "/:bucket/*object"},
 		{http.MethodDelete, "/:bucket/*object"},
+		{http.MethodHead, "/api/s3/:bucket"},
 		{http.MethodGet, "/api/s3/:bucket"},
 		{http.MethodHead, "/api/s3/:bucket/*object"},
 		{http.MethodGet, "/api/s3/:bucket/*object"},

--- a/api-go/internal/docs/docs.go
+++ b/api-go/internal/docs/docs.go
@@ -15,6 +15,68 @@ const docTemplate = `{
     "host": "{{.Host}}",
     "basePath": "{{.BasePath}}",
     "paths": {
+        "/": {
+            "get": {
+                "produces": [
+                    "text/xml"
+                ],
+                "tags": [
+                    "s3"
+                ],
+                "summary": "List buckets",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/s3": {
+            "get": {
+                "produces": [
+                    "text/xml"
+                ],
+                "tags": [
+                    "s3"
+                ],
+                "summary": "List buckets",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/api/s3/{bucket}": {
             "get": {
                 "produces": [
@@ -24,6 +86,41 @@ const docTemplate = `{
                     "s3"
                 ],
                 "summary": "List objects",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Bucket key",
+                        "name": "bucket",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            },
+            "head": {
+                "tags": [
+                    "s3"
+                ],
+                "summary": "Head bucket",
                 "parameters": [
                     {
                         "type": "string",
@@ -2003,6 +2100,41 @@ const docTemplate = `{
                     "s3"
                 ],
                 "summary": "List objects",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Bucket key",
+                        "name": "bucket",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            },
+            "head": {
+                "tags": [
+                    "s3"
+                ],
+                "summary": "Head bucket",
                 "parameters": [
                     {
                         "type": "string",

--- a/api-go/internal/handlers/s3_bucket_discovery.go
+++ b/api-go/internal/handlers/s3_bucket_discovery.go
@@ -1,0 +1,145 @@
+package handlers
+
+import (
+	"context"
+	"encoding/xml"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/example/sfree/api-go/internal/repository"
+	"github.com/gin-gonic/gin"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+const s3BucketRegion = "us-east-1"
+
+type bucketAccessKeyReader interface {
+	GetByAccessKey(ctx context.Context, accessKey string) (*repository.Bucket, error)
+}
+
+type listAllMyBucketsResult struct {
+	XMLName xml.Name         `xml:"ListAllMyBucketsResult"`
+	Xmlns   string           `xml:"xmlns,attr"`
+	Owner   listBucketsOwner `xml:"Owner"`
+	Buckets bucketList       `xml:"Buckets"`
+}
+
+type listBucketsOwner struct {
+	ID          string `xml:"ID"`
+	DisplayName string `xml:"DisplayName,omitempty"`
+}
+
+type bucketList struct {
+	Buckets []bucketListEntry `xml:"Bucket"`
+}
+
+type bucketListEntry struct {
+	Name         string `xml:"Name"`
+	CreationDate string `xml:"CreationDate"`
+}
+
+type bucketLocationConstraint struct {
+	XMLName xml.Name `xml:"LocationConstraint"`
+	Xmlns   string   `xml:"xmlns,attr"`
+	Value   string   `xml:",chardata"`
+}
+
+func lookupBucketByAccessKey(c *gin.Context, repo bucketAccessKeyReader) (*repository.Bucket, bool) {
+	ctx := c.Request.Context()
+	accessKey := c.GetString("accessKey")
+	if accessKey == "" {
+		writeS3Error(c, http.StatusForbidden, "AccessDenied", "")
+		return nil, false
+	}
+	bucketDoc, err := repo.GetByAccessKey(ctx, accessKey)
+	if err != nil {
+		if err == mongo.ErrNoDocuments {
+			writeS3Error(c, http.StatusForbidden, "InvalidAccessKeyId", "")
+			return nil, false
+		}
+		slog.ErrorContext(ctx, "lookup bucket by access key", slog.String("error", err.Error()))
+		writeS3Error(c, http.StatusInternalServerError, "InternalError", "")
+		return nil, false
+	}
+	return bucketDoc, true
+}
+
+func setBucketRegionHeader(c *gin.Context) {
+	c.Header("x-amz-bucket-region", s3BucketRegion)
+}
+
+// ListBucketsS3 godoc
+// @Summary List buckets
+// @Tags s3
+// @Produce xml
+// @Success 200 {string} string ""
+// @Failure 403 {string} string ""
+// @Failure 500 {string} string ""
+// @Router / [get]
+// @Router /api/s3 [get]
+func ListBucketsS3(repo bucketAccessKeyReader) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if repo == nil {
+			c.Status(http.StatusServiceUnavailable)
+			return
+		}
+		bucketDoc, ok := lookupBucketByAccessKey(c, repo)
+		if !ok {
+			return
+		}
+		setBucketRegionHeader(c)
+		c.XML(http.StatusOK, listAllMyBucketsResult{
+			Xmlns: "http://s3.amazonaws.com/doc/2006-03-01/",
+			Owner: listBucketsOwner{
+				ID:          bucketDoc.UserID.Hex(),
+				DisplayName: bucketDoc.UserID.Hex(),
+			},
+			Buckets: bucketList{
+				Buckets: []bucketListEntry{{
+					Name:         bucketDoc.Key,
+					CreationDate: bucketDoc.CreatedAt.UTC().Format(time.RFC3339),
+				}},
+			},
+		})
+	}
+}
+
+// HeadBucket godoc
+// @Summary Head bucket
+// @Tags s3
+// @Param bucket path string true "Bucket key"
+// @Success 200 {string} string ""
+// @Failure 404 {string} string ""
+// @Failure 500 {string} string ""
+// @Router /{bucket} [head]
+// @Router /api/s3/{bucket} [head]
+func HeadBucket(bucketRepo objectBucketReader) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if bucketRepo == nil {
+			c.Status(http.StatusServiceUnavailable)
+			return
+		}
+		if _, ok := lookupBucket(c, bucketRepo); !ok {
+			return
+		}
+		setBucketRegionHeader(c)
+		c.Status(http.StatusOK)
+	}
+}
+
+func GetBucketLocation(bucketRepo objectBucketReader) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if bucketRepo == nil {
+			c.Status(http.StatusServiceUnavailable)
+			return
+		}
+		if _, ok := lookupBucket(c, bucketRepo); !ok {
+			return
+		}
+		setBucketRegionHeader(c)
+		c.XML(http.StatusOK, bucketLocationConstraint{
+			Xmlns: "http://s3.amazonaws.com/doc/2006-03-01/",
+		})
+	}
+}

--- a/api-go/internal/handlers/s3_bucket_discovery_test.go
+++ b/api-go/internal/handlers/s3_bucket_discovery_test.go
@@ -1,0 +1,150 @@
+package handlers
+
+import (
+	"context"
+	"encoding/xml"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/example/sfree/api-go/internal/repository"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+type fakeAccessKeyBucketReader struct {
+	bucket *repository.Bucket
+	err    error
+}
+
+func (r fakeAccessKeyBucketReader) GetByAccessKey(_ context.Context, _ string) (*repository.Bucket, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	return r.bucket, nil
+}
+
+func TestListBucketsS3ReturnsAuthenticatedBucket(t *testing.T) {
+	t.Parallel()
+
+	userID := primitive.NewObjectID()
+	createdAt := time.Date(2026, 4, 24, 12, 30, 45, 0, time.UTC)
+	c, w := newHandlerTestContext(t, http.MethodGet, "/", nil)
+	c.Set("accessKey", "bucket-access")
+
+	ListBucketsS3(fakeAccessKeyBucketReader{
+		bucket: &repository.Bucket{
+			UserID:    userID,
+			Key:       "bucket-alpha",
+			AccessKey: "bucket-access",
+			CreatedAt: createdAt,
+		},
+	})(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if got := w.Header().Get("x-amz-bucket-region"); got != s3BucketRegion {
+		t.Fatalf("expected region header %q, got %q", s3BucketRegion, got)
+	}
+
+	var result listAllMyBucketsResult
+	if err := xml.Unmarshal(w.Body.Bytes(), &result); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if result.Owner.ID != userID.Hex() || result.Owner.DisplayName != userID.Hex() {
+		t.Fatalf("unexpected owner: %+v", result.Owner)
+	}
+	if len(result.Buckets.Buckets) != 1 {
+		t.Fatalf("expected 1 bucket, got %d", len(result.Buckets.Buckets))
+	}
+	if got := result.Buckets.Buckets[0]; got.Name != "bucket-alpha" || got.CreationDate != createdAt.Format(time.RFC3339) {
+		t.Fatalf("unexpected bucket entry: %+v", got)
+	}
+}
+
+func TestListBucketsS3MissingAccessKeyReturnsAccessDenied(t *testing.T) {
+	t.Parallel()
+
+	c, w := newHandlerTestContext(t, http.MethodGet, "/", nil)
+	ListBucketsS3(fakeAccessKeyBucketReader{})(c)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", w.Code)
+	}
+	if body := w.Body.String(); !strings.Contains(body, "<Code>AccessDenied</Code>") {
+		t.Fatalf("unexpected body: %s", body)
+	}
+}
+
+func TestListBucketsS3UnknownAccessKeyReturnsInvalidAccessKeyID(t *testing.T) {
+	t.Parallel()
+
+	c, w := newHandlerTestContext(t, http.MethodGet, "/", nil)
+	c.Set("accessKey", "missing-access")
+
+	ListBucketsS3(fakeAccessKeyBucketReader{err: mongo.ErrNoDocuments})(c)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", w.Code)
+	}
+	if body := w.Body.String(); !strings.Contains(body, "<Code>InvalidAccessKeyId</Code>") {
+		t.Fatalf("unexpected body: %s", body)
+	}
+}
+
+func TestHeadBucketReturnsBucketRegionHeader(t *testing.T) {
+	t.Parallel()
+
+	c, w := newHandlerTestContext(t, http.MethodHead, "/bucket-alpha", nil, testRouteParam{Key: "bucket", Value: "bucket-alpha"})
+	c.Set("accessKey", "bucket-access")
+
+	HeadBucket(fakeObjectBucketReader{
+		bucket: &repository.Bucket{
+			ID:        primitive.NewObjectID(),
+			Key:       "bucket-alpha",
+			AccessKey: "bucket-access",
+		},
+	})(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if got := w.Header().Get("x-amz-bucket-region"); got != s3BucketRegion {
+		t.Fatalf("expected region header %q, got %q", s3BucketRegion, got)
+	}
+}
+
+func TestGetBucketLocationReturnsEmptyLocationConstraint(t *testing.T) {
+	t.Parallel()
+
+	c, w := newHandlerTestContext(t, http.MethodGet, "/bucket-alpha?location", nil, testRouteParam{Key: "bucket", Value: "bucket-alpha"})
+	c.Set("accessKey", "bucket-access")
+
+	GetBucketLocation(fakeObjectBucketReader{
+		bucket: &repository.Bucket{
+			ID:        primitive.NewObjectID(),
+			Key:       "bucket-alpha",
+			AccessKey: "bucket-access",
+		},
+	})(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if got := w.Header().Get("x-amz-bucket-region"); got != s3BucketRegion {
+		t.Fatalf("expected region header %q, got %q", s3BucketRegion, got)
+	}
+
+	var result bucketLocationConstraint
+	if err := xml.Unmarshal(w.Body.Bytes(), &result); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if result.Xmlns != "http://s3.amazonaws.com/doc/2006-03-01/" {
+		t.Fatalf("unexpected xmlns: %q", result.Xmlns)
+	}
+	if result.Value != "" {
+		t.Fatalf("expected empty location constraint, got %q", result.Value)
+	}
+}

--- a/api-go/internal/handlers/s3_multipart.go
+++ b/api-go/internal/handlers/s3_multipart.go
@@ -227,17 +227,23 @@ func GetObjectOrPartsWithFactory(bucketRepo *repository.BucketRepository, source
 
 // ListObjectsOrUploads dispatches GET requests on bucket paths.
 // ?uploads → ListMultipartUploads
+// ?location → GetBucketLocation
 // ?list-type=2 → ListObjectsV2
 // otherwise → ListObjects
 func ListObjectsOrUploads(bucketRepo *repository.BucketRepository, fileRepo *repository.FileRepository, mpRepo *repository.MultipartUploadRepository) gin.HandlerFunc {
 	listHandler := ListObjects(bucketRepo, fileRepo)
 	listV2Handler := ListObjectsV2(bucketRepo, fileRepo)
+	locationHandler := GetBucketLocation(bucketRepo)
 	return func(c *gin.Context) {
 		if mpRepo != nil {
 			if _, ok := c.GetQuery("uploads"); ok {
 				listMultipartUploads(c, bucketRepo, mpRepo)
 				return
 			}
+		}
+		if _, ok := c.GetQuery("location"); ok {
+			locationHandler(c)
+			return
 		}
 		if c.Query("list-type") == "2" {
 			listV2Handler(c)

--- a/api-go/internal/handlers/s3_multipart.go
+++ b/api-go/internal/handlers/s3_multipart.go
@@ -214,7 +214,12 @@ func GetObjectOrParts(bucketRepo *repository.BucketRepository, sourceRepo *repos
 
 func GetObjectOrPartsWithFactory(bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository, mpRepo *repository.MultipartUploadRepository, factory manager.SourceClientFactory) gin.HandlerFunc {
 	getHandler := GetObjectWithFactory(bucketRepo, sourceRepo, fileRepo, factory)
+	listHandler := ListObjectsOrUploads(bucketRepo, fileRepo, mpRepo)
 	return func(c *gin.Context) {
+		if s3ObjectKey(c) == "" {
+			listHandler(c)
+			return
+		}
 		if mpRepo != nil {
 			if _, ok := c.GetQuery("uploadId"); ok {
 				listParts(c, bucketRepo, mpRepo)

--- a/api-go/internal/repository/bucket.go
+++ b/api-go/internal/repository/bucket.go
@@ -84,6 +84,15 @@ func (r *BucketRepository) GetByKey(ctx context.Context, key string) (*Bucket, e
 	return &b, nil
 }
 
+func (r *BucketRepository) GetByAccessKey(ctx context.Context, accessKey string) (*Bucket, error) {
+	var b Bucket
+	err := r.coll.FindOne(ctx, bson.M{"access_key": accessKey}).Decode(&b)
+	if err != nil {
+		return nil, err
+	}
+	return &b, nil
+}
+
 func (r *BucketRepository) GetSecretByAccessKey(ctx context.Context, accessKey string) (string, error) {
 	var b Bucket
 	err := r.coll.FindOne(ctx, bson.M{"access_key": accessKey}).Decode(&b)

--- a/docs/s3-compatibility.md
+++ b/docs/s3-compatibility.md
@@ -8,7 +8,7 @@ Reference: [Amazon S3 API operations](https://docs.aws.amazon.com/AmazonS3/lates
 
 ## Summary
 
-SFree supports the core object lifecycle: upload, download, head, copy, single-delete, multi-delete, ListObjectsV2, byte-range downloads, and multipart upload. The main compatibility gaps are bucket-discovery calls used by general-purpose clients, checksums, and advanced bucket/object APIs.
+SFree supports the core object lifecycle: upload, download, head, copy, single-delete, multi-delete, ListObjectsV2, byte-range downloads, multipart upload, and minimal bucket-discovery probes. The main compatibility gaps are full account-style bucket administration, checksums, and advanced bucket/object APIs.
 
 Validated v0.2 SDK compatibility scope:
 
@@ -63,10 +63,10 @@ Bucket administration APIs, ACLs, versioning, lifecycle, object lock, tagging, a
 
 | S3 operation | Status | Notes |
 | --- | --- | --- |
-| ListBuckets | Missing | Buckets are managed through SFree REST APIs, not S3 `GET /`. |
-| HeadBucket | Missing | No S3 bucket existence probe route. |
+| ListBuckets | Partial | `GET /` and `GET /api/s3` now return the single bucket bound to the signed SFree bucket credentials. This covers setup/discovery probes but does not model account-wide multi-bucket inventory. |
+| HeadBucket | Implemented | `HEAD /{bucket}` and `HEAD /api/s3/{bucket}` validate bucket existence for the matching bucket credentials and return `x-amz-bucket-region: us-east-1`. |
 | CreateBucket / DeleteBucket | Missing | Bucket lifecycle uses `/api/v1/buckets`. |
-| GetBucketLocation | Missing | Many clients use this during setup or endpoint validation. |
+| GetBucketLocation | Implemented | `GET /{bucket}?location` and the legacy alias return an empty `LocationConstraint`, matching `us-east-1` semantics for setup and endpoint validation. |
 | Bucket policy, ACL, CORS, lifecycle, versioning, tagging, website, logging, replication APIs | Missing | Not modeled for the S3 API. |
 
 ### Authentication And Request Features
@@ -100,7 +100,7 @@ These checks are based on the current S3 API surface and known request patterns 
 | Workflow | Expected result on `origin/main` | Blocking gaps |
 | --- | --- | --- |
 | Configure S3 remote with path-style endpoint | Partial | Requires explicit endpoint and path-style configuration. |
-| `rclone lsd` / bucket discovery | No | `ListBuckets` is missing. |
+| `rclone lsd` / bucket discovery | Expected for the signed bucket credentials | Minimal `ListBuckets`, `HeadBucket`, and `GetBucketLocation` probes now exist, but discovery remains bucket-scoped because SFree credentials map to a single bucket. Live rclone execution is still not automated in this PR. |
 | `rclone ls remote:bucket` | Expected for direct bucket paths | ListObjectsV2 prefix/delimiter/pagination is implemented, but live rclone validation is still manual/not automated in this PR. |
 | `rclone copy local remote:bucket` | Partial | Basic PutObject, multipart upload, copy, and listing paths exist; live rclone validation is still manual/not automated in this PR. |
 | `rclone cat remote:bucket/key` | Yes for full-object reads | Basic GetObject works. |
@@ -112,7 +112,7 @@ These checks are based on the current S3 API surface and known request patterns 
 
 | Workflow | Expected result on `origin/main` | Blocking gaps |
 | --- | --- | --- |
-| `s3cmd ls` | No | `ListBuckets` is missing. |
+| `s3cmd ls` | Expected for the signed bucket credentials | Bucket-discovery probes now exist, but the returned inventory is intentionally limited to the bucket associated with the presented SFree bucket credentials. Live s3cmd validation is not automated in this PR. |
 | `s3cmd ls s3://bucket/` | Partial | V1 list behavior has Go e2e coverage for prefix/delimiter, but live s3cmd validation is not automated in this PR. |
 | `s3cmd put file s3://bucket/key` | Yes for simple uploads | PutObject works. |
 | `s3cmd get s3://bucket/key file` | Yes for full-object downloads | GetObject works. |
@@ -123,7 +123,7 @@ These checks are based on the current S3 API surface and known request patterns 
 
 | Workflow | Expected result on `origin/main` | Blocking gaps |
 | --- | --- | --- |
-| `aws s3 ls` | No | `ListBuckets` is missing. |
+| `aws s3 ls` | Expected for the signed bucket credentials | Minimal bucket-discovery probes now exist, but the returned inventory remains bucket-scoped because SFree uses per-bucket S3 credentials. Live AWS CLI validation is still not automated in this PR. |
 | `aws s3 ls s3://bucket/` | Expected for direct bucket paths | High-level `aws s3` listing uses ListObjectsV2, which is now covered through SDK tests; live AWS CLI validation is not automated in this PR. |
 | `aws s3 cp local s3://bucket/key` | Yes for simple uploads | PutObject works, including Content-Type and user metadata persistence. |
 | `aws s3 cp s3://bucket/key local` | Yes for full-object downloads | GetObject works. |
@@ -136,9 +136,9 @@ These checks are based on the current S3 API surface and known request patterns 
 | Workflow | Expected result on `origin/main` | Blocking gaps |
 | --- | --- | --- |
 | Configure alias with SFree endpoint | Yes for root-style endpoints | `mc alias set` accepts `scheme://host[:port]/`, so the root-style S3 endpoint now works without a reverse-proxy remap. The legacy `/api/s3` URL shape is still rejected by `mc` because it includes a resource component. If a bucket key collides with a reserved top-level app route on the same host, keep using the legacy `/api/s3` alias or a dedicated S3 hostname. |
-| `mc ls alias/bucket` | Expected for direct bucket paths | Root-style alias setup removes the endpoint-shape blocker; live `mc` execution still needs Woodpecker or documented manual evidence before broader compatibility claims change. |
+| `mc ls alias/bucket` | Expected for direct bucket paths | Root-style alias setup removes the endpoint-shape blocker; broader `mc` workflows beyond the current smoke coverage still need separate live validation. |
 | `mc cp file alias/bucket/key` | Expected for simple uploads | Root-style alias setup is now possible; broader recursive workflows still need separate live validation. |
-| `mc cat alias/bucket/key` | Expected for full-object reads | Root-style alias setup is now possible; direct read behavior should follow the existing GetObject surface. |
+| `mc cat alias/bucket/key` | Yes | Woodpecker smoke now validates a real `mc` read against the root-style endpoint after uploading a fixture object through SFree. |
 | `mc rm alias/bucket/key` | Expected for single keys | Root-style alias setup is now possible; delete semantics still need live-client verification for stronger public claims. |
 | Recursive remove or mirror | Partial at best | Even with an alias workaround, broader recursive workflows would still need live-client validation and may hit metadata fidelity gaps. |
 

--- a/scripts/woodpecker-smoke.sh
+++ b/scripts/woodpecker-smoke.sh
@@ -182,6 +182,7 @@ pass "sfree download returns matching bytes"
 step "MinIO client root-endpoint download"
 docker run --rm \
 	--network "${COMPOSE_PROJECT_NAME}_default" \
+	--entrypoint sh \
 	"$MINIO_MC_IMAGE" sh -ceu '
 		mc alias set --api S3v4 --path on sfree http://api:8080 "$1" "$2" >/dev/null
 		mc cat "sfree/$3/$4"

--- a/scripts/woodpecker-smoke.sh
+++ b/scripts/woodpecker-smoke.sh
@@ -130,7 +130,7 @@ source_name="smoke-source-$suffix"
 bucket_key="smoke-bucket-$suffix"
 payload="$tmpdir/payload.txt"
 cli_download="$tmpdir/cli-download.txt"
-s3_download="$tmpdir/s3-download.txt"
+mc_download="$tmpdir/mc-download.txt"
 share_download="$tmpdir/share-download.txt"
 
 printf 'sfree smoke payload %s\n' "$suffix" > "$payload"
@@ -179,10 +179,15 @@ step "CLI download"
 cmp "$payload" "$cli_download"
 pass "sfree download returns matching bytes"
 
-step "S3 credential download"
-"$tmpdir/smoke-helper" s3-get "$base_url/api/s3" "$access_key" "$access_secret" "$bucket_key" "$(basename "$payload")" "$s3_download"
-cmp "$payload" "$s3_download"
-pass "Downloaded bytes match through S3-compatible credentials"
+step "MinIO client root-endpoint download"
+docker run --rm \
+	--network "${COMPOSE_PROJECT_NAME}_default" \
+	"$MINIO_MC_IMAGE" sh -ceu '
+		mc alias set --api S3v4 --path on sfree http://api:8080 "$1" "$2" >/dev/null
+		mc cat "sfree/$3/$4"
+	' sh "$access_key" "$access_secret" "$bucket_key" "$(basename "$payload")" > "$mc_download"
+cmp "$payload" "$mc_download"
+pass "Downloaded bytes match through MinIO client on the root S3 endpoint"
 
 step "Frontend-origin public share download"
 share_path="$("$tmpdir/smoke-helper" share-url "$base_url" "$username" "$password" "$bucket_id" "$file_id")"

--- a/scripts/woodpecker-smoke.sh
+++ b/scripts/woodpecker-smoke.sh
@@ -183,7 +183,7 @@ step "MinIO client root-endpoint download"
 docker run --rm \
 	--network "${COMPOSE_PROJECT_NAME}_default" \
 	--entrypoint sh \
-	"$MINIO_MC_IMAGE" sh -ceu '
+	"$MINIO_MC_IMAGE" -ceu '
 		mc alias set --api S3v4 --path on sfree http://api:8080 "$1" "$2" >/dev/null
 		mc cat "sfree/$3/$4"
 	' sh "$access_key" "$access_secret" "$bucket_key" "$(basename "$payload")" > "$mc_download"


### PR DESCRIPTION
## Summary
- add minimal S3 bucket-discovery compatibility endpoints for `ListBuckets`, `HeadBucket`, and `GetBucketLocation`
- route discovery requests on both the root S3 endpoint and the legacy `/api/s3` alias, and cover them with focused Go tests
- support the bucket-root trailing-slash form MinIO Client exercises by routing empty object-key GETs back into bucket listing instead of object fetch
- follow up on Woodpecker by regenerating `api-go/internal/docs/docs.go` for the new S3 routes and fixing the MinIO `mc` smoke invocation to use the shell entrypoint correctly

## Testing
- `go test ./internal/handlers ./internal/app`
- `go test ./cmd/woodpecker-smoke-helper`
- no additional local validation in the CI follow-up; fixes were derived from Woodpecker failures