### PR TITLE
THE-820 Shared authenticated app shell with navbar

### DIFF
--- a/webui/src/app/index.tsx
+++ b/webui/src/app/index.tsx
@@ -7,6 +7,7 @@ import SourcesPage from "../pages/sources";
 import SourcePage from "../pages/source";
 import {OAuthCallback} from "../pages/auth-callback";
 import {isAuthenticated} from "../shared/lib/auth";
+import {AppShell} from "../widgets/app-shell";
 
 export default function App() {
   return (
@@ -17,11 +18,13 @@ export default function App() {
           element={isAuthenticated() ? <Navigate to="/dashboard" replace /> : <LandingPage />}
         />
         <Route path="/auth/callback" element={<OAuthCallback />} />
-        <Route path="/dashboard" element={<DashboardPage />} />
-        <Route path="/buckets" element={<BucketsPage />} />
-        <Route path="/buckets/:id" element={<BucketPage />} />
-        <Route path="/sources" element={<SourcesPage />} />
-        <Route path="/sources/:id" element={<SourcePage />} />
+        <Route element={<AppShell />}>
+          <Route path="/dashboard" element={<DashboardPage />} />
+          <Route path="/buckets" element={<BucketsPage />} />
+          <Route path="/buckets/:id" element={<BucketPage />} />
+          <Route path="/sources" element={<SourcesPage />} />
+          <Route path="/sources/:id" element={<SourcePage />} />
+        </Route>
       </Routes>
     </BrowserRouter>
   );

--- a/webui/src/pages/bucket/ui/bucket-page.tsx
+++ b/webui/src/pages/bucket/ui/bucket-page.tsx
@@ -6,7 +6,7 @@ import {
 } from "@heroui/react";
 import {addToast} from "@heroui/toast";
 import {useCallback, useDeferredValue, useEffect, useRef, useState} from "react";
-import {useNavigate, useParams} from "react-router-dom";
+import {Link, useNavigate, useParams} from "react-router-dom";
 import {
   deleteFile,
   downloadFile,
@@ -16,7 +16,7 @@ import {
 } from "../../../shared/api/buckets";
 import type {Bucket, FileInfo} from "../../../shared/api/buckets";
 import {DownloadIcon, ShareIcon} from "../../../shared/icons";
-import {DeleteIcon, ArrowLeftIcon} from "@heroui/shared-icons";
+import {DeleteIcon} from "@heroui/shared-icons";
 import {ConfirmDialog, EmptyState} from "../../../shared/ui";
 import {FilePreviewModal} from "../../../features/bucket/ui/file-preview-modal";
 import {ShareBucketDialog} from "../../../features/bucket/ui/share-bucket-dialog";
@@ -151,7 +151,7 @@ export function BucketPage() {
 
   if (isLoading) {
     return (
-      <div className="p-8 flex items-center justify-center min-h-[200px]">
+      <div className="p-6 sm:p-8 flex items-center justify-center min-h-[200px]">
         <Spinner size="lg" />
       </div>
     );
@@ -159,10 +159,10 @@ export function BucketPage() {
 
   if (error) {
     return (
-      <div className="p-8">
-        <Button isIconOnly variant="light" onPress={() => navigate(-1)}>
-          <ArrowLeftIcon className="w-5 h-5" />
-        </Button>
+      <div className="p-6 sm:p-8">
+        <Link to="/buckets" className="text-sm text-default-500 hover:text-primary transition-colors">
+          &larr; Buckets
+        </Link>
         <EmptyState
           title="Failed to load bucket"
           description={error}
@@ -176,10 +176,10 @@ export function BucketPage() {
 
   if (!bucket) {
     return (
-      <div className="p-8">
-        <Button isIconOnly variant="light" onPress={() => navigate("/buckets")}>
-          <ArrowLeftIcon className="w-5 h-5" />
-        </Button>
+      <div className="p-6 sm:p-8">
+        <Link to="/buckets" className="text-sm text-default-500 hover:text-primary transition-colors">
+          &larr; Buckets
+        </Link>
         <EmptyState
           title="Bucket not found"
           description="This bucket may have been deleted."
@@ -200,15 +200,10 @@ export function BucketPage() {
       : "Files shared in this bucket will appear here.";
 
   return (
-    <div className="p-8 flex flex-col gap-6">
-      <Button
-        isIconOnly
-        aria-label="Back"
-        variant="light"
-        onPress={() => navigate(-1)}
-      >
-        <ArrowLeftIcon className="w-5 h-5" />
-      </Button>
+    <div className="p-6 sm:p-8 flex flex-col gap-6">
+      <Link to="/buckets" className="text-sm text-default-500 hover:text-primary transition-colors">
+        &larr; Buckets
+      </Link>
       <div className="flex flex-col gap-1">
         <h1 className="text-3xl font-bold">{bucket.key}</h1>
         <p>ID: {bucket.id}</p>

--- a/webui/src/pages/buckets/ui/buckets-page.tsx
+++ b/webui/src/pages/buckets/ui/buckets-page.tsx
@@ -51,7 +51,7 @@ export function BucketsPage() {
   }, []);
 
   return (
-    <div className="p-8 flex flex-col gap-6">
+    <div className="p-6 sm:p-8 flex flex-col gap-6">
       <div className="flex justify-between items-center">
         <h1 className="text-3xl font-bold">Buckets</h1>
         <Button color="primary" onPress={create.onOpen}>

--- a/webui/src/pages/dashboard/ui/dashboard-page.tsx
+++ b/webui/src/pages/dashboard/ui/dashboard-page.tsx
@@ -64,7 +64,7 @@ export function DashboardPage() {
 
   if (isLoading) {
     return (
-      <div className="p-8 flex flex-col gap-8">
+      <div className="p-6 sm:p-8 flex flex-col gap-8">
         <h1 className="text-3xl font-bold">Dashboard</h1>
         <p className="text-default-500">Loading...</p>
       </div>
@@ -72,7 +72,7 @@ export function DashboardPage() {
   }
 
   return (
-    <div className="p-8 flex flex-col gap-8">
+    <div className="p-6 sm:p-8 flex flex-col gap-8">
       <h1 className="text-3xl font-bold">Dashboard</h1>
 
       {/* Summary stat cards */}
@@ -168,15 +168,6 @@ export function DashboardPage() {
         )}
       </div>
 
-      {/* Quick actions */}
-      <div className="flex gap-4">
-        <Button as={Link} variant="flat" to="/sources">
-          Manage Sources
-        </Button>
-        <Button as={Link} variant="flat" to="/buckets">
-          Manage Buckets
-        </Button>
-      </div>
     </div>
   );
 }

--- a/webui/src/pages/source/ui/source-page.tsx
+++ b/webui/src/pages/source/ui/source-page.tsx
@@ -1,12 +1,11 @@
 import {Button, CircularProgress, Spinner} from "@heroui/react";
 import {useCallback, useEffect, useState} from "react";
-import {useNavigate, useParams} from "react-router-dom";
+import {Link, useNavigate, useParams} from "react-router-dom";
 import {downloadFile, getSourceInfo} from "../../../shared/api/sources";
 import type {SourceFile, SourceInfo} from "../../../shared/api/sources";
 import {showErrorToast} from "../../../shared/api/error";
 import {SourceTypeChip} from "../../../entities/source";
 import {DownloadIcon} from "../../../shared/icons";
-import {ArrowLeftIcon} from "@heroui/shared-icons";
 import {EmptyState} from "../../../shared/ui";
 
 export function SourcePage() {
@@ -41,7 +40,7 @@ export function SourcePage() {
 
   if (isLoading) {
     return (
-      <div className="p-8 flex items-center justify-center min-h-[200px]">
+      <div className="p-6 sm:p-8 flex items-center justify-center min-h-[200px]">
         <Spinner size="lg" />
       </div>
     );
@@ -49,10 +48,10 @@ export function SourcePage() {
 
   if (error) {
     return (
-      <div className="p-8">
-        <Button isIconOnly variant="light" onPress={() => navigate(-1)}>
-          <ArrowLeftIcon className="w-5 h-5" />
-        </Button>
+      <div className="p-6 sm:p-8">
+        <Link to="/sources" className="text-sm text-default-500 hover:text-primary transition-colors">
+          &larr; Sources
+        </Link>
         <EmptyState
           title="Failed to load source"
           description={error}
@@ -66,10 +65,10 @@ export function SourcePage() {
 
   if (!info) {
     return (
-      <div className="p-8">
-        <Button isIconOnly variant="light" onPress={() => navigate("/sources")}>
-          <ArrowLeftIcon className="w-5 h-5" />
-        </Button>
+      <div className="p-6 sm:p-8">
+        <Link to="/sources" className="text-sm text-default-500 hover:text-primary transition-colors">
+          &larr; Sources
+        </Link>
         <EmptyState
           title="Source not found"
           description="This source may have been deleted."
@@ -85,10 +84,10 @@ export function SourcePage() {
     : 0;
 
   return (
-    <div className="p-8 flex flex-col gap-6">
-      <Button isIconOnly variant="light" onPress={() => navigate(-1)}>
-        <ArrowLeftIcon className="w-5 h-5" />
-      </Button>
+    <div className="p-6 sm:p-8 flex flex-col gap-6">
+      <Link to="/sources" className="text-sm text-default-500 hover:text-primary transition-colors">
+        &larr; Sources
+      </Link>
       <h1 className="text-3xl font-bold">{info.name}</h1>
       <SourceTypeChip type={info.type} />
       <div className="flex justify-center">

--- a/webui/src/pages/sources/ui/sources-page.tsx
+++ b/webui/src/pages/sources/ui/sources-page.tsx
@@ -128,7 +128,7 @@ export function SourcesPage() {
   }
 
   return (
-    <div className="p-8 flex flex-col gap-6">
+    <div className="p-6 sm:p-8 flex flex-col gap-6">
       <div className="flex justify-between items-center">
         <h1 className="text-3xl font-bold">Sources</h1>
         <Button color="primary" onPress={create.onOpen}>

--- a/webui/src/widgets/app-shell.tsx
+++ b/webui/src/widgets/app-shell.tsx
@@ -1,0 +1,147 @@
+import {
+  Navbar,
+  NavbarBrand,
+  NavbarContent,
+  NavbarItem,
+  NavbarMenuToggle,
+  NavbarMenu,
+  NavbarMenuItem,
+  Button,
+  Dropdown,
+  DropdownTrigger,
+  DropdownMenu,
+  DropdownItem,
+  Avatar,
+} from "@heroui/react";
+import {useState} from "react";
+import {Link, NavLink, Outlet, useNavigate} from "react-router-dom";
+import {logout} from "../shared/lib/auth";
+
+const navItems = [
+  {label: "Dashboard", to: "/dashboard"},
+  {label: "Sources", to: "/sources"},
+  {label: "Buckets", to: "/buckets"},
+] as const;
+
+function getUsername(): string {
+  return localStorage.getItem("username") ?? "User";
+}
+
+function UserInitial({name}: {name: string}) {
+  return (
+    <Avatar
+      size="sm"
+      name={name.charAt(0).toUpperCase()}
+      classNames={{base: "bg-primary text-primary-foreground cursor-pointer"}}
+    />
+  );
+}
+
+export function AppShell() {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const navigate = useNavigate();
+  const username = getUsername();
+
+  function handleLogout() {
+    logout();
+    navigate("/");
+  }
+
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Navbar
+        maxWidth="full"
+        isMenuOpen={menuOpen}
+        onMenuOpenChange={setMenuOpen}
+        classNames={{
+          base: "border-b border-divider",
+          wrapper: "px-4 sm:px-6",
+        }}
+      >
+        <NavbarContent className="gap-4" justify="start">
+          <NavbarMenuToggle
+            aria-label={menuOpen ? "Close menu" : "Open menu"}
+            className="sm:hidden"
+          />
+          <NavbarBrand>
+            <Link to="/dashboard" className="font-bold text-lg text-foreground">
+              SFree
+            </Link>
+          </NavbarBrand>
+        </NavbarContent>
+
+        <NavbarContent className="hidden sm:flex gap-6" justify="center">
+          {navItems.map((item) => (
+            <NavbarItem key={item.to}>
+              <NavLink
+                to={item.to}
+                className={({isActive}) =>
+                  isActive
+                    ? "text-primary font-semibold"
+                    : "text-foreground hover:text-primary transition-colors"
+                }
+              >
+                {item.label}
+              </NavLink>
+            </NavbarItem>
+          ))}
+        </NavbarContent>
+
+        <NavbarContent justify="end">
+          <NavbarItem>
+            <Dropdown placement="bottom-end">
+              <DropdownTrigger>
+                <button type="button" aria-label="User menu">
+                  <UserInitial name={username} />
+                </button>
+              </DropdownTrigger>
+              <DropdownMenu aria-label="User actions">
+                <DropdownItem key="profile" isReadOnly className="opacity-100">
+                  <span className="font-semibold">{username}</span>
+                </DropdownItem>
+                <DropdownItem
+                  key="logout"
+                  color="danger"
+                  onPress={handleLogout}
+                >
+                  Log Out
+                </DropdownItem>
+              </DropdownMenu>
+            </Dropdown>
+          </NavbarItem>
+        </NavbarContent>
+
+        {/* Mobile menu */}
+        <NavbarMenu>
+          {navItems.map((item) => (
+            <NavbarMenuItem key={item.to}>
+              <NavLink
+                to={item.to}
+                className={({isActive}) =>
+                  `w-full ${isActive ? "text-primary font-semibold" : "text-foreground"}`
+                }
+                onClick={() => setMenuOpen(false)}
+              >
+                {item.label}
+              </NavLink>
+            </NavbarMenuItem>
+          ))}
+          <NavbarMenuItem>
+            <Button
+              variant="flat"
+              color="danger"
+              className="w-full mt-4"
+              onPress={handleLogout}
+            >
+              Log Out
+            </Button>
+          </NavbarMenuItem>
+        </NavbarMenu>
+      </Navbar>
+
+      <main className="flex-1">
+        <Outlet />
+      </main>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds `AppShell` layout component (`webui/src/widgets/app-shell.tsx`) with a persistent HeroUI Navbar: brand link, nav items (Dashboard / Sources / Buckets), and user dropdown (avatar + logout)
- Wraps all authenticated routes in a layout `<Route>` so every page shares the shell; landing and auth-callback remain outside
- Replaces standalone back-button icons on detail pages with breadcrumb-style `← Sources` / `← Buckets` links
- Removes redundant "Manage Sources / Manage Buckets" buttons from the dashboard (now covered by persistent nav)
- Responsive: hamburger menu toggle on mobile (`sm:` breakpoint), full nav on desktop

## Test plan
- [ ] Verify navbar renders on `/dashboard`, `/sources`, `/buckets`, `/sources/:id`, `/buckets/:id`
- [ ] Verify landing page (`/`) and `/auth/callback` do **not** show the navbar
- [ ] Verify nav links highlight the active route
- [ ] Verify mobile hamburger menu opens/closes and navigates correctly
- [ ] Verify user dropdown shows username and Log Out works
- [ ] Verify breadcrumb links on detail pages navigate back to list pages
- [ ] Verify no layout regressions on existing pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)