### PR TITLE
THE-821 Add first-run onboarding flow

### DIFF
--- a/webui/e2e/buckets.spec.ts
+++ b/webui/e2e/buckets.spec.ts
@@ -3,7 +3,7 @@
  *
  * Covers:
  * - Buckets page renders with empty state
- * - "Add Bucket" dialog loads available sources
+ * - "Create Bucket" dialog loads available sources
  * - Selecting a source and submitting creates a bucket and shows credentials
  * - Upload File button is present on the bucket detail page
  */
@@ -64,18 +64,18 @@ test.describe("Bucket creation flow", () => {
     ).toBeVisible();
     await expect(page.getByText("No buckets yet")).toBeVisible();
     await expect(
-      page.getByRole("button", { name: "Add Bucket" }).first(),
+      page.getByRole("button", { name: /^(Add|Create) Bucket$/ }).first(),
     ).toBeVisible();
   });
 
-  test("Add Bucket dialog loads available sources", async ({ page }) => {
+  test("Create Bucket dialog loads available sources", async ({ page }) => {
     await injectAuth(page);
     await mockGet(page, "/buckets", []);
     await mockGet(page, "/sources", [MOCK_SOURCE]);
     await page.goto("/buckets");
     const dialog = page.getByRole("dialog");
 
-    await page.getByRole("button", { name: "Add Bucket" }).first().click();
+    await page.getByRole("button", { name: /^(Add|Create) Bucket$/ }).first().click();
     await expect(dialog).toBeVisible();
     await expect(
       dialog.getByText("Create Bucket"),
@@ -86,7 +86,7 @@ test.describe("Bucket creation flow", () => {
     await expect(dialog.getByText("My Drive", { exact: true })).toBeVisible();
   });
 
-  test("Add Bucket dialog surfaces source loading failures and retries", async ({ page }) => {
+  test("Create Bucket dialog surfaces source loading failures and retries", async ({ page }) => {
     await injectAuth(page);
     await mockGet(page, "/buckets", []);
     let sourceRequests = 0;
@@ -106,7 +106,7 @@ test.describe("Bucket creation flow", () => {
     await page.goto("/buckets");
     const dialog = page.getByRole("dialog");
 
-    await page.getByRole("button", { name: "Add Bucket" }).first().click();
+    await page.getByRole("button", { name: /^(Add|Create) Bucket$/ }).first().click();
     await expect(dialog).toBeVisible();
     await expect(dialog.getByText("Sources could not be loaded. Retry to try again.")).toBeVisible();
     await expect(dialog.getByText("Source service unavailable")).toBeVisible();
@@ -124,7 +124,7 @@ test.describe("Bucket creation flow", () => {
 
     await page.goto("/buckets");
     const dialog = page.getByRole("dialog");
-    await page.getByRole("button", { name: "Add Bucket" }).first().click();
+    await page.getByRole("button", { name: /^(Add|Create) Bucket$/ }).first().click();
     await expect(dialog).toBeVisible();
 
     // Wait for sources to load in dialog

--- a/webui/e2e/buckets.spec.ts
+++ b/webui/e2e/buckets.spec.ts
@@ -174,7 +174,7 @@ test.describe("Bucket creation flow", () => {
     ).toBeVisible();
     await expect(
       page.locator("p").filter({
-        hasText: /(Drag and drop a file here|Drop files here)/,
+        hasText: /(Drag and drop a file here|Drop files here|Drop a file here)/,
       }).first(),
     ).toBeVisible();
   });

--- a/webui/e2e/dashboard.spec.ts
+++ b/webui/e2e/dashboard.spec.ts
@@ -3,37 +3,39 @@
  *
  * Covers:
  * - Authenticated user at "/" redirects to "/dashboard"
- * - Dashboard heading and navigation cards render
- * - "Open" buttons navigate to /buckets and /sources
+ * - Fresh accounts see the onboarding hero on the dashboard
+ * - Returning users with sources and buckets see the normal dashboard view
  * - Unauthenticated user at "/" sees the landing page
  */
 
-import { test, expect, type Page } from "@playwright/test";
+import { test, expect } from "@playwright/test";
 import { injectAuth, mockGet, API_GLOB } from "./helpers";
 
-async function expectDashboardNav(
-  page: Page,
-  name: "Sources" | "Buckets",
-) {
-  const pattern =
-    name === "Sources"
-      ? /^(Manage Sources|Sources)$/
-      : /^(Manage Buckets|Buckets)$/;
-  await expect(
-    page.locator("a, button").filter({ hasText: pattern }).first(),
-  ).toBeVisible();
-}
+const MOCK_SOURCE = {
+  id: "src-1",
+  name: "My Drive",
+  type: "gdrive",
+  created_at: "2024-01-15T10:00:00Z",
+};
 
-async function clickDashboardNav(
-  page: Page,
-  name: "Sources" | "Buckets",
-) {
-  const pattern =
-    name === "Sources"
-      ? /^(Manage Sources|Sources)$/
-      : /^(Manage Buckets|Buckets)$/;
-  await page.locator("a, button").filter({ hasText: pattern }).first().click();
-}
+const MOCK_SOURCE_INFO = {
+  id: "src-1",
+  name: "My Drive",
+  type: "gdrive",
+  files: [{id: "file-1", name: "hello.txt", size: 12}],
+  storage_total: 1024,
+  storage_used: 12,
+  storage_free: 1012,
+};
+
+const MOCK_BUCKET = {
+  id: "bkt-1",
+  key: "first-bucket",
+  access_key: "AK123",
+  created_at: "2024-01-15T11:00:00Z",
+  role: "owner",
+  shared: false,
+};
 
 test.describe("Dashboard", () => {
   test("authenticated user at / redirects to /dashboard", async ({ page }) => {
@@ -43,10 +45,17 @@ test.describe("Dashboard", () => {
     await expect(page.getByRole("heading", { name: "Dashboard" })).toBeVisible();
   });
 
-  test("dashboard shows Buckets and Sources cards", async ({ page }) => {
+  test("fresh account dashboard shows onboarding hero", async ({ page }) => {
     await injectAuth(page);
+    await mockGet(page, "/sources", []);
+    await mockGet(page, "/buckets", []);
     await page.goto("/dashboard");
+
     await expect(page.getByRole("heading", { name: "Dashboard" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Get started with SFree" })).toBeVisible();
+    await expect(page.getByText("Three steps to your first upload.")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Add Source" })).toBeVisible();
+
     const summaryCards = page.locator(".grid.gap-4.grid-cols-2.lg\\:grid-cols-4");
     await expect(summaryCards.getByText("Sources", { exact: true })).toBeVisible();
     await expect(summaryCards.getByText("Buckets", { exact: true })).toBeVisible();
@@ -56,29 +65,26 @@ test.describe("Dashboard", () => {
     await expect(
       summaryCards.getByText("Storage Used", { exact: true }),
     ).toBeVisible();
-    await expectDashboardNav(page, "Sources");
-    await expectDashboardNav(page, "Buckets");
   });
 
-  test("Manage Buckets button navigates to /buckets", async ({ page }) => {
+  test("returning user dashboard hides onboarding and shows sources section", async ({ page }) => {
     await injectAuth(page);
-    await mockGet(page, "/buckets", []);
+    await mockGet(page, "/sources", [MOCK_SOURCE]);
+    await mockGet(page, "/sources/src-1/info", MOCK_SOURCE_INFO);
+    await mockGet(page, "/buckets", [MOCK_BUCKET]);
     await page.goto("/dashboard");
-    await clickDashboardNav(page, "Buckets");
-    await expect(page).toHaveURL("/buckets");
+
     await expect(
-      page.getByRole("heading", { name: /^Buckets$/, level: 1 }),
+      page.getByRole("heading", { name: "Dashboard" }),
     ).toBeVisible();
-  });
-
-  test("Manage Sources button navigates to /sources", async ({ page }) => {
-    await injectAuth(page);
-    await mockGet(page, "/sources", []);
-    await page.goto("/dashboard");
-    await clickDashboardNav(page, "Sources");
-    await expect(page).toHaveURL("/sources");
     await expect(
-      page.getByRole("heading", { name: /^Sources$/, level: 1 }),
+      page.getByRole("heading", { name: "Get started with SFree" }),
+    ).not.toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: /^Sources$/, level: 2 }),
+    ).toBeVisible();
+    await expect(
+      page.getByText("My Drive", { exact: true }),
     ).toBeVisible();
   });
 

--- a/webui/e2e/error-states.spec.ts
+++ b/webui/e2e/error-states.spec.ts
@@ -125,7 +125,7 @@ test.describe("Error states", () => {
       page.getByRole("heading", { name: /^Buckets$/, level: 1 }),
     ).toBeVisible();
     await expect(
-      page.getByRole("button", { name: "Add Bucket" }).first(),
+      page.getByRole("button", { name: /^(Add|Create) Bucket$/ }).first(),
     ).toBeVisible();
     await expect(
       page.getByRole("heading", { name: "Failed to load buckets" }),

--- a/webui/src/features/onboarding/index.ts
+++ b/webui/src/features/onboarding/index.ts
@@ -1,0 +1,1 @@
+export {OnboardingHero} from "./ui/onboarding-hero";

--- a/webui/src/features/onboarding/ui/onboarding-hero.tsx
+++ b/webui/src/features/onboarding/ui/onboarding-hero.tsx
@@ -1,0 +1,125 @@
+import {Button, Card, CardBody} from "@heroui/react";
+
+type StepStatus = "done" | "current" | "upcoming";
+
+type Step = {
+  number: number;
+  title: string;
+  description: string;
+  status: StepStatus;
+  ctaLabel?: string;
+  onCta?: () => void;
+};
+
+function CheckIcon({className}: {className?: string}) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" className={className}>
+      <polyline points="20 6 9 17 4 12" />
+    </svg>
+  );
+}
+
+function StepIndicator({step}: {step: Step}) {
+  if (step.status === "done") {
+    return (
+      <div className="w-8 h-8 rounded-full bg-success flex items-center justify-center shrink-0">
+        <CheckIcon className="w-4 h-4 text-success-foreground" />
+      </div>
+    );
+  }
+  if (step.status === "current") {
+    return (
+      <div className="w-8 h-8 rounded-full bg-primary flex items-center justify-center shrink-0">
+        <span className="text-sm font-bold text-primary-foreground">{step.number}</span>
+      </div>
+    );
+  }
+  return (
+    <div className="w-8 h-8 rounded-full bg-default-200 flex items-center justify-center shrink-0">
+      <span className="text-sm font-bold text-default-500">{step.number}</span>
+    </div>
+  );
+}
+
+function StepRow({step, isLast}: {step: Step; isLast: boolean}) {
+  return (
+    <div className="flex gap-4">
+      <div className="flex flex-col items-center">
+        <StepIndicator step={step} />
+        {!isLast && (
+          <div className={`w-0.5 flex-1 my-1 ${step.status === "done" ? "bg-success" : "bg-default-200"}`} />
+        )}
+      </div>
+      <div className={`pb-6 ${isLast ? "pb-0" : ""}`}>
+        <p className={`font-semibold ${step.status === "upcoming" ? "text-default-400" : ""}`}>
+          {step.title}
+        </p>
+        <p className={`text-sm mt-0.5 ${step.status === "upcoming" ? "text-default-300" : "text-default-500"}`}>
+          {step.description}
+        </p>
+        {step.status === "current" && step.ctaLabel && step.onCta && (
+          <Button size="sm" color="primary" className="mt-2" onPress={step.onCta}>
+            {step.ctaLabel}
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+type Props = {
+  hasSources: boolean;
+  hasBuckets: boolean;
+  onAddSource: () => void;
+  onAddBucket: () => void;
+  onGoToBucket: () => void;
+};
+
+export function OnboardingHero({hasSources, hasBuckets, onAddSource, onAddBucket, onGoToBucket}: Props) {
+  const steps: Step[] = [
+    {
+      number: 1,
+      title: "Connect a source",
+      description: hasSources
+        ? "Source connected."
+        : "Link a Google Drive, Telegram, or S3 source so SFree knows where your files live.",
+      status: hasSources ? "done" : "current",
+      ctaLabel: "Add Source",
+      onCta: onAddSource,
+    },
+    {
+      number: 2,
+      title: "Create a bucket",
+      description: hasBuckets
+        ? "Bucket created."
+        : "Buckets give you S3-compatible access to upload and manage files.",
+      status: hasBuckets ? "done" : hasSources ? "current" : "upcoming",
+      ctaLabel: "Create Bucket",
+      onCta: onAddBucket,
+    },
+    {
+      number: 3,
+      title: "Upload your first file",
+      description: "Drop a file into your bucket to see SFree in action.",
+      status: hasSources && hasBuckets ? "current" : "upcoming",
+      ctaLabel: "Go to Bucket",
+      onCta: onGoToBucket,
+    },
+  ];
+
+  return (
+    <Card>
+      <CardBody className="p-6">
+        <h2 className="text-xl font-bold mb-1">Get started with SFree</h2>
+        <p className="text-sm text-default-500 mb-5">
+          Three steps to your first upload.
+        </p>
+        <div className="flex flex-col">
+          {steps.map((step, i) => (
+            <StepRow key={step.number} step={step} isLast={i === steps.length - 1} />
+          ))}
+        </div>
+      </CardBody>
+    </Card>
+  );
+}

--- a/webui/src/pages/bucket/ui/bucket-page.tsx
+++ b/webui/src/pages/bucket/ui/bucket-page.tsx
@@ -192,11 +192,15 @@ export function BucketPage() {
 
   const canManage = canManageBucket(bucket);
   const canWrite = canWriteFiles(bucket);
-  const emptyTitle = activeSearchQuery ? "No matching files" : "No files yet";
+  const emptyTitle = activeSearchQuery
+    ? "No matching files"
+    : canWrite
+      ? "Last step: upload your first file"
+      : "No files yet";
   const emptyDescription = activeSearchQuery
     ? `No files in this bucket match "${activeSearchQuery}".`
     : canWrite
-      ? "Drag and drop a file here, or use the Upload button."
+      ? "Drop a file here or click Upload to finish setting up your SFree account."
       : "Files shared in this bucket will appear here.";
 
   return (

--- a/webui/src/pages/buckets/ui/buckets-page.tsx
+++ b/webui/src/pages/buckets/ui/buckets-page.tsx
@@ -40,16 +40,20 @@ export function BucketsPage() {
     setIsLoading(true);
     setError(null);
     try {
-      const [bucketList, sources] = await Promise.all([
-        listBuckets(),
-        listSources(),
-      ]);
-      setBuckets(bucketList);
-      setSourceCount(sources.length);
+      setBuckets(await listBuckets());
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to load buckets");
     } finally {
       setIsLoading(false);
+    }
+    // Load source count independently so a source API failure
+    // never prevents viewing existing buckets.
+    try {
+      const sources = await listSources();
+      setSourceCount(sources.length);
+    } catch {
+      // Source count stays null; empty-state falls back to the
+      // generic "no buckets" message which still works fine.
     }
   }
 

--- a/webui/src/pages/buckets/ui/buckets-page.tsx
+++ b/webui/src/pages/buckets/ui/buckets-page.tsx
@@ -4,7 +4,6 @@ import {useEffect, useState} from "react";
 import {useNavigate} from "react-router-dom";
 import {CreateBucketDialog} from "../../../features/bucket";
 import {deleteBucket, listBuckets} from "../../../shared/api/buckets";
-import {listSources} from "../../../shared/api/sources";
 import type {Bucket} from "../../../shared/api/buckets";
 import {DeleteIcon} from "@heroui/shared-icons";
 import {ConfirmDialog, EmptyState} from "../../../shared/ui";
@@ -12,7 +11,6 @@ import {showErrorToast} from "../../../shared/api/error";
 
 export function BucketsPage() {
   const [buckets, setBuckets] = useState<Bucket[]>([]);
-  const [sourceCount, setSourceCount] = useState<number | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const navigate = useNavigate();
@@ -46,15 +44,6 @@ export function BucketsPage() {
     } finally {
       setIsLoading(false);
     }
-    // Load source count independently so a source API failure
-    // never prevents viewing existing buckets.
-    try {
-      const sources = await listSources();
-      setSourceCount(sources.length);
-    } catch {
-      // Source count stays null; empty-state falls back to the
-      // generic "no buckets" message which still works fine.
-    }
   }
 
   useEffect(() => {
@@ -82,21 +71,12 @@ export function BucketsPage() {
           variant="danger"
         />
       ) : buckets.length === 0 ? (
-        sourceCount === 0 ? (
-          <EmptyState
-            title="Connect a source first"
-            description="Before creating a bucket you need at least one source. Head to Sources to connect one."
-            ctaLabel="Go to Sources"
-            onCtaPress={() => navigate("/sources")}
-          />
-        ) : (
-          <EmptyState
-            title="No buckets yet"
-            description="Step 2: create a bucket to get S3-compatible access to your files. Almost there!"
-            ctaLabel="Create Bucket"
-            onCtaPress={create.onOpen}
-          />
-        )
+        <EmptyState
+          title="No buckets yet"
+          description="Step 2: create a bucket to get S3-compatible access to your files. Almost there!"
+          ctaLabel="Create Bucket"
+          onCtaPress={create.onOpen}
+        />
       ) : (
         <div className="grid gap-4 sm:grid-cols-2">
           {buckets.map((b) => (

--- a/webui/src/pages/buckets/ui/buckets-page.tsx
+++ b/webui/src/pages/buckets/ui/buckets-page.tsx
@@ -4,6 +4,7 @@ import {useEffect, useState} from "react";
 import {useNavigate} from "react-router-dom";
 import {CreateBucketDialog} from "../../../features/bucket";
 import {deleteBucket, listBuckets} from "../../../shared/api/buckets";
+import {listSources} from "../../../shared/api/sources";
 import type {Bucket} from "../../../shared/api/buckets";
 import {DeleteIcon} from "@heroui/shared-icons";
 import {ConfirmDialog, EmptyState} from "../../../shared/ui";
@@ -11,6 +12,7 @@ import {showErrorToast} from "../../../shared/api/error";
 
 export function BucketsPage() {
   const [buckets, setBuckets] = useState<Bucket[]>([]);
+  const [sourceCount, setSourceCount] = useState<number | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const navigate = useNavigate();
@@ -38,7 +40,12 @@ export function BucketsPage() {
     setIsLoading(true);
     setError(null);
     try {
-      setBuckets(await listBuckets());
+      const [bucketList, sources] = await Promise.all([
+        listBuckets(),
+        listSources(),
+      ]);
+      setBuckets(bucketList);
+      setSourceCount(sources.length);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to load buckets");
     } finally {
@@ -71,12 +78,21 @@ export function BucketsPage() {
           variant="danger"
         />
       ) : buckets.length === 0 ? (
-        <EmptyState
-          title="No buckets yet"
-          description="Buckets give you S3-compatible access to your files. Create one to get started."
-          ctaLabel="Add Bucket"
-          onCtaPress={create.onOpen}
-        />
+        sourceCount === 0 ? (
+          <EmptyState
+            title="Connect a source first"
+            description="Before creating a bucket you need at least one source. Head to Sources to connect one."
+            ctaLabel="Go to Sources"
+            onCtaPress={() => navigate("/sources")}
+          />
+        ) : (
+          <EmptyState
+            title="No buckets yet"
+            description="Step 2: create a bucket to get S3-compatible access to your files. Almost there!"
+            ctaLabel="Create Bucket"
+            onCtaPress={create.onOpen}
+          />
+        )
       ) : (
         <div className="grid gap-4 sm:grid-cols-2">
           {buckets.map((b) => (

--- a/webui/src/pages/dashboard/ui/dashboard-page.tsx
+++ b/webui/src/pages/dashboard/ui/dashboard-page.tsx
@@ -1,9 +1,12 @@
-import {Card, CardBody, CardHeader, Button, CircularProgress} from "@heroui/react";
+import {Card, CardBody, CardHeader, CircularProgress, useDisclosure} from "@heroui/react";
 import {useEffect, useState} from "react";
-import {Link, useNavigate} from "react-router-dom";
+import {useNavigate} from "react-router-dom";
 import {listSources, getSourceInfo} from "../../../shared/api/sources";
 import {listBuckets} from "../../../shared/api/buckets";
 import {SourceTypeChip} from "../../../entities/source";
+import {OnboardingHero} from "../../../features/onboarding";
+import {CreateSourceDialog} from "../../../features/source";
+import {CreateBucketDialog} from "../../../features/bucket";
 import type {Source, SourceInfo} from "../../../shared/api/sources";
 import type {Bucket} from "../../../shared/api/buckets";
 
@@ -22,34 +25,37 @@ export function DashboardPage() {
   const [sources, setSources] = useState<SourceWithInfo[]>([]);
   const [buckets, setBuckets] = useState<Bucket[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+  const createSource = useDisclosure();
+  const createBucket = useDisclosure();
+
+  async function load() {
+    setIsLoading(true);
+    try {
+      const [srcList, bucketList] = await Promise.all([
+        listSources(),
+        listBuckets(),
+      ]);
+      setBuckets(bucketList);
+
+      const withInfo = await Promise.all(
+        srcList.map(async (s) => {
+          try {
+            const info = await getSourceInfo(s.id);
+            return {...s, info};
+          } catch {
+            return {...s, info: null};
+          }
+        }),
+      );
+      setSources(withInfo);
+    } catch {
+      // keep empty state
+    } finally {
+      setIsLoading(false);
+    }
+  }
 
   useEffect(() => {
-    async function load() {
-      setIsLoading(true);
-      try {
-        const [srcList, bucketList] = await Promise.all([
-          listSources(),
-          listBuckets(),
-        ]);
-        setBuckets(bucketList);
-
-        const withInfo = await Promise.all(
-          srcList.map(async (s) => {
-            try {
-              const info = await getSourceInfo(s.id);
-              return {...s, info};
-            } catch {
-              return {...s, info: null};
-            }
-          }),
-        );
-        setSources(withInfo);
-      } catch {
-        // keep empty state
-      } finally {
-        setIsLoading(false);
-      }
-    }
     load();
   }, []);
 
@@ -61,6 +67,10 @@ export function DashboardPage() {
     (sum, s) => sum + (s.info?.storage_used ?? 0),
     0,
   );
+
+  const hasSources = sources.length > 0;
+  const hasBuckets = buckets.length > 0;
+  const showOnboarding = !hasSources || !hasBuckets;
 
   if (isLoading) {
     return (
@@ -74,6 +84,18 @@ export function DashboardPage() {
   return (
     <div className="p-6 sm:p-8 flex flex-col gap-8">
       <h1 className="text-3xl font-bold">Dashboard</h1>
+
+      {showOnboarding && (
+        <OnboardingHero
+          hasSources={hasSources}
+          hasBuckets={hasBuckets}
+          onAddSource={createSource.onOpen}
+          onAddBucket={createBucket.onOpen}
+          onGoToBucket={() => {
+            if (buckets.length > 0) navigate(`/buckets/${buckets[0].id}`);
+          }}
+        />
+      )}
 
       {/* Summary stat cards */}
       <div className="grid gap-4 grid-cols-2 lg:grid-cols-4">
@@ -104,18 +126,9 @@ export function DashboardPage() {
       </div>
 
       {/* Sources breakdown */}
-      <div>
-        <h2 className="text-xl font-semibold mb-4">Sources</h2>
-        {sources.length === 0 ? (
-          <Card>
-            <CardBody className="text-center py-8">
-              <p className="text-default-500 mb-4">No sources configured yet.</p>
-              <Button as={Link} color="primary" to="/sources">
-                Add a Source
-              </Button>
-            </CardBody>
-          </Card>
-        ) : (
+      {hasSources && (
+        <div>
+          <h2 className="text-xl font-semibold mb-4">Sources</h2>
           <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
             {sources.map((s) => {
               const fileCount = s.info?.files.length ?? 0;
@@ -165,9 +178,11 @@ export function DashboardPage() {
               );
             })}
           </div>
-        )}
-      </div>
+        </div>
+      )}
 
+      <CreateSourceDialog isOpen={createSource.isOpen} onOpenChange={createSource.onOpenChange} onCreated={load} />
+      <CreateBucketDialog isOpen={createBucket.isOpen} onOpenChange={createBucket.onOpenChange} onCreated={load} />
     </div>
   );
 }

--- a/webui/src/pages/dashboard/ui/dashboard-page.tsx
+++ b/webui/src/pages/dashboard/ui/dashboard-page.tsx
@@ -1,5 +1,5 @@
 import {Card, CardBody, CardHeader, CircularProgress, useDisclosure} from "@heroui/react";
-import {useEffect, useState} from "react";
+import {useEffect, useRef, useState} from "react";
 import {useNavigate} from "react-router-dom";
 import {listSources, getSourceInfo} from "../../../shared/api/sources";
 import {listBuckets} from "../../../shared/api/buckets";
@@ -27,9 +27,10 @@ export function DashboardPage() {
   const [isLoading, setIsLoading] = useState(true);
   const createSource = useDisclosure();
   const createBucket = useDisclosure();
+  const hasLoadedOnce = useRef(false);
 
   async function load() {
-    setIsLoading(true);
+    if (!hasLoadedOnce.current) setIsLoading(true);
     try {
       const [srcList, bucketList] = await Promise.all([
         listSources(),
@@ -52,6 +53,7 @@ export function DashboardPage() {
       // keep empty state
     } finally {
       setIsLoading(false);
+      hasLoadedOnce.current = true;
     }
   }
 

--- a/webui/src/pages/sources/ui/sources-page.tsx
+++ b/webui/src/pages/sources/ui/sources-page.tsx
@@ -150,7 +150,7 @@ export function SourcesPage() {
       ) : sources.length === 0 ? (
         <EmptyState
           title="No sources yet"
-          description="Connect a Google Drive, Telegram, or S3 source to get started."
+          description="This is step 1: connect a Google Drive, Telegram, or S3-compatible source so SFree knows where your files live."
           ctaLabel="Add Source"
           onCtaPress={create.onOpen}
         />


### PR DESCRIPTION
## Summary
- Adds an `OnboardingHero` stepper component that guides new users through three steps: connect a source, create a bucket, upload a file
- Dashboard shows the onboarding hero when the account has no sources or no buckets, with inline CTAs that open create dialogs directly
- Each page's empty state now reinforces the current onboarding step instead of showing generic fallbacks
- Buckets page detects missing sources and redirects users to connect one first
- Bucket detail empty state says "Last step: upload your first file" for owners/editors
- Returning users with sources + buckets see the normal dashboard — no onboarding trap

## Test plan
- [ ] Log in with a fresh account (no sources, no buckets) and verify the dashboard shows the 3-step onboarding hero
- [ ] Click "Add Source" in the hero, create a source, and verify step 1 turns green
- [ ] Navigate to Buckets page with no sources — verify it shows "Connect a source first" with redirect CTA
- [ ] Create a source, then navigate to Buckets — verify it shows step 2 context and "Create Bucket" CTA
- [ ] Create a bucket, verify the hero now shows step 3 with "Go to Bucket" CTA
- [ ] Navigate to bucket detail, verify empty file state says "Last step: upload your first file"
- [ ] Upload a file, verify the normal file table appears
- [ ] With sources + buckets present, verify dashboard shows normal view without onboarding hero
- [ ] Woodpecker CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)