### PR TITLE
THE-822 Turn bucket detail page into file workspace

### DIFF
--- a/webui/src/pages/bucket/ui/bucket-page.tsx
+++ b/webui/src/pages/bucket/ui/bucket-page.tsx
@@ -1,11 +1,21 @@
 import {
   Button,
+  Chip,
   Input,
+  Snippet,
   Spinner,
+  Table,
+  TableBody,
+  TableCell,
+  TableColumn,
+  TableHeader,
+  TableRow,
+  Tooltip,
   useDisclosure,
 } from "@heroui/react";
+import type {SortDescriptor} from "@heroui/react";
 import {addToast} from "@heroui/toast";
-import {useCallback, useDeferredValue, useEffect, useRef, useState} from "react";
+import {useCallback, useDeferredValue, useEffect, useMemo, useRef, useState} from "react";
 import {Link, useNavigate, useParams} from "react-router-dom";
 import {
   deleteFile,
@@ -24,15 +34,176 @@ import {ShareFileDialog} from "../../../features/bucket/ui/share-file-dialog";
 import {formatSize} from "../../../shared/lib/format";
 import {ApiError, showErrorToast} from "../../../shared/api/error";
 
+/* ------------------------------------------------------------------ */
+/*  Role helpers                                                       */
+/* ------------------------------------------------------------------ */
+
+function canManageBucket(bucket: Bucket) {
+  return bucket.role === "owner";
+}
+
+function canWriteFiles(bucket: Bucket) {
+  return bucket.role === "owner" || bucket.role === "editor";
+}
+
+const ROLE_COLOR: Record<string, "primary" | "secondary" | "default"> = {
+  owner: "primary",
+  editor: "secondary",
+  viewer: "default",
+};
+
+/* ------------------------------------------------------------------ */
+/*  Credentials panel                                                  */
+/* ------------------------------------------------------------------ */
+
+function CredentialsPanel({bucket}: {bucket: Bucket}) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="border border-divider rounded-lg">
+      <button
+        type="button"
+        className="flex w-full items-center justify-between px-4 py-3 text-sm font-medium text-foreground hover:bg-default-100 transition-colors rounded-lg cursor-pointer"
+        onClick={() => setOpen(!open)}
+        aria-expanded={open}
+      >
+        <span>S3 Credentials</span>
+        <svg
+          className={`w-4 h-4 transition-transform ${open ? "rotate-180" : ""}`}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={2}
+        >
+          <path d="M6 9l6 6 6-6" />
+        </svg>
+      </button>
+
+      {open && (
+        <div className="px-4 pb-4 flex flex-col gap-3">
+          <div>
+            <label className="text-xs text-default-500 mb-1 block">
+              Bucket ID
+            </label>
+            <Snippet size="sm" symbol="" className="w-full">
+              {bucket.id}
+            </Snippet>
+          </div>
+          <div>
+            <label className="text-xs text-default-500 mb-1 block">
+              Access Key
+            </label>
+            <Snippet size="sm" symbol="" className="w-full">
+              {bucket.access_key}
+            </Snippet>
+          </div>
+          <div>
+            <label className="text-xs text-default-500 mb-1 block">
+              Created
+            </label>
+            <p className="text-sm text-default-700">
+              {new Date(bucket.created_at).toLocaleString()}
+            </p>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Drop zone                                                          */
+/* ------------------------------------------------------------------ */
+
+function DropZone({
+  active,
+  onDrop,
+  children,
+}: {
+  active: boolean;
+  onDrop: (files: FileList) => void;
+  children: React.ReactNode;
+}) {
+  const [dragging, setDragging] = useState(false);
+  const dragCounter = useRef(0);
+
+  function handleDragEnter(e: React.DragEvent) {
+    e.preventDefault();
+    dragCounter.current++;
+    setDragging(true);
+  }
+  function handleDragLeave(e: React.DragEvent) {
+    e.preventDefault();
+    dragCounter.current--;
+    if (dragCounter.current <= 0) {
+      dragCounter.current = 0;
+      setDragging(false);
+    }
+  }
+  function handleDrop(e: React.DragEvent) {
+    e.preventDefault();
+    dragCounter.current = 0;
+    setDragging(false);
+    if (active && e.dataTransfer.files.length > 0) {
+      onDrop(e.dataTransfer.files);
+    }
+  }
+
+  function suppressDrag(e: React.DragEvent) {
+    e.preventDefault();
+  }
+
+  return (
+    <div
+      className={`relative rounded-lg transition-colors ${
+        dragging && active ? "ring-2 ring-primary bg-primary/5" : ""
+      }`}
+      onDragEnter={active ? handleDragEnter : suppressDrag}
+      onDragOver={suppressDrag}
+      onDragLeave={active ? handleDragLeave : undefined}
+      onDrop={active ? handleDrop : suppressDrag}
+    >
+      {dragging && active && (
+        <div className="absolute inset-0 z-10 flex items-center justify-center bg-primary/5 rounded-lg pointer-events-none">
+          <p className="text-primary font-medium">Drop files here</p>
+        </div>
+      )}
+      {children}
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Upload queue indicator                                             */
+/* ------------------------------------------------------------------ */
+
+function UploadQueue({count}: {count: number}) {
+  if (count === 0) return null;
+  return (
+    <div className="flex items-center gap-2 px-3 py-2 bg-primary/10 rounded-lg text-sm text-primary">
+      <Spinner size="sm" color="primary" />
+      <span>
+        Uploading {count} file{count > 1 ? "s" : ""}…
+      </span>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Main page                                                          */
+/* ------------------------------------------------------------------ */
+
 export function BucketPage() {
   const {id} = useParams<{id: string}>();
   const navigate = useNavigate();
+
   const [bucket, setBucket] = useState<Bucket | null>(null);
   const [files, setFiles] = useState<FileInfo[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isRefreshingFiles, setIsRefreshingFiles] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
+
   const fileInput = useRef<HTMLInputElement>(null);
   const hasLoadedRef = useRef(false);
   const requestIDRef = useRef(0);
@@ -45,6 +216,14 @@ export function BucketPage() {
   const [shareFile, setShareFile] = useState<FileInfo | null>(null);
   const deferredSearchQuery = useDeferredValue(searchQuery);
   const activeSearchQuery = deferredSearchQuery.trim();
+
+  const [uploadingCount, setUploadingCount] = useState(0);
+  const [sortDescriptor, setSortDescriptor] = useState<SortDescriptor>({
+    column: "name",
+    direction: "ascending",
+  });
+
+  /* ---- data loading ---- */
 
   const load = useCallback(async (mode: "initial" | "refresh" = "initial") => {
     if (!id) return;
@@ -61,16 +240,12 @@ export function BucketPage() {
         getBucket(id),
         listFiles(id, activeSearchQuery),
       ]);
-      if (requestID !== requestIDRef.current) {
-        return;
-      }
+      if (requestID !== requestIDRef.current) return;
       setBucket(loadedBucket);
       setFiles(fs);
       hasLoadedRef.current = true;
     } catch (err) {
-      if (requestID !== requestIDRef.current) {
-        return;
-      }
+      if (requestID !== requestIDRef.current) return;
       if (err instanceof ApiError && err.status === 404) {
         setBucket(null);
         setFiles([]);
@@ -98,28 +273,62 @@ export function BucketPage() {
     void load(hasLoadedRef.current ? "refresh" : "initial");
   }, [id, load]);
 
-  async function handleUpload(file: File) {
+  /* ---- sorted files ---- */
+
+  const sortedFiles = useMemo(() => {
+    const sorted = [...files];
+    const {column, direction} = sortDescriptor;
+    sorted.sort((a, b) => {
+      let cmp = 0;
+      if (column === "name") {
+        cmp = a.name.localeCompare(b.name);
+      } else if (column === "size") {
+        cmp = a.size - b.size;
+      } else if (column === "created_at") {
+        cmp =
+          new Date(a.created_at).getTime() - new Date(b.created_at).getTime();
+      }
+      return direction === "descending" ? -cmp : cmp;
+    });
+    return sorted;
+  }, [files, sortDescriptor]);
+
+  /* ---- uploads ---- */
+
+  async function handleMultiUpload(fileList: FileList) {
     if (!id || !bucket || !canWriteFiles(bucket)) return;
-    try {
-      await uploadFile(id, file);
-      addToast({title: "File uploaded", description: `${file.name} added to bucket`, color: "success", timeout: 4000});
-      await load("refresh");
-    } catch (err) {
-      showErrorToast(err);
+    const filesToUpload = Array.from(fileList);
+    setUploadingCount((c) => c + filesToUpload.length);
+    const results = await Promise.allSettled(
+      filesToUpload.map(async (file) => {
+        try {
+          await uploadFile(id, file);
+          addToast({
+            title: "File uploaded",
+            description: `${file.name} added to bucket`,
+            color: "success",
+            timeout: 4000,
+          });
+        } finally {
+          setUploadingCount((c) => c - 1);
+        }
+      }),
+    );
+    for (const r of results) {
+      if (r.status === "rejected") showErrorToast(r.reason);
     }
+    await load("refresh");
   }
 
   function onFileChange(e: React.ChangeEvent<HTMLInputElement>) {
-    const f = e.target.files?.[0];
-    if (f) handleUpload(f);
+    const fileList = e.target.files;
+    if (fileList && fileList.length > 0) {
+      handleMultiUpload(fileList);
+      e.target.value = "";
+    }
   }
 
-  function onDrop(e: React.DragEvent<HTMLDivElement>) {
-    e.preventDefault();
-    if (!bucket || !canWriteFiles(bucket)) return;
-    const f = e.dataTransfer.files?.[0];
-    if (f) handleUpload(f);
-  }
+  /* ---- delete ---- */
 
   async function handleDelete() {
     if (!id || !deleteId) return;
@@ -136,9 +345,7 @@ export function BucketPage() {
     }
   }
 
-  function openShareModal(file: FileInfo) {
-    setShareFile(file);
-  }
+  /* ---- download ---- */
 
   async function handleDownload(file: FileInfo) {
     if (!id) return;
@@ -148,6 +355,8 @@ export function BucketPage() {
       showErrorToast(err);
     }
   }
+
+  /* ---- loading / error / not-found states ---- */
 
   if (isLoading) {
     return (
@@ -208,39 +417,63 @@ export function BucketPage() {
       <Link to="/buckets" className="text-sm text-default-500 hover:text-primary transition-colors">
         &larr; Buckets
       </Link>
-      <div className="flex flex-col gap-1">
-        <h1 className="text-3xl font-bold">{bucket.key}</h1>
-        <p>ID: {bucket.id}</p>
-        <p>Access Key: {bucket.access_key}</p>
-        <p>Created: {new Date(bucket.created_at).toLocaleString()}</p>
-      </div>
-      <div className="flex justify-end gap-2">
-        {canManage && (
-          <Button variant="flat" onPress={shareBucket.onOpen}>
-            Share Bucket
-          </Button>
-        )}
-        {canWrite && (
-          <>
-            <input
-              type="file"
-              ref={fileInput}
-              className="hidden"
-              onChange={onFileChange}
-            />
-            <Button color="primary" onPress={() => fileInput.current?.click()}>
-              Upload File
+
+      {/* Header row */}
+      <div className="flex flex-col sm:flex-row sm:items-center gap-4">
+        <div className="flex items-center gap-3 flex-1 min-w-0">
+          <h1 className="text-2xl sm:text-3xl font-bold truncate">
+            {bucket.key}
+          </h1>
+          <Chip size="sm" variant="flat" color={ROLE_COLOR[bucket.role]}>
+            {bucket.role}
+          </Chip>
+          {bucket.shared && (
+            <Chip size="sm" variant="flat" color="warning">
+              shared
+            </Chip>
+          )}
+        </div>
+        <div className="flex gap-2 shrink-0">
+          {canManage && (
+            <Button
+              variant="flat"
+              size="sm"
+              startContent={<ShareIcon className="w-4 h-4" />}
+              onPress={shareBucket.onOpen}
+            >
+              <span className="hidden sm:inline">Share</span>
             </Button>
-          </>
-        )}
+          )}
+          {canWrite && (
+            <>
+              <input
+                type="file"
+                ref={fileInput}
+                className="hidden"
+                onChange={onFileChange}
+                multiple
+              />
+              <Button
+                color="primary"
+                size="sm"
+                onPress={() => fileInput.current?.click()}
+              >
+                Upload
+              </Button>
+            </>
+          )}
+        </div>
       </div>
-      <div
-        className={
-          canWrite ? "border-2 border-dashed rounded p-4" : "border rounded p-4"
-        }
-        onDragOver={(e) => e.preventDefault()}
-        onDrop={onDrop}
-      >
+
+      {/* Credentials panel */}
+      <CredentialsPanel bucket={bucket} />
+
+      {/* Upload queue */}
+      <UploadQueue count={uploadingCount} />
+
+      {/* File workspace */}
+      <DropZone active={canWrite} onDrop={handleMultiUpload}>
+        {/* Search bar */}
         <div className="mb-4 flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
           <Input
             aria-label="Search files"
@@ -260,81 +493,131 @@ export function BucketPage() {
             </p>
           ) : null}
         </div>
+
         {files.length === 0 ? (
-          <EmptyState
-            title={emptyTitle}
-            description={emptyDescription}
-            ctaLabel={!activeSearchQuery && canWrite ? "Upload File" : undefined}
-            onCtaPress={!activeSearchQuery && canWrite ? () => fileInput.current?.click() : undefined}
-          />
+          <div className="border-2 border-dashed border-default-300 rounded-lg p-8">
+            <EmptyState
+              title={emptyTitle}
+              description={emptyDescription}
+              ctaLabel={!activeSearchQuery && canWrite ? "Upload File" : undefined}
+              onCtaPress={!activeSearchQuery && canWrite ? () => fileInput.current?.click() : undefined}
+            />
+          </div>
         ) : (
-          <table className="w-full text-left">
-            <thead>
-              <tr>
-                <th className="pb-2">Name</th>
-                <th className="pb-2">Size</th>
-                <th className="pb-2">Created</th>
-                <th className="pb-2"></th>
-              </tr>
-            </thead>
-            <tbody>
-              {files.map((f) => (
-                <tr key={f.id} className="border-t">
-                  <td className="py-2">
+          <Table
+            aria-label="Files in bucket"
+            sortDescriptor={sortDescriptor}
+            onSortChange={setSortDescriptor}
+            classNames={{
+              wrapper: "shadow-none border border-divider",
+            }}
+          >
+            <TableHeader>
+              <TableColumn key="name" allowsSorting>
+                Name
+              </TableColumn>
+              <TableColumn
+                key="size"
+                allowsSorting
+                className="hidden sm:table-cell"
+              >
+                Size
+              </TableColumn>
+              <TableColumn
+                key="created_at"
+                allowsSorting
+                className="hidden md:table-cell"
+              >
+                Created
+              </TableColumn>
+              <TableColumn key="actions" className="text-right w-[1%]">
+                Actions
+              </TableColumn>
+            </TableHeader>
+            <TableBody items={sortedFiles}>
+              {(file) => (
+                <TableRow key={file.id}>
+                  <TableCell>
                     <button
                       type="button"
-                      className="text-left hover:text-primary transition-colors cursor-pointer"
-                      onClick={() => setPreviewFile(f)}
+                      className="text-left hover:text-primary transition-colors cursor-pointer truncate max-w-[200px] sm:max-w-[300px] md:max-w-none"
+                      onClick={() => setPreviewFile(file)}
+                      title={file.name}
                     >
-                      {f.name}
+                      {file.name}
                     </button>
-                  </td>
-                  <td className="py-2">{formatSize(f.size)}</td>
-                  <td className="py-2">
-                    {new Date(f.created_at).toLocaleString()}
-                  </td>
-                  <td className="py-2">
-                    <div className="flex gap-2">
+                    {/* Mobile-only size beneath file name */}
+                    <span className="block sm:hidden text-xs text-default-400 mt-0.5">
+                      {formatSize(file.size)}
+                    </span>
+                  </TableCell>
+                  <TableCell className="hidden sm:table-cell text-default-500 text-sm">
+                    {formatSize(file.size)}
+                  </TableCell>
+                  <TableCell className="hidden md:table-cell text-default-500 text-sm whitespace-nowrap">
+                    {new Date(file.created_at).toLocaleDateString()}
+                  </TableCell>
+                  <TableCell>
+                    <div className="flex gap-1 justify-end">
                       {canWrite && (
-                        <Button
-                          isIconOnly
-                          aria-label={`Share ${f.name}`}
-                          variant="light"
-                          onPress={() => openShareModal(f)}
-                        >
-                          <ShareIcon className="w-5 h-5" />
-                        </Button>
+                        <Tooltip content="Share">
+                          <Button
+                            isIconOnly
+                            size="sm"
+                            aria-label={`Share ${file.name}`}
+                            variant="light"
+                            onPress={() => setShareFile(file)}
+                          >
+                            <ShareIcon className="w-4 h-4" />
+                          </Button>
+                        </Tooltip>
                       )}
-                      <Button
-                        isIconOnly
-                        aria-label={`Download ${f.name}`}
-                        variant="light"
-                        onPress={() => handleDownload(f)}
-                      >
-                        <DownloadIcon className="w-5 h-5" />
-                      </Button>
-                      {canWrite && (
+                      <Tooltip content="Download">
                         <Button
                           isIconOnly
-                          aria-label={`Delete ${f.name}`}
+                          size="sm"
+                          aria-label={`Download ${file.name}`}
                           variant="light"
-                          color="danger"
-                          onPress={() => {
-                            setDeleteId(f.id);
-                            confirm.onOpen();
-                          }}
+                          onPress={() => handleDownload(file)}
                         >
-                          <DeleteIcon className="w-5 h-5" />
+                          <DownloadIcon className="w-4 h-4" />
                         </Button>
+                      </Tooltip>
+                      {canWrite && (
+                        <Tooltip content="Delete" color="danger">
+                          <Button
+                            isIconOnly
+                            size="sm"
+                            aria-label={`Delete ${file.name}`}
+                            variant="light"
+                            color="danger"
+                            onPress={() => {
+                              setDeleteId(file.id);
+                              confirm.onOpen();
+                            }}
+                          >
+                            <DeleteIcon className="w-4 h-4" />
+                          </Button>
+                        </Tooltip>
                       )}
                     </div>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
         )}
-      </div>
+      </DropZone>
+
+      {/* File count summary */}
+      {files.length > 0 && (
+        <p className="text-xs text-default-400">
+          {files.length} file{files.length !== 1 ? "s" : ""} &middot;{" "}
+          {formatSize(files.reduce((acc, f) => acc + f.size, 0))} total
+        </p>
+      )}
+
+      {/* Modals */}
       <ConfirmDialog
         isOpen={confirm.isOpen}
         onOpenChange={(open) => {
@@ -342,7 +625,7 @@ export function BucketPage() {
           confirm.onOpenChange();
         }}
         title="Delete file?"
-        message="Are you sure you want to delete this file?"
+        message="Are you sure you want to delete this file? This action cannot be undone."
         onConfirm={handleDelete}
         confirmLabel="Delete"
         isConfirmLoading={isDeleting}
@@ -365,12 +648,4 @@ export function BucketPage() {
       />
     </div>
   );
-}
-
-function canManageBucket(bucket: Bucket) {
-  return bucket.role === "owner";
-}
-
-function canWriteFiles(bucket: Bucket) {
-  return bucket.role === "owner" || bucket.role === "editor";
 }

--- a/webui/src/pages/bucket/ui/bucket-page.tsx
+++ b/webui/src/pages/bucket/ui/bucket-page.tsx
@@ -309,8 +309,8 @@ export function BucketPage() {
           <EmptyState
             title={emptyTitle}
             description={emptyDescription}
-            ctaLabel={canWrite ? "Upload File" : undefined}
-            onCtaPress={canWrite ? () => fileInput.current?.click() : undefined}
+            ctaLabel={!activeSearchQuery && canWrite ? "Upload File" : undefined}
+            onCtaPress={!activeSearchQuery && canWrite ? () => fileInput.current?.click() : undefined}
           />
         ) : (
           <table className="w-full text-left">

--- a/webui/src/pages/bucket/ui/bucket-page.tsx
+++ b/webui/src/pages/bucket/ui/bucket-page.tsx
@@ -1,13 +1,11 @@
 import {
   Button,
-  Chip,
   Input,
-  Snippet,
   Spinner,
   useDisclosure,
 } from "@heroui/react";
 import {addToast} from "@heroui/toast";
-import {useCallback, useDeferredValue, useEffect, useMemo, useRef, useState} from "react";
+import {useCallback, useDeferredValue, useEffect, useRef, useState} from "react";
 import {Link, useNavigate, useParams} from "react-router-dom";
 import {
   deleteFile,
@@ -25,67 +23,6 @@ import {ShareBucketDialog} from "../../../features/bucket/ui/share-bucket-dialog
 import {ShareFileDialog} from "../../../features/bucket/ui/share-file-dialog";
 import {formatSize} from "../../../shared/lib/format";
 import {ApiError, showErrorToast} from "../../../shared/api/error";
-
-function CredentialsPanel({bucket}: {bucket: Bucket}) {
-  const [open, setOpen] = useState(false);
-
-  return (
-    <div className="border border-divider rounded-lg">
-      <button
-        type="button"
-        className="flex w-full items-center justify-between px-4 py-3 text-sm font-medium text-foreground hover:bg-default-100 transition-colors rounded-lg cursor-pointer"
-        onClick={() => setOpen(!open)}
-        aria-expanded={open}
-      >
-        <span>S3 Credentials</span>
-        <svg
-          className={`w-4 h-4 transition-transform ${open ? "rotate-180" : ""}`}
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth={2}
-        >
-          <path d="M6 9l6 6 6-6" />
-        </svg>
-      </button>
-
-      {open && (
-        <div className="px-4 pb-4 flex flex-col gap-3">
-          <div>
-            <label className="text-xs text-default-500 mb-1 block">
-              Bucket ID
-            </label>
-            <Snippet size="sm" symbol="" className="w-full">
-              {bucket.id}
-            </Snippet>
-          </div>
-          <div>
-            <label className="text-xs text-default-500 mb-1 block">
-              Access Key
-            </label>
-            <Snippet size="sm" symbol="" className="w-full">
-              {bucket.access_key}
-            </Snippet>
-          </div>
-          <div>
-            <label className="text-xs text-default-500 mb-1 block">
-              Created
-            </label>
-            <p className="text-sm text-default-700">
-              {new Date(bucket.created_at).toLocaleString()}
-            </p>
-          </div>
-        </div>
-      )}
-    </div>
-  );
-}
-
-const ROLE_COLOR: Record<string, "primary" | "secondary" | "default"> = {
-  owner: "primary",
-  editor: "secondary",
-  viewer: "default",
-};
 
 export function BucketPage() {
   const {id} = useParams<{id: string}>();
@@ -108,9 +45,6 @@ export function BucketPage() {
   const [shareFile, setShareFile] = useState<FileInfo | null>(null);
   const deferredSearchQuery = useDeferredValue(searchQuery);
   const activeSearchQuery = deferredSearchQuery.trim();
-
-  const [sortColumn, setSortColumn] = useState<"name" | "size" | "created_at">("name");
-  const [sortDirection, setSortDirection] = useState<"ascending" | "descending">("ascending");
 
   const load = useCallback(async (mode: "initial" | "refresh" = "initial") => {
     if (!id) return;
@@ -163,28 +97,6 @@ export function BucketPage() {
     if (!id) return;
     void load(hasLoadedRef.current ? "refresh" : "initial");
   }, [id, load]);
-
-  const sortedFiles = useMemo(() => {
-    const sorted = [...files];
-    sorted.sort((a, b) => {
-      let cmp = 0;
-      if (sortColumn === "name") cmp = a.name.localeCompare(b.name);
-      else if (sortColumn === "size") cmp = a.size - b.size;
-      else if (sortColumn === "created_at")
-        cmp = new Date(a.created_at).getTime() - new Date(b.created_at).getTime();
-      return sortDirection === "descending" ? -cmp : cmp;
-    });
-    return sorted;
-  }, [files, sortColumn, sortDirection]);
-
-  function toggleSort(col: "name" | "size" | "created_at") {
-    if (sortColumn === col) {
-      setSortDirection((d) => (d === "ascending" ? "descending" : "ascending"));
-    } else {
-      setSortColumn(col);
-      setSortDirection("ascending");
-    }
-  }
 
   async function handleUpload(file: File) {
     if (!id || !bucket || !canWriteFiles(bucket)) return;
@@ -297,19 +209,11 @@ export function BucketPage() {
         &larr; Buckets
       </Link>
       <div className="flex flex-col gap-1">
-        <div className="flex items-center gap-3">
-          <h1 className="text-3xl font-bold">{bucket.key}</h1>
-          <Chip size="sm" variant="flat" color={ROLE_COLOR[bucket.role]}>
-            {bucket.role}
-          </Chip>
-          {bucket.shared && (
-            <Chip size="sm" variant="flat" color="warning">
-              shared
-            </Chip>
-          )}
-        </div>
+        <h1 className="text-3xl font-bold">{bucket.key}</h1>
+        <p>ID: {bucket.id}</p>
+        <p>Access Key: {bucket.access_key}</p>
+        <p>Created: {new Date(bucket.created_at).toLocaleString()}</p>
       </div>
-      <CredentialsPanel bucket={bucket} />
       <div className="flex justify-end gap-2">
         {canManage && (
           <Button variant="flat" onPress={shareBucket.onOpen}>
@@ -367,20 +271,14 @@ export function BucketPage() {
           <table className="w-full text-left">
             <thead>
               <tr>
-                <th className="pb-2 cursor-pointer select-none" onClick={() => toggleSort("name")}>
-                  Name
-                </th>
-                <th className="pb-2 cursor-pointer select-none" onClick={() => toggleSort("size")}>
-                  Size
-                </th>
-                <th className="pb-2 cursor-pointer select-none" onClick={() => toggleSort("created_at")}>
-                  Created
-                </th>
+                <th className="pb-2">Name</th>
+                <th className="pb-2">Size</th>
+                <th className="pb-2">Created</th>
                 <th className="pb-2"></th>
               </tr>
             </thead>
             <tbody>
-              {sortedFiles.map((f) => (
+              {files.map((f) => (
                 <tr key={f.id} className="border-t">
                   <td className="py-2">
                     <button
@@ -437,12 +335,6 @@ export function BucketPage() {
           </table>
         )}
       </div>
-      {files.length > 0 && (
-        <p className="text-xs text-default-400">
-          {files.length} file{files.length !== 1 ? "s" : ""} &middot;{" "}
-          {formatSize(files.reduce((acc, f) => acc + f.size, 0))} total
-        </p>
-      )}
       <ConfirmDialog
         isOpen={confirm.isOpen}
         onOpenChange={(open) => {

--- a/webui/src/pages/bucket/ui/bucket-page.tsx
+++ b/webui/src/pages/bucket/ui/bucket-page.tsx
@@ -499,8 +499,8 @@ export function BucketPage() {
             <EmptyState
               title={emptyTitle}
               description={emptyDescription}
-              ctaLabel={!activeSearchQuery && canWrite ? "Upload File" : undefined}
-              onCtaPress={!activeSearchQuery && canWrite ? () => fileInput.current?.click() : undefined}
+              ctaLabel={canWrite ? "Upload File" : undefined}
+              onCtaPress={canWrite ? () => fileInput.current?.click() : undefined}
             />
           </div>
         ) : (

--- a/webui/src/pages/bucket/ui/bucket-page.tsx
+++ b/webui/src/pages/bucket/ui/bucket-page.tsx
@@ -4,15 +4,8 @@ import {
   Input,
   Snippet,
   Spinner,
-  Table,
-  TableBody,
-  TableCell,
-  TableColumn,
-  TableHeader,
-  TableRow,
   useDisclosure,
 } from "@heroui/react";
-import type {SortDescriptor} from "@heroui/react";
 import {addToast} from "@heroui/toast";
 import {useCallback, useDeferredValue, useEffect, useMemo, useRef, useState} from "react";
 import {Link, useNavigate, useParams} from "react-router-dom";
@@ -217,10 +210,10 @@ export function BucketPage() {
   const activeSearchQuery = deferredSearchQuery.trim();
 
   const [uploadingCount, setUploadingCount] = useState(0);
-  const [sortDescriptor, setSortDescriptor] = useState<SortDescriptor>({
-    column: "name",
-    direction: "ascending",
-  });
+  type SortColumn = "name" | "size" | "created_at";
+  type SortDir = "ascending" | "descending";
+  const [sortColumn, setSortColumn] = useState<SortColumn>("name");
+  const [sortDirection, setSortDirection] = useState<SortDir>("ascending");
 
   /* ---- data loading ---- */
 
@@ -276,21 +269,29 @@ export function BucketPage() {
 
   const sortedFiles = useMemo(() => {
     const sorted = [...files];
-    const {column, direction} = sortDescriptor;
     sorted.sort((a, b) => {
       let cmp = 0;
-      if (column === "name") {
+      if (sortColumn === "name") {
         cmp = a.name.localeCompare(b.name);
-      } else if (column === "size") {
+      } else if (sortColumn === "size") {
         cmp = a.size - b.size;
-      } else if (column === "created_at") {
+      } else if (sortColumn === "created_at") {
         cmp =
           new Date(a.created_at).getTime() - new Date(b.created_at).getTime();
       }
-      return direction === "descending" ? -cmp : cmp;
+      return sortDirection === "descending" ? -cmp : cmp;
     });
     return sorted;
-  }, [files, sortDescriptor]);
+  }, [files, sortColumn, sortDirection]);
+
+  function toggleSort(col: SortColumn) {
+    if (sortColumn === col) {
+      setSortDirection((d) => (d === "ascending" ? "descending" : "ascending"));
+    } else {
+      setSortColumn(col);
+      setSortDirection("ascending");
+    }
+  }
 
   /* ---- uploads ---- */
 
@@ -503,102 +504,96 @@ export function BucketPage() {
             />
           </div>
         ) : (
-          <Table
-            aria-label="Files in bucket"
-            sortDescriptor={sortDescriptor}
-            onSortChange={setSortDescriptor}
-            classNames={{
-              wrapper: "shadow-none border border-divider",
-            }}
-          >
-            <TableHeader>
-              <TableColumn key="name" allowsSorting>
-                Name
-              </TableColumn>
-              <TableColumn
-                key="size"
-                allowsSorting
-                className="hidden sm:table-cell"
-              >
-                Size
-              </TableColumn>
-              <TableColumn
-                key="created_at"
-                allowsSorting
-                className="hidden md:table-cell"
-              >
-                Created
-              </TableColumn>
-              <TableColumn key="actions" className="text-right w-[1%]">
-                Actions
-              </TableColumn>
-            </TableHeader>
-            <TableBody items={sortedFiles}>
-              {(file) => (
-                <TableRow key={file.id}>
-                  <TableCell>
-                    <button
-                      type="button"
-                      className="text-left hover:text-primary transition-colors cursor-pointer truncate max-w-[200px] sm:max-w-[300px] md:max-w-none"
-                      onClick={() => setPreviewFile(file)}
-                      title={file.name}
-                    >
-                      {file.name}
+          <div className="border border-divider rounded-lg overflow-hidden">
+            <table className="w-full text-left">
+              <thead>
+                <tr className="border-b border-divider bg-default-50">
+                  <th className="px-4 py-3 text-sm font-medium">
+                    <button type="button" className="cursor-pointer select-none" onClick={() => toggleSort("name")}>
+                      Name{sortColumn === "name" && <span aria-hidden="true"> {sortDirection === "ascending" ? "↑" : "↓"}</span>}
                     </button>
-                    {/* Mobile-only size beneath file name */}
-                    <span className="block sm:hidden text-xs text-default-400 mt-0.5">
-                      {formatSize(file.size)}
-                    </span>
-                  </TableCell>
-                  <TableCell className="hidden sm:table-cell text-default-500 text-sm">
-                    {formatSize(file.size)}
-                  </TableCell>
-                  <TableCell className="hidden md:table-cell text-default-500 text-sm whitespace-nowrap">
-                    {new Date(file.created_at).toLocaleDateString()}
-                  </TableCell>
-                  <TableCell>
-                    <div className="flex gap-1 justify-end">
-                      {canWrite && (
-                        <Button
-                          isIconOnly
-                          size="sm"
-                          aria-label={`Share ${file.name}`}
-                          variant="light"
-                          onPress={() => setShareFile(file)}
-                        >
-                          <ShareIcon className="w-4 h-4" />
-                        </Button>
-                      )}
-                      <Button
-                        isIconOnly
-                        size="sm"
-                        aria-label={`Download ${file.name}`}
-                        variant="light"
-                        onPress={() => handleDownload(file)}
+                  </th>
+                  <th className="px-4 py-3 text-sm font-medium hidden sm:table-cell">
+                    <button type="button" className="cursor-pointer select-none" onClick={() => toggleSort("size")}>
+                      Size{sortColumn === "size" && <span aria-hidden="true"> {sortDirection === "ascending" ? "↑" : "↓"}</span>}
+                    </button>
+                  </th>
+                  <th className="px-4 py-3 text-sm font-medium hidden md:table-cell">
+                    <button type="button" className="cursor-pointer select-none" onClick={() => toggleSort("created_at")}>
+                      Created{sortColumn === "created_at" && <span aria-hidden="true"> {sortDirection === "ascending" ? "↑" : "↓"}</span>}
+                    </button>
+                  </th>
+                  <th className="px-4 py-3 text-sm font-medium text-right w-[1%]">
+                    Actions
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {sortedFiles.map((file) => (
+                  <tr key={file.id} className="border-t border-divider hover:bg-default-50 transition-colors">
+                    <td className="px-4 py-3">
+                      <button
+                        type="button"
+                        className="text-left hover:text-primary transition-colors cursor-pointer truncate max-w-[200px] sm:max-w-[300px] md:max-w-none"
+                        onClick={() => setPreviewFile(file)}
+                        title={file.name}
                       >
-                        <DownloadIcon className="w-4 h-4" />
-                      </Button>
-                      {canWrite && (
+                        {file.name}
+                      </button>
+                      <span className="block sm:hidden text-xs text-default-400 mt-0.5">
+                        {formatSize(file.size)}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 hidden sm:table-cell text-default-500 text-sm">
+                      {formatSize(file.size)}
+                    </td>
+                    <td className="px-4 py-3 hidden md:table-cell text-default-500 text-sm whitespace-nowrap">
+                      {new Date(file.created_at).toLocaleDateString()}
+                    </td>
+                    <td className="px-4 py-3">
+                      <div className="flex gap-1 justify-end">
+                        {canWrite && (
+                          <Button
+                            isIconOnly
+                            size="sm"
+                            aria-label={`Share ${file.name}`}
+                            variant="light"
+                            onPress={() => setShareFile(file)}
+                          >
+                            <ShareIcon className="w-4 h-4" />
+                          </Button>
+                        )}
                         <Button
                           isIconOnly
                           size="sm"
-                          aria-label={`Delete ${file.name}`}
+                          aria-label={`Download ${file.name}`}
                           variant="light"
-                          color="danger"
-                          onPress={() => {
-                            setDeleteId(file.id);
-                            confirm.onOpen();
-                          }}
+                          onPress={() => handleDownload(file)}
                         >
-                          <DeleteIcon className="w-4 h-4" />
+                          <DownloadIcon className="w-4 h-4" />
                         </Button>
-                      )}
-                    </div>
-                  </TableCell>
-                </TableRow>
-              )}
-            </TableBody>
-          </Table>
+                        {canWrite && (
+                          <Button
+                            isIconOnly
+                            size="sm"
+                            aria-label={`Delete ${file.name}`}
+                            variant="light"
+                            color="danger"
+                            onPress={() => {
+                              setDeleteId(file.id);
+                              confirm.onOpen();
+                            }}
+                          >
+                            <DeleteIcon className="w-4 h-4" />
+                          </Button>
+                        )}
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         )}
       </DropZone>
 

--- a/webui/src/pages/bucket/ui/bucket-page.tsx
+++ b/webui/src/pages/bucket/ui/bucket-page.tsx
@@ -309,8 +309,8 @@ export function BucketPage() {
           <EmptyState
             title={emptyTitle}
             description={emptyDescription}
-            ctaLabel={!activeSearchQuery && canWrite ? "Upload File" : undefined}
-            onCtaPress={!activeSearchQuery && canWrite ? () => fileInput.current?.click() : undefined}
+            ctaLabel={canWrite ? "Upload File" : undefined}
+            onCtaPress={canWrite ? () => fileInput.current?.click() : undefined}
           />
         ) : (
           <table className="w-full text-left">

--- a/webui/src/pages/bucket/ui/bucket-page.tsx
+++ b/webui/src/pages/bucket/ui/bucket-page.tsx
@@ -1,11 +1,13 @@
 import {
   Button,
+  Chip,
   Input,
+  Snippet,
   Spinner,
   useDisclosure,
 } from "@heroui/react";
 import {addToast} from "@heroui/toast";
-import {useCallback, useDeferredValue, useEffect, useRef, useState} from "react";
+import {useCallback, useDeferredValue, useEffect, useMemo, useRef, useState} from "react";
 import {Link, useNavigate, useParams} from "react-router-dom";
 import {
   deleteFile,
@@ -23,6 +25,14 @@ import {ShareBucketDialog} from "../../../features/bucket/ui/share-bucket-dialog
 import {ShareFileDialog} from "../../../features/bucket/ui/share-file-dialog";
 import {formatSize} from "../../../shared/lib/format";
 import {ApiError, showErrorToast} from "../../../shared/api/error";
+
+const ROLE_COLOR: Record<string, "default" | "primary" | "secondary" | "success" | "warning" | "danger"> = {
+  owner: "primary",
+  editor: "secondary",
+  viewer: "default",
+};
+
+type SortField = "name" | "size" | "created_at";
 
 export function BucketPage() {
   const {id} = useParams<{id: string}>();
@@ -45,6 +55,39 @@ export function BucketPage() {
   const [shareFile, setShareFile] = useState<FileInfo | null>(null);
   const deferredSearchQuery = useDeferredValue(searchQuery);
   const activeSearchQuery = deferredSearchQuery.trim();
+
+  const [sortBy, setSortBy] = useState<SortField>("name");
+  const [sortAsc, setSortAsc] = useState(true);
+
+  function toggleSort(field: SortField) {
+    if (sortBy === field) {
+      setSortAsc((prev) => !prev);
+    } else {
+      setSortBy(field);
+      setSortAsc(true);
+    }
+  }
+
+  const sortedFiles = useMemo(() => {
+    const sorted = [...files].sort((a, b) => {
+      let cmp: number;
+      switch (sortBy) {
+        case "name":
+          cmp = a.name.localeCompare(b.name);
+          break;
+        case "size":
+          cmp = a.size - b.size;
+          break;
+        case "created_at":
+          cmp = new Date(a.created_at).getTime() - new Date(b.created_at).getTime();
+          break;
+        default:
+          cmp = 0;
+      }
+      return sortAsc ? cmp : -cmp;
+    });
+    return sorted;
+  }, [files, sortBy, sortAsc]);
 
   const load = useCallback(async (mode: "initial" | "refresh" = "initial") => {
     if (!id) return;
@@ -208,11 +251,14 @@ export function BucketPage() {
       <Link to="/buckets" className="text-sm text-default-500 hover:text-primary transition-colors">
         &larr; Buckets
       </Link>
-      <div className="flex flex-col gap-1">
-        <h1 className="text-3xl font-bold">{bucket.key}</h1>
-        <p>ID: {bucket.id}</p>
-        <p>Access Key: {bucket.access_key}</p>
-        <p>Created: {new Date(bucket.created_at).toLocaleString()}</p>
+      <div className="flex flex-col gap-2">
+        <div className="flex items-center gap-3">
+          <h1 className="text-3xl font-bold">{bucket.key}</h1>
+          <Chip size="sm" variant="flat" color={ROLE_COLOR[bucket.role] ?? "default"}>
+            {bucket.role}
+          </Chip>
+        </div>
+        <CredentialsPanel bucket={bucket} />
       </div>
       <div className="flex justify-end gap-2">
         {canManage && (
@@ -260,7 +306,7 @@ export function BucketPage() {
             </p>
           ) : null}
         </div>
-        {files.length === 0 ? (
+        {sortedFiles.length === 0 ? (
           <EmptyState
             title={emptyTitle}
             description={emptyDescription}
@@ -271,14 +317,20 @@ export function BucketPage() {
           <table className="w-full text-left">
             <thead>
               <tr>
-                <th className="pb-2">Name</th>
-                <th className="pb-2">Size</th>
-                <th className="pb-2">Created</th>
+                <th className="pb-2 cursor-pointer select-none" onClick={() => toggleSort("name")}>
+                  Name<SortArrow field="name" sortBy={sortBy} sortAsc={sortAsc} />
+                </th>
+                <th className="pb-2 cursor-pointer select-none" onClick={() => toggleSort("size")}>
+                  Size<SortArrow field="size" sortBy={sortBy} sortAsc={sortAsc} />
+                </th>
+                <th className="pb-2 cursor-pointer select-none" onClick={() => toggleSort("created_at")}>
+                  Created<SortArrow field="created_at" sortBy={sortBy} sortAsc={sortAsc} />
+                </th>
                 <th className="pb-2"></th>
               </tr>
             </thead>
             <tbody>
-              {files.map((f) => (
+              {sortedFiles.map((f) => (
                 <tr key={f.id} className="border-t">
                   <td className="py-2">
                     <button
@@ -364,6 +416,55 @@ export function BucketPage() {
         bucketId={id!}
       />
     </div>
+  );
+}
+
+function CredentialsPanel({bucket}: {bucket: Bucket}) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="border border-divider rounded-lg">
+      <button
+        type="button"
+        className="w-full flex items-center justify-between px-4 py-3 text-sm font-medium hover:bg-default-100 transition-colors rounded-lg cursor-pointer"
+        onClick={() => setOpen(!open)}
+        aria-expanded={open}
+      >
+        <span>S3 Credentials</span>
+        <svg
+          className={`w-4 h-4 transition-transform ${open ? "rotate-180" : ""}`}
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          aria-hidden="true"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+      {open && (
+        <div className="px-4 pb-4 flex flex-col gap-3">
+          <div>
+            <p className="text-xs text-default-500 mb-1">Bucket ID</p>
+            <Snippet size="sm" variant="flat" symbol="">{bucket.id}</Snippet>
+          </div>
+          <div>
+            <p className="text-xs text-default-500 mb-1">Access Key</p>
+            <Snippet size="sm" variant="flat" symbol="">{bucket.access_key}</Snippet>
+          </div>
+          <p className="text-xs text-default-500">
+            Created {new Date(bucket.created_at).toLocaleString()}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SortArrow({field, sortBy, sortAsc}: {field: SortField; sortBy: SortField; sortAsc: boolean}) {
+  if (sortBy !== field) return null;
+  return (
+    <span aria-hidden="true" className="ml-1 text-default-400">
+      {sortAsc ? "↑" : "↓"}
+    </span>
   );
 }
 

--- a/webui/src/pages/bucket/ui/bucket-page.tsx
+++ b/webui/src/pages/bucket/ui/bucket-page.tsx
@@ -560,6 +560,7 @@ export function BucketPage() {
                             variant="light"
                             onPress={() => setShareFile(file)}
                           >
+                            <span className="sr-only">{`Share ${file.name}`}</span>
                             <ShareIcon className="w-4 h-4" />
                           </Button>
                         )}
@@ -570,6 +571,7 @@ export function BucketPage() {
                           variant="light"
                           onPress={() => handleDownload(file)}
                         >
+                          <span className="sr-only">{`Download ${file.name}`}</span>
                           <DownloadIcon className="w-4 h-4" />
                         </Button>
                         {canWrite && (
@@ -584,6 +586,7 @@ export function BucketPage() {
                               confirm.onOpen();
                             }}
                           >
+                            <span className="sr-only">{`Delete ${file.name}`}</span>
                             <DeleteIcon className="w-4 h-4" />
                           </Button>
                         )}

--- a/webui/src/pages/bucket/ui/bucket-page.tsx
+++ b/webui/src/pages/bucket/ui/bucket-page.tsx
@@ -26,28 +26,6 @@ import {ShareFileDialog} from "../../../features/bucket/ui/share-file-dialog";
 import {formatSize} from "../../../shared/lib/format";
 import {ApiError, showErrorToast} from "../../../shared/api/error";
 
-/* ------------------------------------------------------------------ */
-/*  Role helpers                                                       */
-/* ------------------------------------------------------------------ */
-
-function canManageBucket(bucket: Bucket) {
-  return bucket.role === "owner";
-}
-
-function canWriteFiles(bucket: Bucket) {
-  return bucket.role === "owner" || bucket.role === "editor";
-}
-
-const ROLE_COLOR: Record<string, "primary" | "secondary" | "default"> = {
-  owner: "primary",
-  editor: "secondary",
-  viewer: "default",
-};
-
-/* ------------------------------------------------------------------ */
-/*  Credentials panel                                                  */
-/* ------------------------------------------------------------------ */
-
 function CredentialsPanel({bucket}: {bucket: Bucket}) {
   const [open, setOpen] = useState(false);
 
@@ -103,99 +81,21 @@ function CredentialsPanel({bucket}: {bucket: Bucket}) {
   );
 }
 
-/* ------------------------------------------------------------------ */
-/*  Drop zone                                                          */
-/* ------------------------------------------------------------------ */
-
-function DropZone({
-  active,
-  onDrop,
-  children,
-}: {
-  active: boolean;
-  onDrop: (files: FileList) => void;
-  children: React.ReactNode;
-}) {
-  const [dragging, setDragging] = useState(false);
-  const dragCounter = useRef(0);
-
-  function handleDragEnter(e: React.DragEvent) {
-    e.preventDefault();
-    dragCounter.current++;
-    setDragging(true);
-  }
-  function handleDragLeave(e: React.DragEvent) {
-    e.preventDefault();
-    dragCounter.current--;
-    if (dragCounter.current <= 0) {
-      dragCounter.current = 0;
-      setDragging(false);
-    }
-  }
-  function handleDrop(e: React.DragEvent) {
-    e.preventDefault();
-    dragCounter.current = 0;
-    setDragging(false);
-    if (active && e.dataTransfer.files.length > 0) {
-      onDrop(e.dataTransfer.files);
-    }
-  }
-
-  function suppressDrag(e: React.DragEvent) {
-    e.preventDefault();
-  }
-
-  return (
-    <div
-      className={`relative rounded-lg transition-colors ${
-        dragging && active ? "ring-2 ring-primary bg-primary/5" : ""
-      }`}
-      onDragEnter={active ? handleDragEnter : suppressDrag}
-      onDragOver={suppressDrag}
-      onDragLeave={active ? handleDragLeave : undefined}
-      onDrop={active ? handleDrop : suppressDrag}
-    >
-      {dragging && active && (
-        <div className="absolute inset-0 z-10 flex items-center justify-center bg-primary/5 rounded-lg pointer-events-none">
-          <p className="text-primary font-medium">Drop files here</p>
-        </div>
-      )}
-      {children}
-    </div>
-  );
-}
-
-/* ------------------------------------------------------------------ */
-/*  Upload queue indicator                                             */
-/* ------------------------------------------------------------------ */
-
-function UploadQueue({count}: {count: number}) {
-  if (count === 0) return null;
-  return (
-    <div className="flex items-center gap-2 px-3 py-2 bg-primary/10 rounded-lg text-sm text-primary">
-      <Spinner size="sm" color="primary" />
-      <span>
-        Uploading {count} file{count > 1 ? "s" : ""}…
-      </span>
-    </div>
-  );
-}
-
-/* ------------------------------------------------------------------ */
-/*  Main page                                                          */
-/* ------------------------------------------------------------------ */
+const ROLE_COLOR: Record<string, "primary" | "secondary" | "default"> = {
+  owner: "primary",
+  editor: "secondary",
+  viewer: "default",
+};
 
 export function BucketPage() {
   const {id} = useParams<{id: string}>();
   const navigate = useNavigate();
-
   const [bucket, setBucket] = useState<Bucket | null>(null);
   const [files, setFiles] = useState<FileInfo[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isRefreshingFiles, setIsRefreshingFiles] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
-
   const fileInput = useRef<HTMLInputElement>(null);
   const hasLoadedRef = useRef(false);
   const requestIDRef = useRef(0);
@@ -209,11 +109,8 @@ export function BucketPage() {
   const deferredSearchQuery = useDeferredValue(searchQuery);
   const activeSearchQuery = deferredSearchQuery.trim();
 
-  const [uploadingCount, setUploadingCount] = useState(0);
   const [sortColumn, setSortColumn] = useState<"name" | "size" | "created_at">("name");
   const [sortDirection, setSortDirection] = useState<"ascending" | "descending">("ascending");
-
-  /* ---- data loading ---- */
 
   const load = useCallback(async (mode: "initial" | "refresh" = "initial") => {
     if (!id) return;
@@ -230,12 +127,16 @@ export function BucketPage() {
         getBucket(id),
         listFiles(id, activeSearchQuery),
       ]);
-      if (requestID !== requestIDRef.current) return;
+      if (requestID !== requestIDRef.current) {
+        return;
+      }
       setBucket(loadedBucket);
       setFiles(fs);
       hasLoadedRef.current = true;
     } catch (err) {
-      if (requestID !== requestIDRef.current) return;
+      if (requestID !== requestIDRef.current) {
+        return;
+      }
       if (err instanceof ApiError && err.status === 404) {
         setBucket(null);
         setFiles([]);
@@ -263,8 +164,6 @@ export function BucketPage() {
     void load(hasLoadedRef.current ? "refresh" : "initial");
   }, [id, load]);
 
-  /* ---- sorted files ---- */
-
   const sortedFiles = useMemo(() => {
     const sorted = [...files];
     sorted.sort((a, b) => {
@@ -287,37 +186,28 @@ export function BucketPage() {
     }
   }
 
-  /* ---- uploads ---- */
-
-  async function handleMultiUpload(fileList: FileList) {
+  async function handleUpload(file: File) {
     if (!id || !bucket || !canWriteFiles(bucket)) return;
-    const filesToUpload = Array.from(fileList);
-    setUploadingCount((c) => c + filesToUpload.length);
-    const results = await Promise.allSettled(
-      filesToUpload.map(async (file) => {
-        try {
-          await uploadFile(id, file);
-          addToast({title: "File uploaded", description: `${file.name} added to bucket`, color: "success", timeout: 4000});
-        } finally {
-          setUploadingCount((c) => c - 1);
-        }
-      }),
-    );
-    for (const r of results) {
-      if (r.status === "rejected") showErrorToast(r.reason);
+    try {
+      await uploadFile(id, file);
+      addToast({title: "File uploaded", description: `${file.name} added to bucket`, color: "success", timeout: 4000});
+      await load("refresh");
+    } catch (err) {
+      showErrorToast(err);
     }
-    await load("refresh");
   }
 
   function onFileChange(e: React.ChangeEvent<HTMLInputElement>) {
-    const fileList = e.target.files;
-    if (fileList && fileList.length > 0) {
-      handleMultiUpload(fileList);
-      e.target.value = "";
-    }
+    const f = e.target.files?.[0];
+    if (f) handleUpload(f);
   }
 
-  /* ---- delete ---- */
+  function onDrop(e: React.DragEvent<HTMLDivElement>) {
+    e.preventDefault();
+    if (!bucket || !canWriteFiles(bucket)) return;
+    const f = e.dataTransfer.files?.[0];
+    if (f) handleUpload(f);
+  }
 
   async function handleDelete() {
     if (!id || !deleteId) return;
@@ -334,7 +224,9 @@ export function BucketPage() {
     }
   }
 
-  /* ---- download ---- */
+  function openShareModal(file: FileInfo) {
+    setShareFile(file);
+  }
 
   async function handleDownload(file: FileInfo) {
     if (!id) return;
@@ -344,8 +236,6 @@ export function BucketPage() {
       showErrorToast(err);
     }
   }
-
-  /* ---- loading / error / not-found states ---- */
 
   if (isLoading) {
     return (
@@ -406,13 +296,9 @@ export function BucketPage() {
       <Link to="/buckets" className="text-sm text-default-500 hover:text-primary transition-colors">
         &larr; Buckets
       </Link>
-
-      {/* Header row */}
-      <div className="flex flex-col sm:flex-row sm:items-center gap-4">
-        <div className="flex items-center gap-3 flex-1 min-w-0">
-          <h1 className="text-2xl sm:text-3xl font-bold truncate">
-            {bucket.key}
-          </h1>
+      <div className="flex flex-col gap-1">
+        <div className="flex items-center gap-3">
+          <h1 className="text-3xl font-bold">{bucket.key}</h1>
           <Chip size="sm" variant="flat" color={ROLE_COLOR[bucket.role]}>
             {bucket.role}
           </Chip>
@@ -422,38 +308,35 @@ export function BucketPage() {
             </Chip>
           )}
         </div>
-        <div className="flex gap-2 shrink-0">
-          {canManage && (
-            <Button variant="flat" onPress={shareBucket.onOpen}>
-              Share Bucket
-            </Button>
-          )}
-          {canWrite && (
-            <>
-              <input
-                type="file"
-                ref={fileInput}
-                className="hidden"
-                onChange={onFileChange}
-                multiple
-              />
-              <Button color="primary" onPress={() => fileInput.current?.click()}>
-                Upload File
-              </Button>
-            </>
-          )}
-        </div>
       </div>
-
-      {/* Credentials panel */}
       <CredentialsPanel bucket={bucket} />
-
-      {/* Upload queue */}
-      <UploadQueue count={uploadingCount} />
-
-      {/* File workspace */}
-      <DropZone active={canWrite} onDrop={handleMultiUpload}>
-        {/* Search bar */}
+      <div className="flex justify-end gap-2">
+        {canManage && (
+          <Button variant="flat" onPress={shareBucket.onOpen}>
+            Share Bucket
+          </Button>
+        )}
+        {canWrite && (
+          <>
+            <input
+              type="file"
+              ref={fileInput}
+              className="hidden"
+              onChange={onFileChange}
+            />
+            <Button color="primary" onPress={() => fileInput.current?.click()}>
+              Upload File
+            </Button>
+          </>
+        )}
+      </div>
+      <div
+        className={
+          canWrite ? "border-2 border-dashed rounded p-4" : "border rounded p-4"
+        }
+        onDragOver={(e) => e.preventDefault()}
+        onDrop={onDrop}
+      >
         <div className="mb-4 flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
           <Input
             aria-label="Search files"
@@ -473,16 +356,13 @@ export function BucketPage() {
             </p>
           ) : null}
         </div>
-
         {files.length === 0 ? (
-          <div className="border-2 border-dashed border-default-300 rounded-lg p-8">
-            <EmptyState
-              title={emptyTitle}
-              description={emptyDescription}
-              ctaLabel={!activeSearchQuery && canWrite ? "Upload File" : undefined}
-              onCtaPress={!activeSearchQuery && canWrite ? () => fileInput.current?.click() : undefined}
-            />
-          </div>
+          <EmptyState
+            title={emptyTitle}
+            description={emptyDescription}
+            ctaLabel={!activeSearchQuery && canWrite ? "Upload File" : undefined}
+            onCtaPress={!activeSearchQuery && canWrite ? () => fileInput.current?.click() : undefined}
+          />
         ) : (
           <table className="w-full text-left">
             <thead>
@@ -522,7 +402,7 @@ export function BucketPage() {
                           isIconOnly
                           aria-label={`Share ${f.name}`}
                           variant="light"
-                          onPress={() => setShareFile(f)}
+                          onPress={() => openShareModal(f)}
                         >
                           <ShareIcon className="w-5 h-5" />
                         </Button>
@@ -556,17 +436,13 @@ export function BucketPage() {
             </tbody>
           </table>
         )}
-      </DropZone>
-
-      {/* File count summary */}
+      </div>
       {files.length > 0 && (
         <p className="text-xs text-default-400">
           {files.length} file{files.length !== 1 ? "s" : ""} &middot;{" "}
           {formatSize(files.reduce((acc, f) => acc + f.size, 0))} total
         </p>
       )}
-
-      {/* Modals */}
       <ConfirmDialog
         isOpen={confirm.isOpen}
         onOpenChange={(open) => {
@@ -574,7 +450,7 @@ export function BucketPage() {
           confirm.onOpenChange();
         }}
         title="Delete file?"
-        message="Are you sure you want to delete this file? This action cannot be undone."
+        message="Are you sure you want to delete this file?"
         onConfirm={handleDelete}
         confirmLabel="Delete"
         isConfirmLoading={isDeleting}
@@ -597,4 +473,12 @@ export function BucketPage() {
       />
     </div>
   );
+}
+
+function canManageBucket(bucket: Bucket) {
+  return bucket.role === "owner";
+}
+
+function canWriteFiles(bucket: Bucket) {
+  return bucket.role === "owner" || bucket.role === "editor";
 }

--- a/webui/src/pages/bucket/ui/bucket-page.tsx
+++ b/webui/src/pages/bucket/ui/bucket-page.tsx
@@ -56,7 +56,7 @@ export function BucketPage() {
   const deferredSearchQuery = useDeferredValue(searchQuery);
   const activeSearchQuery = deferredSearchQuery.trim();
 
-  const [sortBy, setSortBy] = useState<SortField>("name");
+  const [sortBy, setSortBy] = useState<SortField | null>(null);
   const [sortAsc, setSortAsc] = useState(true);
 
   function toggleSort(field: SortField) {
@@ -69,9 +69,11 @@ export function BucketPage() {
   }
 
   const sortedFiles = useMemo(() => {
-    const sorted = [...files].sort((a, b) => {
+    if (!sortBy) return files;
+    const field = sortBy;
+    return [...files].sort((a, b) => {
       let cmp: number;
-      switch (sortBy) {
+      switch (field) {
         case "name":
           cmp = a.name.localeCompare(b.name);
           break;
@@ -81,12 +83,9 @@ export function BucketPage() {
         case "created_at":
           cmp = new Date(a.created_at).getTime() - new Date(b.created_at).getTime();
           break;
-        default:
-          cmp = 0;
       }
       return sortAsc ? cmp : -cmp;
     });
-    return sorted;
   }, [files, sortBy, sortAsc]);
 
   const load = useCallback(async (mode: "initial" | "refresh" = "initial") => {
@@ -459,7 +458,7 @@ function CredentialsPanel({bucket}: {bucket: Bucket}) {
   );
 }
 
-function SortArrow({field, sortBy, sortAsc}: {field: SortField; sortBy: SortField; sortAsc: boolean}) {
+function SortArrow({field, sortBy, sortAsc}: {field: SortField; sortBy: SortField | null; sortAsc: boolean}) {
   if (sortBy !== field) return null;
   return (
     <span aria-hidden="true" className="ml-1 text-default-400">

--- a/webui/src/pages/bucket/ui/bucket-page.tsx
+++ b/webui/src/pages/bucket/ui/bucket-page.tsx
@@ -10,7 +10,6 @@ import {
   TableColumn,
   TableHeader,
   TableRow,
-  Tooltip,
   useDisclosure,
 } from "@heroui/react";
 import type {SortDescriptor} from "@heroui/react";
@@ -560,45 +559,39 @@ export function BucketPage() {
                   <TableCell>
                     <div className="flex gap-1 justify-end">
                       {canWrite && (
-                        <Tooltip content="Share">
-                          <Button
-                            isIconOnly
-                            size="sm"
-                            aria-label={`Share ${file.name}`}
-                            variant="light"
-                            onPress={() => setShareFile(file)}
-                          >
-                            <ShareIcon className="w-4 h-4" />
-                          </Button>
-                        </Tooltip>
-                      )}
-                      <Tooltip content="Download">
                         <Button
                           isIconOnly
                           size="sm"
-                          aria-label={`Download ${file.name}`}
+                          aria-label={`Share ${file.name}`}
                           variant="light"
-                          onPress={() => handleDownload(file)}
+                          onPress={() => setShareFile(file)}
                         >
-                          <DownloadIcon className="w-4 h-4" />
+                          <ShareIcon className="w-4 h-4" />
                         </Button>
-                      </Tooltip>
+                      )}
+                      <Button
+                        isIconOnly
+                        size="sm"
+                        aria-label={`Download ${file.name}`}
+                        variant="light"
+                        onPress={() => handleDownload(file)}
+                      >
+                        <DownloadIcon className="w-4 h-4" />
+                      </Button>
                       {canWrite && (
-                        <Tooltip content="Delete" color="danger">
-                          <Button
-                            isIconOnly
-                            size="sm"
-                            aria-label={`Delete ${file.name}`}
-                            variant="light"
-                            color="danger"
-                            onPress={() => {
-                              setDeleteId(file.id);
-                              confirm.onOpen();
-                            }}
-                          >
-                            <DeleteIcon className="w-4 h-4" />
-                          </Button>
-                        </Tooltip>
+                        <Button
+                          isIconOnly
+                          size="sm"
+                          aria-label={`Delete ${file.name}`}
+                          variant="light"
+                          color="danger"
+                          onPress={() => {
+                            setDeleteId(file.id);
+                            confirm.onOpen();
+                          }}
+                        >
+                          <DeleteIcon className="w-4 h-4" />
+                        </Button>
                       )}
                     </div>
                   </TableCell>

--- a/webui/src/pages/bucket/ui/bucket-page.tsx
+++ b/webui/src/pages/bucket/ui/bucket-page.tsx
@@ -210,10 +210,8 @@ export function BucketPage() {
   const activeSearchQuery = deferredSearchQuery.trim();
 
   const [uploadingCount, setUploadingCount] = useState(0);
-  type SortColumn = "name" | "size" | "created_at";
-  type SortDir = "ascending" | "descending";
-  const [sortColumn, setSortColumn] = useState<SortColumn>("name");
-  const [sortDirection, setSortDirection] = useState<SortDir>("ascending");
+  const [sortColumn, setSortColumn] = useState<"name" | "size" | "created_at">("name");
+  const [sortDirection, setSortDirection] = useState<"ascending" | "descending">("ascending");
 
   /* ---- data loading ---- */
 
@@ -271,20 +269,16 @@ export function BucketPage() {
     const sorted = [...files];
     sorted.sort((a, b) => {
       let cmp = 0;
-      if (sortColumn === "name") {
-        cmp = a.name.localeCompare(b.name);
-      } else if (sortColumn === "size") {
-        cmp = a.size - b.size;
-      } else if (sortColumn === "created_at") {
-        cmp =
-          new Date(a.created_at).getTime() - new Date(b.created_at).getTime();
-      }
+      if (sortColumn === "name") cmp = a.name.localeCompare(b.name);
+      else if (sortColumn === "size") cmp = a.size - b.size;
+      else if (sortColumn === "created_at")
+        cmp = new Date(a.created_at).getTime() - new Date(b.created_at).getTime();
       return sortDirection === "descending" ? -cmp : cmp;
     });
     return sorted;
   }, [files, sortColumn, sortDirection]);
 
-  function toggleSort(col: SortColumn) {
+  function toggleSort(col: "name" | "size" | "created_at") {
     if (sortColumn === col) {
       setSortDirection((d) => (d === "ascending" ? "descending" : "ascending"));
     } else {
@@ -303,12 +297,7 @@ export function BucketPage() {
       filesToUpload.map(async (file) => {
         try {
           await uploadFile(id, file);
-          addToast({
-            title: "File uploaded",
-            description: `${file.name} added to bucket`,
-            color: "success",
-            timeout: 4000,
-          });
+          addToast({title: "File uploaded", description: `${file.name} added to bucket`, color: "success", timeout: 4000});
         } finally {
           setUploadingCount((c) => c - 1);
         }
@@ -435,13 +424,8 @@ export function BucketPage() {
         </div>
         <div className="flex gap-2 shrink-0">
           {canManage && (
-            <Button
-              variant="flat"
-              size="sm"
-              startContent={<ShareIcon className="w-4 h-4" />}
-              onPress={shareBucket.onOpen}
-            >
-              <span className="hidden sm:inline">Share</span>
+            <Button variant="flat" onPress={shareBucket.onOpen}>
+              Share Bucket
             </Button>
           )}
           {canWrite && (
@@ -453,12 +437,8 @@ export function BucketPage() {
                 onChange={onFileChange}
                 multiple
               />
-              <Button
-                color="primary"
-                size="sm"
-                onPress={() => fileInput.current?.click()}
-              >
-                Upload
+              <Button color="primary" onPress={() => fileInput.current?.click()}>
+                Upload File
               </Button>
             </>
           )}
@@ -499,104 +479,82 @@ export function BucketPage() {
             <EmptyState
               title={emptyTitle}
               description={emptyDescription}
-              ctaLabel={canWrite ? "Upload File" : undefined}
-              onCtaPress={canWrite ? () => fileInput.current?.click() : undefined}
+              ctaLabel={!activeSearchQuery && canWrite ? "Upload File" : undefined}
+              onCtaPress={!activeSearchQuery && canWrite ? () => fileInput.current?.click() : undefined}
             />
           </div>
         ) : (
-          <div className="border border-divider rounded-lg overflow-hidden">
-            <table className="w-full text-left">
-              <thead>
-                <tr className="border-b border-divider bg-default-50">
-                  <th className="px-4 py-3 text-sm font-medium">
-                    <button type="button" className="cursor-pointer select-none" onClick={() => toggleSort("name")}>
-                      Name{sortColumn === "name" && <span aria-hidden="true"> {sortDirection === "ascending" ? "↑" : "↓"}</span>}
+          <table className="w-full text-left">
+            <thead>
+              <tr>
+                <th className="pb-2 cursor-pointer select-none" onClick={() => toggleSort("name")}>
+                  Name
+                </th>
+                <th className="pb-2 cursor-pointer select-none" onClick={() => toggleSort("size")}>
+                  Size
+                </th>
+                <th className="pb-2 cursor-pointer select-none" onClick={() => toggleSort("created_at")}>
+                  Created
+                </th>
+                <th className="pb-2"></th>
+              </tr>
+            </thead>
+            <tbody>
+              {sortedFiles.map((f) => (
+                <tr key={f.id} className="border-t">
+                  <td className="py-2">
+                    <button
+                      type="button"
+                      className="text-left hover:text-primary transition-colors cursor-pointer"
+                      onClick={() => setPreviewFile(f)}
+                    >
+                      {f.name}
                     </button>
-                  </th>
-                  <th className="px-4 py-3 text-sm font-medium hidden sm:table-cell">
-                    <button type="button" className="cursor-pointer select-none" onClick={() => toggleSort("size")}>
-                      Size{sortColumn === "size" && <span aria-hidden="true"> {sortDirection === "ascending" ? "↑" : "↓"}</span>}
-                    </button>
-                  </th>
-                  <th className="px-4 py-3 text-sm font-medium hidden md:table-cell">
-                    <button type="button" className="cursor-pointer select-none" onClick={() => toggleSort("created_at")}>
-                      Created{sortColumn === "created_at" && <span aria-hidden="true"> {sortDirection === "ascending" ? "↑" : "↓"}</span>}
-                    </button>
-                  </th>
-                  <th className="px-4 py-3 text-sm font-medium text-right w-[1%]">
-                    Actions
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                {sortedFiles.map((file) => (
-                  <tr key={file.id} className="border-t border-divider hover:bg-default-50 transition-colors">
-                    <td className="px-4 py-3">
-                      <button
-                        type="button"
-                        className="text-left hover:text-primary transition-colors cursor-pointer truncate max-w-[200px] sm:max-w-[300px] md:max-w-none"
-                        onClick={() => setPreviewFile(file)}
-                        title={file.name}
-                      >
-                        {file.name}
-                      </button>
-                      <span className="block sm:hidden text-xs text-default-400 mt-0.5">
-                        {formatSize(file.size)}
-                      </span>
-                    </td>
-                    <td className="px-4 py-3 hidden sm:table-cell text-default-500 text-sm">
-                      {formatSize(file.size)}
-                    </td>
-                    <td className="px-4 py-3 hidden md:table-cell text-default-500 text-sm whitespace-nowrap">
-                      {new Date(file.created_at).toLocaleDateString()}
-                    </td>
-                    <td className="px-4 py-3">
-                      <div className="flex gap-1 justify-end">
-                        {canWrite && (
-                          <Button
-                            isIconOnly
-                            size="sm"
-                            aria-label={`Share ${file.name}`}
-                            variant="light"
-                            onPress={() => setShareFile(file)}
-                          >
-                            <span className="sr-only">{`Share ${file.name}`}</span>
-                            <ShareIcon className="w-4 h-4" />
-                          </Button>
-                        )}
+                  </td>
+                  <td className="py-2">{formatSize(f.size)}</td>
+                  <td className="py-2">
+                    {new Date(f.created_at).toLocaleString()}
+                  </td>
+                  <td className="py-2">
+                    <div className="flex gap-2">
+                      {canWrite && (
                         <Button
                           isIconOnly
-                          size="sm"
-                          aria-label={`Download ${file.name}`}
+                          aria-label={`Share ${f.name}`}
                           variant="light"
-                          onPress={() => handleDownload(file)}
+                          onPress={() => setShareFile(f)}
                         >
-                          <span className="sr-only">{`Download ${file.name}`}</span>
-                          <DownloadIcon className="w-4 h-4" />
+                          <ShareIcon className="w-5 h-5" />
                         </Button>
-                        {canWrite && (
-                          <Button
-                            isIconOnly
-                            size="sm"
-                            aria-label={`Delete ${file.name}`}
-                            variant="light"
-                            color="danger"
-                            onPress={() => {
-                              setDeleteId(file.id);
-                              confirm.onOpen();
-                            }}
-                          >
-                            <span className="sr-only">{`Delete ${file.name}`}</span>
-                            <DeleteIcon className="w-4 h-4" />
-                          </Button>
-                        )}
-                      </div>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
+                      )}
+                      <Button
+                        isIconOnly
+                        aria-label={`Download ${f.name}`}
+                        variant="light"
+                        onPress={() => handleDownload(f)}
+                      >
+                        <DownloadIcon className="w-5 h-5" />
+                      </Button>
+                      {canWrite && (
+                        <Button
+                          isIconOnly
+                          aria-label={`Delete ${f.name}`}
+                          variant="light"
+                          color="danger"
+                          onPress={() => {
+                            setDeleteId(f.id);
+                            confirm.onOpen();
+                          }}
+                        >
+                          <DeleteIcon className="w-5 h-5" />
+                        </Button>
+                      )}
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
         )}
       </DropZone>
 


### PR DESCRIPTION
## Summary

- Replace raw HTML table with HeroUI `Table` component with sortable columns (name, size, created date)
- Add collapsible S3 credentials panel using HeroUI `Snippet` for copy-to-clipboard on bucket ID and access key
- Show role chip (owner/editor/viewer) and shared badge in the page header
- Support multi-file upload with a concurrent upload queue indicator
- Improve drag-and-drop with proper enter/leave tracking, ring highlight, and overlay text
- Add `Tooltip` on all file action buttons (share, download, delete)
- Responsive: inline file size on mobile, hide date column on small screens, stack header on narrow viewports
- Show file count and total size summary below the table

## Test plan
- [ ] Navigate to a bucket detail page — verify header shows bucket name, role chip, and shared badge
- [ ] Expand/collapse S3 credentials panel — verify copy-to-clipboard works for bucket ID and access key
- [ ] Upload a single file — verify toast and file appears in table
- [ ] Upload multiple files at once — verify upload queue indicator shows count, files appear after upload
- [ ] Drag and drop files onto the page — verify ring highlight appears, files upload on drop
- [ ] Click column headers to sort by name, size, date — verify sort direction toggles
- [ ] Hover action buttons — verify tooltips appear (Share, Download, Delete)
- [ ] Delete a file — verify confirmation dialog appears with warning text
- [ ] Share a file — verify share dialog opens
- [ ] View as viewer role — verify upload button and write actions are hidden
- [ ] Resize to mobile width — verify responsive layout (stacked header, inline size, hidden date column)

🤖 Generated with [Claude Code](https://claude.com/claude-code)