### PR TITLE
[codex] THE-854 stabilize shared webui Playwright gate

### DIFF
--- a/webui/e2e/buckets.spec.ts
+++ b/webui/e2e/buckets.spec.ts
@@ -57,6 +57,7 @@ test.describe("Bucket creation flow", () => {
   }) => {
     await injectAuth(page);
     await mockGet(page, "/buckets", []);
+    await mockGet(page, "/sources", [MOCK_SOURCE]);
     await page.goto("/buckets");
     await expect(
       page.getByRole("heading", { name: /^Buckets$/, level: 1 }),
@@ -165,9 +166,15 @@ test.describe("Bucket creation flow", () => {
     await mockGet(page, "/buckets/bkt-1/files", []);
     await page.goto("/buckets/bkt-1");
 
-    await expect(page.getByRole("button", { name: "Upload File" })).toHaveCount(2);
-    await expect(page.getByRole("button", { name: "Share Bucket" })).toBeVisible();
-    await expect(page.getByText("Drag and drop a file here")).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /^Upload( File)?$/ }).first(),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /^(Share Bucket|Share)$/ }),
+    ).toBeVisible();
+    await expect(
+      page.getByText(/(Drag and drop a file here|Drop files here|Upload)/),
+    ).toBeVisible();
   });
 
   test("Share Bucket dialog shows grant loading and successful grants", async ({
@@ -190,7 +197,7 @@ test.describe("Bucket creation flow", () => {
     await page.goto("/buckets/bkt-1");
     const dialog = page.getByRole("dialog");
 
-    await page.getByRole("button", { name: "Share Bucket" }).click();
+    await page.getByRole("button", { name: /^(Share Bucket|Share)$/ }).click();
     await expect(dialog.getByText("Loading people with access")).toBeVisible();
 
     expect(fulfillGrants).toBeDefined();
@@ -214,7 +221,7 @@ test.describe("Bucket creation flow", () => {
     await page.goto("/buckets/bkt-1");
     const dialog = page.getByRole("dialog");
 
-    await page.getByRole("button", { name: "Share Bucket" }).click();
+    await page.getByRole("button", { name: /^(Share Bucket|Share)$/ }).click();
     await expect(dialog.getByText("Access list failed to load")).toBeVisible();
     await expect(dialog.getByText("Grant store unavailable")).toBeVisible();
     await expect(dialog.getByRole("button", { name: "Retry" })).toBeVisible();
@@ -241,13 +248,13 @@ test.describe("Bucket creation flow", () => {
     await page.goto("/buckets/bkt-1");
     const dialog = page.getByRole("dialog");
 
-    await page.getByRole("button", { name: "Share Bucket" }).click();
+    await page.getByRole("button", { name: /^(Share Bucket|Share)$/ }).click();
     await expect(dialog.getByText("Loading people with access")).toBeVisible();
     await expect.poll(() => grantRoutes.length).toBe(1);
     await dialog.getByRole("button", { name: "Close" }).last().click();
     await expect(dialog).not.toBeVisible();
 
-    await page.getByRole("button", { name: "Share Bucket" }).click();
+    await page.getByRole("button", { name: /^(Share Bucket|Share)$/ }).click();
     await expect.poll(() => grantRoutes.length).toBe(2);
     await grantRoutes[1].fulfill({status: 200, json: [MOCK_GRANT]});
     await expect(dialog.getByText("shared-user")).toBeVisible();

--- a/webui/e2e/buckets.spec.ts
+++ b/webui/e2e/buckets.spec.ts
@@ -173,7 +173,9 @@ test.describe("Bucket creation flow", () => {
       page.getByRole("button", { name: /^(Share Bucket|Share)$/ }),
     ).toBeVisible();
     await expect(
-      page.getByText(/(Drag and drop a file here|Drop files here|Upload)/),
+      page.locator("p").filter({
+        hasText: /(Drag and drop a file here|Drop files here)/,
+      }).first(),
     ).toBeVisible();
   });
 

--- a/webui/e2e/dashboard.spec.ts
+++ b/webui/e2e/dashboard.spec.ts
@@ -8,8 +8,32 @@
  * - Unauthenticated user at "/" sees the landing page
  */
 
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
 import { injectAuth, mockGet, API_GLOB } from "./helpers";
+
+async function expectDashboardNav(
+  page: Page,
+  name: "Sources" | "Buckets",
+) {
+  const pattern =
+    name === "Sources"
+      ? /^(Manage Sources|Sources)$/
+      : /^(Manage Buckets|Buckets)$/;
+  await expect(
+    page.locator("a, button").filter({ hasText: pattern }).first(),
+  ).toBeVisible();
+}
+
+async function clickDashboardNav(
+  page: Page,
+  name: "Sources" | "Buckets",
+) {
+  const pattern =
+    name === "Sources"
+      ? /^(Manage Sources|Sources)$/
+      : /^(Manage Buckets|Buckets)$/;
+  await page.locator("a, button").filter({ hasText: pattern }).first().click();
+}
 
 test.describe("Dashboard", () => {
   test("authenticated user at / redirects to /dashboard", async ({ page }) => {
@@ -32,23 +56,15 @@ test.describe("Dashboard", () => {
     await expect(
       summaryCards.getByText("Storage Used", { exact: true }),
     ).toBeVisible();
-    await expect(
-      page
-        .locator("a, button")
-        .filter({ hasText: /^Manage Sources$/ }),
-    ).toBeVisible();
-    await expect(
-      page
-        .locator("a, button")
-        .filter({ hasText: /^Manage Buckets$/ }),
-    ).toBeVisible();
+    await expectDashboardNav(page, "Sources");
+    await expectDashboardNav(page, "Buckets");
   });
 
   test("Manage Buckets button navigates to /buckets", async ({ page }) => {
     await injectAuth(page);
     await mockGet(page, "/buckets", []);
     await page.goto("/dashboard");
-    await page.locator("a, button").filter({ hasText: /^Manage Buckets$/ }).click();
+    await clickDashboardNav(page, "Buckets");
     await expect(page).toHaveURL("/buckets");
     await expect(
       page.getByRole("heading", { name: /^Buckets$/, level: 1 }),
@@ -59,7 +75,7 @@ test.describe("Dashboard", () => {
     await injectAuth(page);
     await mockGet(page, "/sources", []);
     await page.goto("/dashboard");
-    await page.locator("a, button").filter({ hasText: /^Manage Sources$/ }).click();
+    await clickDashboardNav(page, "Sources");
     await expect(page).toHaveURL("/sources");
     await expect(
       page.getByRole("heading", { name: /^Sources$/, level: 1 }),
@@ -71,10 +87,12 @@ test.describe("Dashboard", () => {
     await page.route(`${API_GLOB}/**`, (route) => route.abort());
     await page.goto("/");
     await expect(
-      page.getByRole("heading", { name: "Free Distributed Object Storage" }),
+      page.getByRole("heading", {
+        name: /^(Free Distributed Object Storage|Unify your free storage into one bucket)$/,
+      }),
     ).toBeVisible();
     await expect(
-      page.getByRole("button", { name: "Sign Up" }).first(),
+      page.getByRole("button", { name: /^(Sign Up|Get Started Free)$/ }).first(),
     ).toBeVisible();
     await expect(
       page.getByRole("button", { name: "Log In" }),

--- a/webui/e2e/error-states.spec.ts
+++ b/webui/e2e/error-states.spec.ts
@@ -42,18 +42,18 @@ test.describe("Error states", () => {
     await expect(
       dialog
         .locator(":not(button)")
-        .filter({ hasText: /^Sign Up$/ })
+        .filter({ hasText: /^(Sign Up|Create a free SFree account)$/ })
         .first(),
     ).toBeVisible();
 
     await dialog.getByLabel("Username").fill("newuser");
-    await dialog.getByRole("button", { name: "Sign Up" }).click();
+    await dialog.getByRole("button", { name: "Create Account" }).click();
 
     // Generated password is shown via Snippet
     await expect(dialog.getByText("generated-secret-pw")).toBeVisible();
 
-    // Close button dismisses
-    await dialog.getByText("Close", { exact: true }).click();
+    // Confirmation button dismisses
+    await dialog.getByRole("button", { name: "I saved my password" }).click();
     await expect(dialog).not.toBeVisible();
   });
 
@@ -64,7 +64,7 @@ test.describe("Error states", () => {
     await page.route(`${API_GLOB}/**`, (route) => route.abort());
 
     await page.goto("/");
-    await page.getByRole("button", { name: "Log In" }).click();
+    await page.getByRole("button", { name: "Log In" }).first().click();
 
     const dialog = page.getByRole("dialog");
     await expect(dialog).toBeVisible();

--- a/webui/e2e/error-states.spec.ts
+++ b/webui/e2e/error-states.spec.ts
@@ -47,13 +47,17 @@ test.describe("Error states", () => {
     ).toBeVisible();
 
     await dialog.getByLabel("Username").fill("newuser");
-    await dialog.getByRole("button", { name: "Create Account" }).click();
+    await dialog
+      .getByRole("button", { name: /^(Sign Up|Create Account)$/ })
+      .click();
 
     // Generated password is shown via Snippet
     await expect(dialog.getByText("generated-secret-pw")).toBeVisible();
 
-    // Confirmation button dismisses
-    await dialog.getByRole("button", { name: "I saved my password" }).click();
+    // Dismiss with either the legacy or refreshed confirmation action
+    await dialog
+      .getByRole("button", { name: /^(Close|I saved my password)$/ })
+      .click();
     await expect(dialog).not.toBeVisible();
   });
 

--- a/webui/e2e/error-states.spec.ts
+++ b/webui/e2e/error-states.spec.ts
@@ -57,6 +57,7 @@ test.describe("Error states", () => {
     // Dismiss with either the legacy or refreshed confirmation action
     await dialog
       .getByRole("button", { name: /^(Close|I saved my password)$/ })
+      .last()
       .click();
     await expect(dialog).not.toBeVisible();
   });

--- a/webui/e2e/files.spec.ts
+++ b/webui/e2e/files.spec.ts
@@ -8,7 +8,7 @@
  * - Back navigation button is present
  */
 
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
 import { injectAuth, mockGet } from "./helpers";
 import { formatSize } from "../src/shared/lib/format";
 
@@ -56,6 +56,21 @@ const LARGE_TEXT_FILE = {
 };
 
 test.describe("File listing and download", () => {
+  async function revealCredentialsIfNeeded(
+    page: Page,
+  ) {
+    if (await page.getByText(/AK123/).isVisible().catch(() => false)) {
+      return;
+    }
+
+    const credentialsToggle = page.getByRole("button", {
+      name: "S3 Credentials",
+    });
+    if (await credentialsToggle.isVisible().catch(() => false)) {
+      await credentialsToggle.click();
+    }
+  }
+
   test("bucket detail shows bucket info", async ({ page }) => {
     await injectAuth(page);
     await mockGet(page, "/buckets", [MOCK_BUCKET]);
@@ -64,6 +79,7 @@ test.describe("File listing and download", () => {
     await page.goto("/buckets/bkt-1");
 
     await expect(page.getByRole("heading", { name: "my-bucket" })).toBeVisible();
+    await revealCredentialsIfNeeded(page);
     await expect(page.getByText(/AK123/)).toBeVisible();
   });
 
@@ -74,7 +90,9 @@ test.describe("File listing and download", () => {
     await mockGet(page, "/buckets/bkt-1/files", []);
     await page.goto("/buckets/bkt-1");
 
-    await expect(page.getByText("No files")).toBeVisible();
+    await expect(
+      page.getByText(/(No files yet|Last step: upload your first file)/),
+    ).toBeVisible();
   });
 
   test("bucket detail lists files with name, size, and date columns", async ({
@@ -139,8 +157,12 @@ test.describe("File listing and download", () => {
     await expect(
       firstRowActions.getByRole("button", { name: "Download report.pdf" }),
     ).toBeVisible();
-    await expect(page.getByRole("button", { name: "Upload File" })).not.toBeVisible();
-    await expect(page.getByRole("button", { name: "Share Bucket" })).not.toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /^Upload( File)?$/ }),
+    ).not.toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /^(Share Bucket|Share)$/ }),
+    ).not.toBeVisible();
     await expect(page.getByRole("button", { name: "Share report.pdf" })).not.toBeVisible();
     await expect(page.getByRole("button", { name: "Delete report.pdf" })).not.toBeVisible();
   });
@@ -152,8 +174,12 @@ test.describe("File listing and download", () => {
     await mockGet(page, "/buckets/bkt-1/files", [MOCK_FILES[0]]);
     await page.goto("/buckets/bkt-1");
 
-    await expect(page.getByRole("button", { name: "Upload File" })).toBeVisible();
-    await expect(page.getByRole("button", { name: "Share Bucket" })).not.toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /^Upload( File)?$/ }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /^(Share Bucket|Share)$/ }),
+    ).not.toBeVisible();
     await expect(page.getByRole("button", { name: "Share report.pdf" })).toBeVisible();
     await expect(page.getByRole("button", { name: "Download report.pdf" })).toBeVisible();
     await expect(page.getByRole("button", { name: "Delete report.pdf" })).toBeVisible();
@@ -254,8 +280,9 @@ test.describe("File listing and download", () => {
     // Navigate to bucket detail
     await page.goto("/buckets/bkt-1");
 
-    // Back button (isIconOnly with ArrowLeftIcon) is present
-    const backButton = page.getByRole("button").first();
+    const backButton = page
+      .locator('a[href="/buckets"], button[aria-label="Back"]')
+      .first();
     await expect(backButton).toBeVisible();
   });
 });

--- a/webui/e2e/sources.spec.ts
+++ b/webui/e2e/sources.spec.ts
@@ -8,7 +8,7 @@
  * - Newly created source appears in the list
  */
 
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
 import { injectAuth, mockGet, mockPost } from "./helpers";
 
 const MOCK_SOURCE = {
@@ -20,6 +20,24 @@ const MOCK_SOURCE = {
 };
 
 test.describe("Source creation flow", () => {
+  async function openCreateSourceDialog(
+    page: Page,
+  ) {
+    await page.getByRole("button", { name: "Add Source" }).first().click();
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+
+    const providerPicker = dialog.getByText("Connect a Source");
+    if (await providerPicker.isVisible().catch(() => false)) {
+      await dialog.getByText("Google Drive", { exact: true }).first().click();
+      await expect(
+        dialog.getByLabel(/^(Name|Source Name)$/),
+      ).toBeVisible();
+    }
+
+    return dialog;
+  }
+
   test("sources page shows empty state when no sources exist", async ({
     page,
   }) => {
@@ -39,16 +57,12 @@ test.describe("Source creation flow", () => {
     await injectAuth(page);
     await mockGet(page, "/sources", []);
     await page.goto("/sources");
-    await page.getByRole("button", { name: "Add Source" }).first().click();
-    const dialog = page.getByRole("dialog");
-    await expect(dialog).toBeVisible();
+    const dialog = await openCreateSourceDialog(page);
     await expect(
-      dialog.getByText("Create Source"),
+      dialog.getByText(/^(Create Source|Connect a Source|Connect Google Drive)$/),
     ).toBeVisible();
-    await expect(dialog.getByLabel("Name")).toBeVisible();
-    await expect(
-      dialog.getByLabel("Service Account Key (JSON)"),
-    ).toBeVisible();
+    await expect(dialog.getByLabel(/^(Name|Source Name)$/)).toBeVisible();
+    await expect(dialog.getByLabel("Service Account Key (JSON)")).toBeVisible();
   });
 
   test("submitting the dialog creates a source and refreshes the list", async ({
@@ -74,22 +88,25 @@ test.describe("Source creation flow", () => {
     await expect(page.getByText("No sources yet")).toBeVisible();
 
     // Open dialog
-    await page.getByRole("button", { name: "Add Source" }).first().click();
-    await expect(page.getByRole("dialog")).toBeVisible();
+    const dialog = await openCreateSourceDialog(page);
 
     // Fill form
-    await page.getByLabel("Name").fill("My Drive");
-    await page
+    await dialog.getByLabel(/^(Name|Source Name)$/).fill("My Drive");
+    await dialog
       .getByLabel("Service Account Key (JSON)")
-      .fill("service-account-key");
+      .fill("{\"type\":\"service_account\",\"project_id\":\"demo-project\"}");
 
     // Submit
-    await page
-      .getByRole("dialog")
+    await dialog
       .getByRole("button", { name: "Create" })
+      .or(dialog.getByRole("button", { name: "Connect Source" }))
       .click();
 
-    // Dialog should close and source should appear
+    const successState = dialog.getByText(/^(Source Connected|My Drive is ready)$/);
+    if (await successState.first().isVisible().catch(() => false)) {
+      await dialog.getByRole("button", { name: "Close" }).click();
+    }
+
     await expect(page.getByRole("dialog")).not.toBeVisible();
     await expect(page.getByText("My Drive", { exact: true })).toBeVisible();
   });


### PR DESCRIPTION
## Summary
- stabilize the shared `webui` Playwright specs so they assert stable user behavior instead of branch-specific copy and control labels
- cover both current and in-flight frontend variants for dashboard navigation, source creation, bucket actions, file workspace states, and landing/auth entry points
- keep the change scoped to `webui/e2e/*` so the fix can unblock PRs #323, #324, #325, #326, and #327 without coupling to product code

## Root Cause
The shared Woodpecker `ci/woodpecker/pr/webui` gate was brittle against active frontend work. Several specs hard-coded exact labels and layouts such as `Manage Sources`, `Manage Buckets`, `Upload File`, old landing-page hero copy, and the pre-wizard source creation flow. That made one shared gate fail across multiple unrelated user-facing PRs even when the underlying behavior stayed valid.

## Validation
- `cd webui && npm run lint`
  - passes with the pre-existing `react-hooks/exhaustive-deps` warning in `src/pages/sources/ui/sources-page.tsx`
- `cd webui && npm run build`
- Playwright was not run locally because browser E2E remains Woodpecker-only on agent machines

## Impact
This PR gives QA a standalone branch for the shared frontend-gate fix so Woodpecker can validate it independently and unblock the frontend review queue once green.