### PR TITLE
[codex] Expose bucket file search in the web UI

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -186,7 +186,32 @@ curl -s -X POST "http://localhost:8080/api/v1/buckets/$BUCKET_ID/upload" \
 }
 ```
 
-## 6. Download the file
+## 6. List or search bucket files
+
+You can list bucket files or narrow the result set with a case-insensitive
+filename query:
+
+```bash
+curl -s "http://localhost:8080/api/v1/buckets/$BUCKET_ID/files?q=readme" \
+  -H "Authorization: Basic $AUTH"
+```
+
+**Expected output:**
+
+```json
+[
+  {
+    "id": "FILE_ID",
+    "name": "README.md",
+    "created_at": "...",
+    "size": 1234
+  }
+]
+```
+
+Whitespace-only `q` behaves like the unfiltered file list.
+
+## 7. Download the file
 
 ```bash
 curl -s "http://localhost:8080/api/v1/buckets/$BUCKET_ID/files/FILE_ID/download" \
@@ -202,7 +227,7 @@ diff README.md downloaded-README.md
 
 No output means the files are identical — your upload and download worked.
 
-## 7. (Optional) Access via S3-compatible endpoint
+## 8. (Optional) Access via S3-compatible endpoint
 
 Every SFree bucket exposes an S3-compatible interface. Use the `access_key`
 and `access_secret` from step 4 with any S3-compatible client.

--- a/webui/e2e/files.spec.ts
+++ b/webui/e2e/files.spec.ts
@@ -127,6 +127,70 @@ test.describe("File listing and download", () => {
     await expect(fileRows.first().getByRole("button", { name: "Delete report.pdf" })).toBeVisible();
   });
 
+  test("bucket detail filters files by filename search", async ({ page }) => {
+    await injectAuth(page);
+    await mockGet(page, "/buckets", [MOCK_BUCKET]);
+    await mockGet(page, "/buckets/bkt-1", MOCK_BUCKET);
+
+    const requestedQueries: string[] = [];
+    await page.route("**/api/v1/buckets/bkt-1/files*", async (route) => {
+      if (route.request().method() !== "GET") {
+        await route.continue();
+        return;
+      }
+      const query = new URL(route.request().url()).searchParams.get("q") ?? "";
+      requestedQueries.push(query);
+      const body = query
+        ? MOCK_FILES.filter((file) =>
+            file.name.toLowerCase().includes(query.toLowerCase()),
+          )
+        : MOCK_FILES;
+      await route.fulfill({status: 200, json: body});
+    });
+
+    await page.goto("/buckets/bkt-1");
+    await expect(page.getByText("report.pdf")).toBeVisible();
+    await expect(page.getByText("data.csv")).toBeVisible();
+
+    await page.getByLabel("Search files").fill("report");
+
+    await expect.poll(() => requestedQueries.includes("report")).toBe(true);
+    await expect(page.getByText("report.pdf")).toBeVisible();
+    await expect(page.getByText("data.csv")).not.toBeVisible();
+    await expect(page.getByText("1 matching file")).toBeVisible();
+    await expect(
+      page.getByRole("button", {name: "Download report.pdf"}),
+    ).toBeVisible();
+  });
+
+  test("bucket detail shows a search-specific empty state", async ({ page }) => {
+    await injectAuth(page);
+    await mockGet(page, "/buckets", [MOCK_BUCKET]);
+    await mockGet(page, "/buckets/bkt-1", MOCK_BUCKET);
+
+    await page.route("**/api/v1/buckets/bkt-1/files*", async (route) => {
+      if (route.request().method() !== "GET") {
+        await route.continue();
+        return;
+      }
+      const query = new URL(route.request().url()).searchParams.get("q") ?? "";
+      const body = query === "missing" ? [] : MOCK_FILES;
+      await route.fulfill({status: 200, json: body});
+    });
+
+    await page.goto("/buckets/bkt-1");
+    await expect(page.getByText("report.pdf")).toBeVisible();
+
+    await page.getByLabel("Search files").fill("missing");
+
+    await expect(page.getByText("No matching files")).toBeVisible();
+    await expect(
+      page.getByText('No files in this bucket match "missing".'),
+    ).toBeVisible();
+    await expect(page.getByText("report.pdf")).not.toBeVisible();
+    await expect(page.getByRole("button", {name: "Upload File"})).toHaveCount(1);
+  });
+
   test("viewer file rows only expose download actions", async ({ page }) => {
     await injectAuth(page);
     await mockGet(page, "/buckets", [MOCK_VIEWER_BUCKET]);

--- a/webui/src/pages/bucket/ui/bucket-page.tsx
+++ b/webui/src/pages/bucket/ui/bucket-page.tsx
@@ -78,13 +78,12 @@ export function BucketPage() {
       }
       setError(err instanceof Error ? err.message : "Failed to load bucket");
     } finally {
-      if (requestID !== requestIDRef.current) {
-        return;
-      }
-      if (mode === "initial") {
-        setIsLoading(false);
-      } else {
-        setIsRefreshingFiles(false);
+      if (requestID === requestIDRef.current) {
+        if (mode === "initial") {
+          setIsLoading(false);
+        } else {
+          setIsRefreshingFiles(false);
+        }
       }
     }
   }, [activeSearchQuery, id]);

--- a/webui/src/pages/bucket/ui/bucket-page.tsx
+++ b/webui/src/pages/bucket/ui/bucket-page.tsx
@@ -1,10 +1,11 @@
 import {
   Button,
+  Input,
   Spinner,
   useDisclosure,
 } from "@heroui/react";
 import {addToast} from "@heroui/toast";
-import {useCallback, useEffect, useRef, useState} from "react";
+import {useCallback, useDeferredValue, useEffect, useRef, useState} from "react";
 import {useNavigate, useParams} from "react-router-dom";
 import {
   deleteFile,
@@ -29,8 +30,12 @@ export function BucketPage() {
   const [bucket, setBucket] = useState<Bucket | null>(null);
   const [files, setFiles] = useState<FileInfo[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+  const [isRefreshingFiles, setIsRefreshingFiles] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [searchQuery, setSearchQuery] = useState("");
   const fileInput = useRef<HTMLInputElement>(null);
+  const hasLoadedRef = useRef(false);
+  const requestIDRef = useRef(0);
   const confirm = useDisclosure();
   const [deleteId, setDeleteId] = useState<string | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
@@ -38,19 +43,34 @@ export function BucketPage() {
 
   const shareBucket = useDisclosure();
   const [shareFile, setShareFile] = useState<FileInfo | null>(null);
+  const deferredSearchQuery = useDeferredValue(searchQuery);
+  const activeSearchQuery = deferredSearchQuery.trim();
 
-  const load = useCallback(async () => {
+  const load = useCallback(async (mode: "initial" | "refresh" = "initial") => {
     if (!id) return;
-    setIsLoading(true);
+    const requestID = requestIDRef.current + 1;
+    requestIDRef.current = requestID;
+    if (mode === "initial") {
+      setIsLoading(true);
+    } else {
+      setIsRefreshingFiles(true);
+    }
     setError(null);
     try {
       const [loadedBucket, fs] = await Promise.all([
         getBucket(id),
-        listFiles(id),
+        listFiles(id, activeSearchQuery),
       ]);
+      if (requestID !== requestIDRef.current) {
+        return;
+      }
       setBucket(loadedBucket);
       setFiles(fs);
+      hasLoadedRef.current = true;
     } catch (err) {
+      if (requestID !== requestIDRef.current) {
+        return;
+      }
       if (err instanceof ApiError && err.status === 404) {
         setBucket(null);
         setFiles([]);
@@ -58,20 +78,33 @@ export function BucketPage() {
       }
       setError(err instanceof Error ? err.message : "Failed to load bucket");
     } finally {
-      setIsLoading(false);
+      if (requestID !== requestIDRef.current) {
+        return;
+      }
+      if (mode === "initial") {
+        setIsLoading(false);
+      } else {
+        setIsRefreshingFiles(false);
+      }
     }
+  }, [activeSearchQuery, id]);
+
+  useEffect(() => {
+    hasLoadedRef.current = false;
+    setSearchQuery("");
   }, [id]);
 
   useEffect(() => {
-    load();
-  }, [load]);
+    if (!id) return;
+    void load(hasLoadedRef.current ? "refresh" : "initial");
+  }, [id, load]);
 
   async function handleUpload(file: File) {
     if (!id || !bucket || !canWriteFiles(bucket)) return;
     try {
       await uploadFile(id, file);
       addToast({title: "File uploaded", description: `${file.name} added to bucket`, color: "success", timeout: 4000});
-      await load();
+      await load("refresh");
     } catch (err) {
       showErrorToast(err);
     }
@@ -95,7 +128,7 @@ export function BucketPage() {
     try {
       await deleteFile(id, deleteId);
       addToast({title: "File deleted", color: "success", timeout: 4000});
-      await load();
+      await load("refresh");
     } catch (err) {
       showErrorToast(err);
     } finally {
@@ -160,6 +193,12 @@ export function BucketPage() {
 
   const canManage = canManageBucket(bucket);
   const canWrite = canWriteFiles(bucket);
+  const emptyTitle = activeSearchQuery ? "No matching files" : "No files yet";
+  const emptyDescription = activeSearchQuery
+    ? `No files in this bucket match "${activeSearchQuery}".`
+    : canWrite
+      ? "Drag and drop a file here, or use the Upload button."
+      : "Files shared in this bucket will appear here.";
 
   return (
     <div className="p-8 flex flex-col gap-6">
@@ -204,16 +243,31 @@ export function BucketPage() {
         onDragOver={(e) => e.preventDefault()}
         onDrop={onDrop}
       >
+        <div className="mb-4 flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
+          <Input
+            aria-label="Search files"
+            className="w-full md:max-w-md"
+            isClearable
+            label="Search files"
+            placeholder="Filter by filename"
+            type="search"
+            value={searchQuery}
+            onClear={() => setSearchQuery("")}
+            onValueChange={setSearchQuery}
+            endContent={isRefreshingFiles ? <Spinner size="sm" /> : null}
+          />
+          {activeSearchQuery ? (
+            <p className="text-sm text-default-500">
+              {files.length === 1 ? "1 matching file" : `${files.length} matching files`}
+            </p>
+          ) : null}
+        </div>
         {files.length === 0 ? (
           <EmptyState
-            title="No files yet"
-            description={
-              canWrite
-                ? "Drag and drop a file here, or use the Upload button."
-                : "Files shared in this bucket will appear here."
-            }
-            ctaLabel={canWrite ? "Upload File" : undefined}
-            onCtaPress={canWrite ? () => fileInput.current?.click() : undefined}
+            title={emptyTitle}
+            description={emptyDescription}
+            ctaLabel={!activeSearchQuery && canWrite ? "Upload File" : undefined}
+            onCtaPress={!activeSearchQuery && canWrite ? () => fileInput.current?.click() : undefined}
           />
         ) : (
           <table className="w-full text-left">

--- a/webui/src/pages/sources/ui/sources-page.tsx
+++ b/webui/src/pages/sources/ui/sources-page.tsx
@@ -1,7 +1,7 @@
 import {Button, Card, CardBody, CardHeader, Chip, Spinner, Tooltip, useDisclosure} from "@heroui/react";
 import {addToast} from "@heroui/toast";
 import {useNavigate} from "react-router-dom";
-import {useEffect, useState} from "react";
+import {useCallback, useEffect, useState} from "react";
 import {CreateSourceDialog} from "../../../features/source";
 import {deleteSource, getSourceHealth, listSources} from "../../../shared/api/sources";
 import type {Source, SourceHealth, SourceHealthStatus} from "../../../shared/api/sources";
@@ -88,7 +88,7 @@ export function SourcesPage() {
     });
   }
 
-  async function load() {
+  const load = useCallback(async () => {
     setIsLoading(true);
     setError(null);
     try {
@@ -100,11 +100,11 @@ export function SourcesPage() {
     } finally {
       setIsLoading(false);
     }
-  }
+  }, []);
 
   useEffect(() => {
-    load();
-  }, []);
+    void load();
+  }, [load]);
 
   function renderHealth(source: Source) {
     const health = healthBySource[source.id];

--- a/webui/src/shared/api/buckets.ts
+++ b/webui/src/shared/api/buckets.ts
@@ -41,9 +41,24 @@ export async function createBucket(
   });
 }
 
-export async function listFiles(bucketId: string): Promise<FileInfo[]> {
+function bucketFilesPath(bucketId: string, query?: string): string {
+  const params = new URLSearchParams();
+  const trimmedQuery = query?.trim();
+  if (trimmedQuery) {
+    params.set("q", trimmedQuery);
+  }
+  const encodedQuery = params.toString();
+  return encodedQuery
+    ? `/buckets/${bucketId}/files?${encodedQuery}`
+    : `/buckets/${bucketId}/files`;
+}
+
+export async function listFiles(
+  bucketId: string,
+  query?: string,
+): Promise<FileInfo[]> {
   return apiJson<FileInfo[]>(
-    `/buckets/${bucketId}/files`,
+    bucketFilesPath(bucketId, query),
     "Failed to list files",
   );
 }


### PR DESCRIPTION
## Summary
- expose the existing bucket file `q` search from the web bucket page
- keep upload, share, preview, download, and delete actions intact while search is active
- add focused Playwright coverage for filename filtering and search-specific empty states
- document REST bucket file search in the quickstart

## Why
Public issue #162 was only partially real after PR #233: the backend supported filename search, but the product still had no end-to-end discovery control in the bucket UI. This PR ships the bounded, honest slice instead of inventing unsupported type/size/date filter semantics.

## User impact
Users can now search bucket files by filename directly in the web UI. The search uses the existing case-insensitive backend query behavior and returns a clear empty state when nothing matches.

## Validation
- `git diff --check`
- `npm exec eslint src/shared/api/buckets.ts src/pages/bucket/ui/bucket-page.tsx e2e/files.spec.ts` *(blocked in this worktree because web dev dependencies are not installed locally; defer full lint/build/Playwright validation to Woodpecker as required by repo policy)*

Links: THE-839, public issue #162.