### PR TITLE
THE-841 Ship honest quota and capacity signals

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ disappears. See [Launch Caveats](#launch-caveats) for the full picture.
 
 | Backend | API | Browser UI | Notes |
 | --- | --- | --- | --- |
-| Google Drive | Yes | Yes | Richest quota and file metadata reporting |
-| Telegram | Yes | Yes | Uses bot API for chunk storage |
-| S3-compatible | Yes | Yes | Works with MinIO, Backblaze B2, Wasabi, etc. |
+| Google Drive | Yes | Yes | Native quota and file metadata reporting |
+| Telegram | Yes | Yes | Uses bot API for chunk storage; no native quota meter |
+| S3-compatible | Yes | Yes | Works with MinIO, Backblaze B2, Wasabi, etc.; health is supported but provider-wide quota is not inferred |
 
 ## Architecture
 
@@ -257,7 +257,8 @@ SFree is an early-stage project. These constraints are current and intentional:
 - **Authentication is still early.** The API supports HTTP Basic Auth and OAuth,
   but auth flows and browser token storage are not production-hardened.
 - **Uneven observability.** Google Drive sources expose the richest file and
-  quota info. Telegram and S3-compatible sources return less metadata.
+  quota info. Telegram and S3-compatible sources can still show health and
+  stored bytes, but SFree does not fake provider-wide capacity for them.
 
 ## Contributing
 

--- a/api-go/internal/docs/docs.go
+++ b/api-go/internal/docs/docs.go
@@ -1828,7 +1828,7 @@ const docTemplate = `{
                         "BasicAuth": []
                     }
                 ],
-                "description": "Runs a lightweight on-demand provider probe. Google Drive returns native quota when available; S3-compatible and Telegram quota fields are null because no cheap native capacity is available.",
+                "description": "Runs a lightweight on-demand provider probe. Google Drive returns native quota when available; S3-compatible and Telegram quota fields stay null because SFree does not invent provider-wide capacity where no cheap native signal exists.",
                 "tags": [
                     "sources"
                 ],
@@ -1883,6 +1883,7 @@ const docTemplate = `{
                         "BasicAuth": []
                     }
                 ],
+                "description": "Returns provider file inventory plus provider-reported storage usage fields when cheaply available. These storage totals are not a universal quota contract; use the health endpoint for honest quota/capacity signals.",
                 "tags": [
                     "sources"
                 ],

--- a/api-go/internal/handlers/source.go
+++ b/api-go/internal/handlers/source.go
@@ -359,6 +359,7 @@ func DeleteSource(repo *repository.SourceRepository, bucketRepo *repository.Buck
 
 // GetSourceInfo godoc
 // @Summary Get source info
+// @Description Returns provider file inventory plus provider-reported storage usage fields when cheaply available. These storage totals are not a universal quota contract; use the health endpoint for honest quota/capacity signals.
 // @Tags sources
 // @Param id path string true "Source ID"
 // @Success 200 {object} sourceInfoResponse
@@ -411,7 +412,7 @@ func getSourceInfo(repo *repository.SourceRepository, factory manager.SourceClie
 
 // GetSourceHealth godoc
 // @Summary Check source health
-// @Description Runs a lightweight on-demand provider probe. Google Drive returns native quota when available; S3-compatible and Telegram quota fields are null because no cheap native capacity is available.
+// @Description Runs a lightweight on-demand provider probe. Google Drive returns native quota when available; S3-compatible and Telegram quota fields stay null because SFree does not invent provider-wide capacity where no cheap native signal exists.
 // @Tags sources
 // @Param id path string true "Source ID"
 // @Success 200 {object} sourceHealthResponse

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -56,9 +56,9 @@ At a high level:
 
 | Source type | Backend support | Browser UI creation | Notes |
 | --- | --- | --- | --- |
-| Google Drive | Yes | Yes | Richest source info and quota reporting. |
-| Telegram | Yes | Yes | Uses bot API for chunk storage. |
-| S3-compatible | Yes | Yes | Works with MinIO, Backblaze B2, Wasabi, etc. |
+| Google Drive | Yes | Yes | Richest source info and native quota reporting. |
+| Telegram | Yes | Yes | Uses bot API for chunk storage; quota remains unavailable. |
+| S3-compatible | Yes | Yes | Works with MinIO, Backblaze B2, Wasabi, etc.; health is supported without inventing provider-wide quota. |
 
 ## Data Model And Storage Behavior
 
@@ -83,7 +83,7 @@ copy:
   and source create/list responses echo stored credential payloads.
 - Do not imply identical observability across source types. Google Drive,
   Telegram, and S3-compatible sources return different levels of file/quota
-  detail.
+  detail, and only provider-native quota should be rendered as capacity.
 - Do not describe rate limiting as complete abuse protection. The API has
   in-memory request limits, but they are not a distributed production
   throttling layer.

--- a/webui/e2e/dashboard.spec.ts
+++ b/webui/e2e/dashboard.spec.ts
@@ -11,21 +11,64 @@
 import { test, expect } from "@playwright/test";
 import { injectAuth, mockGet, API_GLOB } from "./helpers";
 
-const MOCK_SOURCE = {
+const MOCK_GDRIVE_SOURCE = {
   id: "src-1",
   name: "My Drive",
   type: "gdrive",
   created_at: "2024-01-15T10:00:00Z",
 };
 
-const MOCK_SOURCE_INFO = {
+const MOCK_GDRIVE_INFO = {
   id: "src-1",
   name: "My Drive",
   type: "gdrive",
   files: [{id: "file-1", name: "hello.txt", size: 12}],
-  storage_total: 1024,
-  storage_used: 12,
-  storage_free: 1012,
+  storage_total: 1024 * 1024,
+  storage_used: 512 * 1024,
+  storage_free: 512 * 1024,
+};
+
+const MOCK_GDRIVE_HEALTH = {
+  id: "src-1",
+  type: "gdrive",
+  status: "healthy",
+  checked_at: "2024-01-15T10:10:00Z",
+  latency_ms: 25,
+  reason_code: "ok",
+  message: "Google Drive metadata is reachable.",
+  quota_total_bytes: 1024 * 1024,
+  quota_used_bytes: 512 * 1024,
+  quota_free_bytes: 512 * 1024,
+};
+
+const MOCK_S3_SOURCE = {
+  id: "src-2",
+  name: "Archive Bucket",
+  type: "s3",
+  created_at: "2024-01-15T10:30:00Z",
+};
+
+const MOCK_S3_INFO = {
+  id: "src-2",
+  name: "Archive Bucket",
+  type: "s3",
+  files: [{id: "obj-1", name: "backup.tar", size: 256}],
+  storage_total: 0,
+  storage_used: 256,
+  storage_free: 0,
+};
+
+const MOCK_S3_HEALTH = {
+  id: "src-2",
+  type: "s3",
+  status: "healthy",
+  checked_at: "2024-01-15T10:35:00Z",
+  latency_ms: 11,
+  reason_code: "ok",
+  message: "S3 bucket metadata is reachable.",
+  quota_total_bytes: null,
+  quota_used_bytes: null,
+  quota_free_bytes: null,
 };
 
 const MOCK_BUCKET = {
@@ -63,14 +106,17 @@ test.describe("Dashboard", () => {
       summaryCards.getByText("Files", { exact: true }),
     ).toBeVisible();
     await expect(
-      summaryCards.getByText("Storage Used", { exact: true }),
+      summaryCards.getByText("Sources Reporting Quota", { exact: true }),
     ).toBeVisible();
   });
 
-  test("returning user dashboard hides onboarding and shows sources section", async ({ page }) => {
+  test("returning user dashboard hides onboarding and shows honest quota states", async ({ page }) => {
     await injectAuth(page);
-    await mockGet(page, "/sources", [MOCK_SOURCE]);
-    await mockGet(page, "/sources/src-1/info", MOCK_SOURCE_INFO);
+    await mockGet(page, "/sources", [MOCK_GDRIVE_SOURCE, MOCK_S3_SOURCE]);
+    await mockGet(page, "/sources/src-1/info", MOCK_GDRIVE_INFO);
+    await mockGet(page, "/sources/src-1/health", MOCK_GDRIVE_HEALTH);
+    await mockGet(page, "/sources/src-2/info", MOCK_S3_INFO);
+    await mockGet(page, "/sources/src-2/health", MOCK_S3_HEALTH);
     await mockGet(page, "/buckets", [MOCK_BUCKET]);
     await page.goto("/dashboard");
 
@@ -85,6 +131,18 @@ test.describe("Dashboard", () => {
     ).toBeVisible();
     await expect(
       page.getByText("My Drive", { exact: true }),
+    ).toBeVisible();
+    await expect(
+      page.getByText("Archive Bucket", { exact: true }),
+    ).toBeVisible();
+    await expect(
+      page.getByText("Sources Reporting Quota", { exact: true }),
+    ).toBeVisible();
+    await expect(
+      page.getByText("1/2", { exact: true }),
+    ).toBeVisible();
+    await expect(
+      page.getByText("Quota unavailable", { exact: true }),
     ).toBeVisible();
   });
 

--- a/webui/e2e/source-detail.spec.ts
+++ b/webui/e2e/source-detail.spec.ts
@@ -75,7 +75,10 @@ test.describe("Source detail", () => {
     await expect(page.getByRole("heading", {name: "Archive Bucket"})).toBeVisible();
     await expect(capacitySignalCard.getByText("Quota unavailable", {exact: true})).toBeVisible();
     await expect(
-      page.getByText("S3-compatible sources are checked for reachability here, not provider-wide capacity limits."),
+      capacitySignalCard.getByText(
+        "S3-compatible sources are checked for reachability here, not provider-wide capacity limits.",
+        {exact: true},
+      ),
     ).toBeVisible();
   });
 });

--- a/webui/e2e/source-detail.spec.ts
+++ b/webui/e2e/source-detail.spec.ts
@@ -1,0 +1,77 @@
+import {expect, test} from "@playwright/test";
+import {injectAuth, mockGet} from "./helpers";
+
+const GDRIVE_INFO = {
+  id: "src-1",
+  name: "My Drive",
+  type: "gdrive",
+  files: [{id: "file-1", name: "hello.txt", size: 12}],
+  storage_total: 1024 * 1024,
+  storage_used: 512 * 1024,
+  storage_free: 512 * 1024,
+};
+
+const GDRIVE_HEALTH = {
+  id: "src-1",
+  type: "gdrive",
+  status: "degraded",
+  checked_at: "2024-01-15T10:10:00Z",
+  latency_ms: 25,
+  reason_code: "quota_low",
+  message: "Google Drive quota is nearly exhausted.",
+  quota_total_bytes: 1024 * 1024,
+  quota_used_bytes: 980 * 1024,
+  quota_free_bytes: 44 * 1024,
+};
+
+const S3_INFO = {
+  id: "src-2",
+  name: "Archive Bucket",
+  type: "s3",
+  files: [{id: "obj-1", name: "backup.tar", size: 256}],
+  storage_total: 0,
+  storage_used: 256,
+  storage_free: 0,
+};
+
+const S3_HEALTH = {
+  id: "src-2",
+  type: "s3",
+  status: "healthy",
+  checked_at: "2024-01-15T10:35:00Z",
+  latency_ms: 11,
+  reason_code: "ok",
+  message: "S3 bucket metadata is reachable.",
+  quota_total_bytes: null,
+  quota_used_bytes: null,
+  quota_free_bytes: null,
+};
+
+test.describe("Source detail", () => {
+  test("shows provider-native quota when available", async ({page}) => {
+    await injectAuth(page);
+    await mockGet(page, "/sources/src-1/info", GDRIVE_INFO);
+    await mockGet(page, "/sources/src-1/health", GDRIVE_HEALTH);
+
+    await page.goto("/sources/src-1");
+
+    await expect(page.getByRole("heading", {name: "My Drive"})).toBeVisible();
+    await expect(page.getByText("Native quota", {exact: true})).toBeVisible();
+    await expect(page.getByText("Stored In Source", {exact: true})).toBeVisible();
+    await expect(page.getByText("Google Drive quota is nearly exhausted.")).toBeVisible();
+  });
+
+  test("shows explicit unavailable state when quota is unsupported", async ({page}) => {
+    await injectAuth(page);
+    await mockGet(page, "/sources/src-2/info", S3_INFO);
+    await mockGet(page, "/sources/src-2/health", S3_HEALTH);
+
+    await page.goto("/sources/src-2");
+
+    await expect(page.getByRole("heading", {name: "Archive Bucket"})).toBeVisible();
+    await expect(page.getByText("Quota unavailable", {exact: true})).toBeVisible();
+    await expect(
+      page.getByText("S3-compatible sources are checked for reachability here, not provider-wide capacity limits."),
+    ).toBeVisible();
+  });
+});

--- a/webui/e2e/source-detail.spec.ts
+++ b/webui/e2e/source-detail.spec.ts
@@ -68,8 +68,12 @@ test.describe("Source detail", () => {
 
     await page.goto("/sources/src-2");
 
+    const capacitySignalCard = page
+      .locator("div.rounded-lg.border.border-default-200")
+      .filter({has: page.getByText("Capacity Signal", {exact: true})});
+
     await expect(page.getByRole("heading", {name: "Archive Bucket"})).toBeVisible();
-    await expect(page.getByText("Quota unavailable", {exact: true})).toBeVisible();
+    await expect(capacitySignalCard.getByText("Quota unavailable", {exact: true})).toBeVisible();
     await expect(
       page.getByText("S3-compatible sources are checked for reachability here, not provider-wide capacity limits."),
     ).toBeVisible();

--- a/webui/src/entities/source/lib/capacity.ts
+++ b/webui/src/entities/source/lib/capacity.ts
@@ -33,6 +33,7 @@ export function getSourceQuotaState(
     health.quota_free_bytes !== null &&
     health.quota_total_bytes > 0
   ) {
+    const freeBytes = Math.max(0, health.quota_free_bytes);
     const percent = Math.max(
       0,
       Math.min(100, (health.quota_used_bytes / health.quota_total_bytes) * 100),
@@ -41,7 +42,7 @@ export function getSourceQuotaState(
       kind: "available",
       totalBytes: health.quota_total_bytes,
       usedBytes: health.quota_used_bytes,
-      freeBytes: health.quota_free_bytes,
+      freeBytes,
       percent,
     };
   }

--- a/webui/src/entities/source/lib/capacity.ts
+++ b/webui/src/entities/source/lib/capacity.ts
@@ -1,0 +1,77 @@
+import type {SourceHealth, SourceHealthStatus} from "../../../shared/api/sources";
+
+export const sourceHealthColor: Record<
+  SourceHealthStatus,
+  "success" | "warning" | "danger"
+> = {
+  healthy: "success",
+  degraded: "warning",
+  unhealthy: "danger",
+};
+
+export type SourceQuotaState =
+  | {
+      kind: "available";
+      totalBytes: number;
+      usedBytes: number;
+      freeBytes: number;
+      percent: number;
+    }
+  | {
+      kind: "unavailable";
+      label: string;
+      description: string;
+    };
+
+export function getSourceQuotaState(
+  health: SourceHealth | null | undefined,
+): SourceQuotaState {
+  if (
+    health &&
+    health.quota_total_bytes !== null &&
+    health.quota_used_bytes !== null &&
+    health.quota_free_bytes !== null &&
+    health.quota_total_bytes > 0
+  ) {
+    const percent = Math.max(
+      0,
+      Math.min(100, (health.quota_used_bytes / health.quota_total_bytes) * 100),
+    );
+    return {
+      kind: "available",
+      totalBytes: health.quota_total_bytes,
+      usedBytes: health.quota_used_bytes,
+      freeBytes: health.quota_free_bytes,
+      percent,
+    };
+  }
+
+  if (!health) {
+    return {
+      kind: "unavailable",
+      label: "Health unavailable",
+      description: "SFree could not load a trustworthy capacity signal for this source.",
+    };
+  }
+
+  switch (health.type) {
+    case "telegram":
+      return {
+        kind: "unavailable",
+        label: "Quota unavailable",
+        description: "Telegram sources do not expose native quota metadata to SFree.",
+      };
+    case "s3":
+      return {
+        kind: "unavailable",
+        label: "Quota unavailable",
+        description: "S3-compatible sources are checked for reachability here, not provider-wide capacity limits.",
+      };
+    default:
+      return {
+        kind: "unavailable",
+        label: "Quota unavailable",
+        description: health.message || "This source did not return a trustworthy quota signal.",
+      };
+  }
+}

--- a/webui/src/pages/dashboard/ui/dashboard-page.tsx
+++ b/webui/src/pages/dashboard/ui/dashboard-page.tsx
@@ -1,35 +1,32 @@
-import {Card, CardBody, CardHeader, CircularProgress, useDisclosure} from "@heroui/react";
-import {useEffect, useRef, useState} from "react";
+import {Card, CardBody, CardHeader, Chip, CircularProgress, useDisclosure} from "@heroui/react";
+import {useCallback, useEffect, useRef, useState} from "react";
 import {useNavigate} from "react-router-dom";
-import {listSources, getSourceInfo} from "../../../shared/api/sources";
+import {listSources, getSourceHealth, getSourceInfo} from "../../../shared/api/sources";
 import {listBuckets} from "../../../shared/api/buckets";
 import {SourceTypeChip} from "../../../entities/source";
+import {getSourceQuotaState, sourceHealthColor} from "../../../entities/source/lib/capacity";
 import {OnboardingHero} from "../../../features/onboarding";
 import {CreateSourceDialog} from "../../../features/source";
 import {CreateBucketDialog} from "../../../features/bucket";
-import type {Source, SourceInfo} from "../../../shared/api/sources";
+import type {Source, SourceHealth, SourceInfo} from "../../../shared/api/sources";
 import type {Bucket} from "../../../shared/api/buckets";
+import {formatSize} from "../../../shared/lib/format";
 
-function formatBytes(bytes: number): string {
-  if (bytes === 0) return "0 B";
-  const units = ["B", "KB", "MB", "GB", "TB"];
-  const i = Math.floor(Math.log(bytes) / Math.log(1024));
-  const value = bytes / Math.pow(1024, i);
-  return `${value.toFixed(i === 0 ? 0 : 1)} ${units[i]}`;
-}
-
-type SourceWithInfo = Source & {info: SourceInfo | null};
+type SourceWithDetails = Source & {
+  info: SourceInfo | null;
+  health: SourceHealth | null;
+};
 
 export function DashboardPage() {
   const navigate = useNavigate();
-  const [sources, setSources] = useState<SourceWithInfo[]>([]);
+  const [sources, setSources] = useState<SourceWithDetails[]>([]);
   const [buckets, setBuckets] = useState<Bucket[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const createSource = useDisclosure();
   const createBucket = useDisclosure();
   const hasLoadedOnce = useRef(false);
 
-  async function load() {
+  const load = useCallback(async () => {
     if (!hasLoadedOnce.current) setIsLoading(true);
     try {
       const [srcList, bucketList] = await Promise.all([
@@ -38,37 +35,42 @@ export function DashboardPage() {
       ]);
       setBuckets(bucketList);
 
-      const withInfo = await Promise.all(
+      const withDetails = await Promise.all(
         srcList.map(async (s) => {
-          try {
-            const info = await getSourceInfo(s.id);
-            return {...s, info};
-          } catch {
-            return {...s, info: null};
-          }
+          const [infoResult, healthResult] = await Promise.allSettled([
+            getSourceInfo(s.id),
+            getSourceHealth(s.id),
+          ]);
+          return {
+            ...s,
+            info: infoResult.status === "fulfilled" ? infoResult.value : null,
+            health: healthResult.status === "fulfilled" ? healthResult.value : null,
+          };
         }),
       );
-      setSources(withInfo);
+      setSources(withDetails);
     } catch {
       // keep empty state
     } finally {
       setIsLoading(false);
       hasLoadedOnce.current = true;
     }
-  }
+  }, []);
 
   useEffect(() => {
-    load();
-  }, []);
+    void load();
+  }, [load]);
 
   const totalFiles = sources.reduce(
     (sum, s) => sum + (s.info?.files.length ?? 0),
     0,
   );
-  const totalStorageUsed = sources.reduce(
-    (sum, s) => sum + (s.info?.storage_used ?? 0),
-    0,
-  );
+  const quotaReportingSources = sources.filter(
+    (s) => getSourceQuotaState(s.health).kind === "available",
+  ).length;
+  const sourcesNeedingAttention = sources.filter(
+    (s) => s.health && s.health.status !== "healthy",
+  ).length;
 
   const hasSources = sources.length > 0;
   const hasBuckets = buckets.length > 0;
@@ -121,8 +123,15 @@ export function DashboardPage() {
         </Card>
         <Card>
           <CardBody className="text-center py-6">
-            <p className="text-4xl font-bold">{formatBytes(totalStorageUsed)}</p>
-            <p className="text-sm text-default-500 mt-1">Storage Used</p>
+            <p className="text-4xl font-bold">
+              {sources.length === 0 ? "0" : `${quotaReportingSources}/${sources.length}`}
+            </p>
+            <p className="text-sm text-default-500 mt-1">Sources Reporting Quota</p>
+            <p className="text-xs text-default-400 mt-2">
+              {sourcesNeedingAttention === 0
+                ? "No active provider warnings"
+                : `${sourcesNeedingAttention} source${sourcesNeedingAttention === 1 ? "" : "s"} need attention`}
+            </p>
           </CardBody>
         </Card>
       </div>
@@ -134,12 +143,8 @@ export function DashboardPage() {
           <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
             {sources.map((s) => {
               const fileCount = s.info?.files.length ?? 0;
-              const percent =
-                s.info && s.info.storage_total
-                  ? (s.info.storage_used / s.info.storage_total) * 100
-                  : 0;
               const used = s.info?.storage_used ?? 0;
-              const total = s.info?.storage_total ?? 0;
+              const quota = getSourceQuotaState(s.health);
 
               return (
                 <Card
@@ -147,34 +152,67 @@ export function DashboardPage() {
                   isPressable
                   onPress={() => navigate(`/sources/${s.id}`)}
                 >
-                  <CardHeader className="flex justify-between items-center">
+                  <CardHeader className="flex justify-between items-start gap-3">
                     <div className="flex flex-col gap-1">
                       <span className="font-bold">{s.name}</span>
                       <SourceTypeChip type={s.type} />
                     </div>
-                    {total > 0 && (
-                      <CircularProgress
-                        classNames={{
-                          svg: "w-16 h-16",
-                          indicator: "stroke-primary",
-                          track: "stroke-default-200",
-                          value: "text-xs font-semibold",
-                        }}
-                        showValueLabel
-                        strokeWidth={4}
-                        value={percent}
-                      />
+                    {s.health ? (
+                      <Chip
+                        size="sm"
+                        variant="flat"
+                        color={sourceHealthColor[s.health.status]}
+                      >
+                        {s.health.status}
+                      </Chip>
+                    ) : (
+                      <Chip size="sm" variant="flat" color="default">
+                        health unavailable
+                      </Chip>
                     )}
                   </CardHeader>
-                  <CardBody className="pt-0">
+                  <CardBody className="pt-0 flex flex-col gap-3">
                     <div className="flex justify-between text-sm text-default-500">
                       <span>{fileCount} {fileCount === 1 ? "file" : "files"}</span>
-                      {total > 0 && (
-                        <span>
-                          {formatBytes(used)} / {formatBytes(total)}
-                        </span>
-                      )}
+                      <span>{formatSize(used)} stored</span>
                     </div>
+                    {quota.kind === "available" ? (
+                      <div className="flex items-center gap-4">
+                        <CircularProgress
+                          classNames={{
+                            svg: "w-14 h-14",
+                            indicator:
+                              s.health?.status === "healthy"
+                                ? "stroke-success"
+                                : s.health?.status === "degraded"
+                                  ? "stroke-warning"
+                                  : "stroke-danger",
+                            track: "stroke-default-200",
+                            value: "text-xs font-semibold",
+                          }}
+                          showValueLabel
+                          strokeWidth={4}
+                          value={quota.percent}
+                        />
+                        <div className="flex flex-col">
+                          <span className="text-sm font-medium">Quota</span>
+                          <span className="text-sm text-default-500">
+                            {formatSize(quota.usedBytes)} / {formatSize(quota.totalBytes)}
+                          </span>
+                          <span className="text-xs text-default-400">
+                            {formatSize(quota.freeBytes)} free
+                          </span>
+                        </div>
+                      </div>
+                    ) : (
+                      <div className="rounded-lg border border-default-200 bg-default-50 px-3 py-2">
+                        <p className="text-sm font-medium">{quota.label}</p>
+                        <p className="text-xs text-default-500">{quota.description}</p>
+                      </div>
+                    )}
+                    {s.health && s.health.status !== "healthy" && (
+                      <p className="text-xs text-default-500">{s.health.message}</p>
+                    )}
                   </CardBody>
                 </Card>
               );

--- a/webui/src/pages/source/ui/source-page.tsx
+++ b/webui/src/pages/source/ui/source-page.tsx
@@ -1,32 +1,47 @@
-import {Button, CircularProgress, Spinner} from "@heroui/react";
+import {Button, Card, CardBody, Chip, CircularProgress, Spinner} from "@heroui/react";
 import {useCallback, useEffect, useState} from "react";
 import {Link, useNavigate, useParams} from "react-router-dom";
-import {downloadFile, getSourceInfo} from "../../../shared/api/sources";
-import type {SourceFile, SourceInfo} from "../../../shared/api/sources";
+import {downloadFile, getSourceHealth, getSourceInfo} from "../../../shared/api/sources";
+import type {SourceFile, SourceHealth, SourceInfo} from "../../../shared/api/sources";
 import {showErrorToast} from "../../../shared/api/error";
 import {SourceTypeChip} from "../../../entities/source";
+import {getSourceQuotaState, sourceHealthColor} from "../../../entities/source/lib/capacity";
 import {DownloadIcon} from "../../../shared/icons";
 import {EmptyState} from "../../../shared/ui";
+import {formatSize} from "../../../shared/lib/format";
 
 export function SourcePage() {
   const {id} = useParams<{id: string}>();
   const navigate = useNavigate();
   const [info, setInfo] = useState<SourceInfo | null>(null);
+  const [health, setHealth] = useState<SourceHealth | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  const load = useCallback(() => {
+  const load = useCallback(async () => {
     if (!id) return;
     setIsLoading(true);
     setError(null);
-    getSourceInfo(id)
-      .then(setInfo)
-      .catch((err) => setError(err instanceof Error ? err.message : "Failed to load source"))
-      .finally(() => setIsLoading(false));
+    const [infoResult, healthResult] = await Promise.allSettled([
+      getSourceInfo(id),
+      getSourceHealth(id),
+    ]);
+
+    if (infoResult.status === "rejected") {
+      setInfo(null);
+      setHealth(null);
+      setError(infoResult.reason instanceof Error ? infoResult.reason.message : "Failed to load source");
+      setIsLoading(false);
+      return;
+    }
+
+    setInfo(infoResult.value);
+    setHealth(healthResult.status === "fulfilled" ? healthResult.value : null);
+    setIsLoading(false);
   }, [id]);
 
   useEffect(() => {
-    load();
+    void load();
   }, [load]);
 
   async function handleDownload(file: SourceFile) {
@@ -79,29 +94,98 @@ export function SourcePage() {
     );
   }
 
-  const percent = info.storage_total
-    ? (info.storage_used / info.storage_total) * 100
-    : 0;
+  const quota = getSourceQuotaState(health);
+  const fileCount = info.files.length;
 
   return (
     <div className="p-6 sm:p-8 flex flex-col gap-6">
       <Link to="/sources" className="text-sm text-default-500 hover:text-primary transition-colors">
         &larr; Sources
       </Link>
-      <h1 className="text-3xl font-bold">{info.name}</h1>
-      <SourceTypeChip type={info.type} />
-      <div className="flex justify-center">
-        <CircularProgress
-          classNames={{
-            svg: "w-36 h-36 drop-shadow-md",
-            indicator: "stroke-white",
-            track: "stroke-white/10",
-            value: "text-3xl font-semibold text-white",
-          }}
-          showValueLabel
-          strokeWidth={4}
-          value={percent}
-        />
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex flex-col gap-2">
+          <h1 className="text-3xl font-bold">{info.name}</h1>
+          <SourceTypeChip type={info.type} />
+        </div>
+        {health ? (
+          <Chip size="sm" variant="flat" color={sourceHealthColor[health.status]}>
+            {health.status}
+          </Chip>
+        ) : (
+          <Chip size="sm" variant="flat" color="default">
+            health unavailable
+          </Chip>
+        )}
+      </div>
+      <div className="grid gap-4 lg:grid-cols-[220px,minmax(0,1fr)]">
+        <Card>
+          <CardBody className="items-center justify-center gap-4 py-6 text-center">
+            {quota.kind === "available" ? (
+              <>
+                <CircularProgress
+                  classNames={{
+                    svg: "w-36 h-36",
+                    indicator:
+                      health?.status === "healthy"
+                        ? "stroke-success"
+                        : health?.status === "degraded"
+                          ? "stroke-warning"
+                          : "stroke-danger",
+                    track: "stroke-default-200",
+                    value: "text-3xl font-semibold",
+                  }}
+                  showValueLabel
+                  strokeWidth={4}
+                  value={quota.percent}
+                />
+                <div className="flex flex-col gap-1">
+                  <p className="text-sm font-medium">Native quota</p>
+                  <p className="text-sm text-default-500">
+                    {formatSize(quota.usedBytes)} of {formatSize(quota.totalBytes)}
+                  </p>
+                  <p className="text-xs text-default-400">
+                    {formatSize(quota.freeBytes)} free
+                  </p>
+                </div>
+              </>
+            ) : (
+              <div className="flex h-full flex-col items-center justify-center gap-2">
+                <p className="text-sm font-medium">{quota.label}</p>
+                <p className="text-sm text-default-500">{quota.description}</p>
+              </div>
+            )}
+          </CardBody>
+        </Card>
+        <Card>
+          <CardBody className="gap-4 py-6">
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div className="rounded-lg border border-default-200 px-4 py-3">
+                <p className="text-xs uppercase tracking-wide text-default-400">Stored In Source</p>
+                <p className="mt-2 text-2xl font-semibold">{formatSize(info.storage_used)}</p>
+                <p className="mt-1 text-sm text-default-500">
+                  {fileCount} listed file{fileCount === 1 ? "" : "s"}
+                </p>
+              </div>
+              <div className="rounded-lg border border-default-200 px-4 py-3">
+                <p className="text-xs uppercase tracking-wide text-default-400">Capacity Signal</p>
+                <p className="mt-2 text-base font-semibold">
+                  {quota.kind === "available" ? "Provider quota available" : quota.label}
+                </p>
+                <p className="mt-1 text-sm text-default-500">
+                  {quota.kind === "available"
+                    ? "This meter comes from native provider quota metadata."
+                    : quota.description}
+                </p>
+              </div>
+            </div>
+            {health && (
+              <div className="rounded-lg border border-default-200 bg-default-50 px-4 py-3">
+                <p className="text-xs uppercase tracking-wide text-default-400">Health Probe</p>
+                <p className="mt-2 text-sm text-default-700">{health.message}</p>
+              </div>
+            )}
+          </CardBody>
+        </Card>
       </div>
       <div className="border-2 border-dashed rounded p-4">
         {info.files.length === 0 ? (
@@ -122,7 +206,7 @@ export function SourcePage() {
               {info.files.map((f) => (
                 <tr key={f.id} className="border-t">
                   <td className="py-2">{f.name}</td>
-                  <td className="py-2">{f.size}</td>
+                  <td className="py-2">{formatSize(f.size)}</td>
                   <td className="py-2">
                     <Button
                       isIconOnly

--- a/webui/src/pages/sources/ui/sources-page.tsx
+++ b/webui/src/pages/sources/ui/sources-page.tsx
@@ -4,8 +4,9 @@ import {useNavigate} from "react-router-dom";
 import {useCallback, useEffect, useState} from "react";
 import {CreateSourceDialog} from "../../../features/source";
 import {deleteSource, getSourceHealth, listSources} from "../../../shared/api/sources";
-import type {Source, SourceHealth, SourceHealthStatus} from "../../../shared/api/sources";
+import type {Source, SourceHealth} from "../../../shared/api/sources";
 import {SourceTypeChip} from "../../../entities/source";
+import {sourceHealthColor} from "../../../entities/source/lib/capacity";
 import {DeleteIcon} from "@heroui/shared-icons";
 import {ConfirmDialog, EmptyState} from "../../../shared/ui";
 import {showErrorToast} from "../../../shared/api/error";
@@ -14,12 +15,6 @@ type HealthState =
   | {state: "checking"}
   | {state: "ready"; health: SourceHealth}
   | {state: "error"; message: string};
-
-const healthColor: Record<SourceHealthStatus, "success" | "warning" | "danger"> = {
-  healthy: "success",
-  degraded: "warning",
-  unhealthy: "danger",
-};
 
 function RefreshIcon(props: {className?: string}) {
   return (
@@ -120,7 +115,7 @@ export function SourcesPage() {
     }
     return (
       <Tooltip content={health.health.message}>
-        <Chip size="sm" variant="flat" color={healthColor[health.health.status]}>
+        <Chip size="sm" variant="flat" color={sourceHealthColor[health.health.status]}>
           {health.health.status}
         </Chip>
       </Tooltip>

--- a/webui/src/shared/lib/format.ts
+++ b/webui/src/shared/lib/format.ts
@@ -1,6 +1,6 @@
 export function formatSize(bytes: number): string {
   if (bytes === 0) return "0 B";
-  const units = ["B", "KB", "MB", "GB"];
+  const units = ["B", "KB", "MB", "GB", "TB"];
   const i = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
   const val = bytes / Math.pow(1024, i);
   return `${val.toFixed(i === 0 ? 0 : 1)} ${units[i]}`;


### PR DESCRIPTION
## Summary
- stop treating `/sources/:id/info` storage totals as a universal quota meter in the dashboard and source detail views
- surface provider-native quota only when `/sources/:id/health` returns trustworthy quota bytes, with explicit unavailable states for S3-compatible and Telegram sources
- document the `/info` versus `/health` contract and add browser mocks for the honest quota states

## Validation
- `go test ./internal/handlers/... ./internal/manager/...`
- Swagger docs regenerated via `go run github.com/swaggo/swag/cmd/swag@v1.16.4 init --generalInfo cmd/server/main.go --dir . --output internal/docs --outputTypes go --parseInternal --quiet`
- Frontend lint/build not run locally in this worktree because `webui/node_modules` is not installed; Woodpecker should cover the full frontend gates

Refs #153