### PR TITLE
[codex] THE-881 ignore local Playwright artifacts

### DIFF
--- a/webui/.gitignore
+++ b/webui/.gitignore
@@ -11,6 +11,8 @@ node_modules
 dist
 dist-ssr
 *.local
+playwright-report
+test-results
 
 # Editor directories and files
 .vscode/*


### PR DESCRIPTION
## Summary
- ignore `webui/test-results` so local Playwright failures and retries do not dirty the repo
- ignore `webui/playwright-report` so the local HTML reporter output stays out of Git status

## Why
Local Playwright runs in `webui` generate artifacts that currently show up as untracked files. That creates repo-state noise during PR work, makes it harder to see real changes, and encourages accidental staging of generated test output.

## Impact
This is a repo-hygiene change only. It does not affect runtime behavior, CI logic, or tracked source files.

## Validation
- `git check-ignore -v webui/test-results/.last-run.json webui/playwright-report/index.html`
- confirmed the patch is isolated to `webui/.gitignore`
