### PR TITLE
[codex] THE-516 give repository index creation explicit startup context and timeout

### DIFF
--- a/api-go/cmd/server/main.go
+++ b/api-go/cmd/server/main.go
@@ -77,7 +77,7 @@ func run(ctx context.Context) error {
 		}
 	}()
 
-	router, err := app.SetupRouter(mongoConn, cfg)
+	router, err := app.SetupRouter(ctx, mongoConn, cfg)
 	if err != nil {
 		return fmt.Errorf("failed to initialize router: %w", err)
 	}

--- a/api-go/internal/app/router.go
+++ b/api-go/internal/app/router.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/example/sfree/api-go/internal/config"
@@ -12,21 +13,21 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin"
 )
 
-func SetupRouter(m *db.Mongo, cfg *config.Config) (*gin.Engine, error) {
-	return setupRouter(m, cfg, routerSetupOptions{})
+func SetupRouter(ctx context.Context, m *db.Mongo, cfg *config.Config) (*gin.Engine, error) {
+	return setupRouter(ctx, m, cfg, routerSetupOptions{})
 }
 
 type routerSetupOptions struct {
 	constructors routerDependencyConstructors
 }
 
-func setupRouter(m *db.Mongo, cfg *config.Config, opts routerSetupOptions) (*gin.Engine, error) {
+func setupRouter(ctx context.Context, m *db.Mongo, cfg *config.Config, opts routerSetupOptions) (*gin.Engine, error) {
 	router := gin.New()
 
 	limiters := registerMiddleware(router, cfg)
 	registerProbeRoutes(router, m, limiters)
 
-	deps, err := newRouterDependencies(m, cfg, opts.constructors)
+	deps, err := newRouterDependencies(ctx, m, cfg, opts.constructors)
 	if err != nil {
 		return nil, err
 	}

--- a/api-go/internal/app/router_dependencies.go
+++ b/api-go/internal/app/router_dependencies.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -27,14 +28,16 @@ type routerDependencies struct {
 }
 
 type routerDependencyConstructors struct {
-	user            func(*mongo.Database) (*repository.UserRepository, error)
-	bucket          func(*mongo.Database) (*repository.BucketRepository, error)
-	source          func(*mongo.Database, ...string) (*repository.SourceRepository, error)
-	file            func(*mongo.Database) (*repository.FileRepository, error)
-	shareLink       func(*mongo.Database) (*repository.ShareLinkRepository, error)
-	multipartUpload func(*mongo.Database) (*repository.MultipartUploadRepository, error)
-	bucketGrant     func(*mongo.Database) (*repository.BucketGrantRepository, error)
+	user            func(context.Context, *mongo.Database) (*repository.UserRepository, error)
+	bucket          func(context.Context, *mongo.Database) (*repository.BucketRepository, error)
+	source          func(context.Context, *mongo.Database, ...string) (*repository.SourceRepository, error)
+	file            func(context.Context, *mongo.Database) (*repository.FileRepository, error)
+	shareLink       func(context.Context, *mongo.Database) (*repository.ShareLinkRepository, error)
+	multipartUpload func(context.Context, *mongo.Database) (*repository.MultipartUploadRepository, error)
+	bucketGrant     func(context.Context, *mongo.Database) (*repository.BucketGrantRepository, error)
 }
+
+const repositoryInitTimeout = 10 * time.Second
 
 func (constructors routerDependencyConstructors) withDefaults() routerDependencyConstructors {
 	if constructors.user == nil {
@@ -61,41 +64,46 @@ func (constructors routerDependencyConstructors) withDefaults() routerDependency
 	return constructors
 }
 
-func newRouterDependencies(m *db.Mongo, cfg *config.Config, constructors routerDependencyConstructors) (*routerDependencies, error) {
+func newRouterDependencies(ctx context.Context, m *db.Mongo, cfg *config.Config, constructors routerDependencyConstructors) (*routerDependencies, error) {
 	deps := &routerDependencies{sourceFactory: routerSourceClientFactory(cfg)}
 	if m == nil {
 		return deps, nil
 	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	constructors = constructors.withDefaults()
+	initCtx, cancel := context.WithTimeout(ctx, repositoryInitTimeout)
+	defer cancel()
 
 	var err error
-	deps.userRepo, err = constructors.user(m.DB)
+	deps.userRepo, err = constructors.user(initCtx, m.DB)
 	if err != nil {
 		return nil, fmt.Errorf("initialize user repository: %w", err)
 	}
 	deps.auth = handlers.Auth(deps.userRepo, routerJWTSecret(cfg))
 
-	deps.bucketRepo, err = constructors.bucket(m.DB)
+	deps.bucketRepo, err = constructors.bucket(initCtx, m.DB)
 	if err != nil {
 		return nil, fmt.Errorf("initialize bucket repository: %w", err)
 	}
-	deps.sourceRepo, err = constructors.source(m.DB, routerAccessSecret(cfg))
+	deps.sourceRepo, err = constructors.source(initCtx, m.DB, routerAccessSecret(cfg))
 	if err != nil {
 		return nil, fmt.Errorf("initialize source repository: %w", err)
 	}
-	deps.fileRepo, err = constructors.file(m.DB)
+	deps.fileRepo, err = constructors.file(initCtx, m.DB)
 	if err != nil {
 		return nil, fmt.Errorf("initialize file repository: %w", err)
 	}
-	deps.mpRepo, err = constructors.multipartUpload(m.DB)
+	deps.mpRepo, err = constructors.multipartUpload(initCtx, m.DB)
 	if err != nil {
 		return nil, fmt.Errorf("initialize multipart upload repository: %w", err)
 	}
-	deps.shareLinkRepo, err = constructors.shareLink(m.DB)
+	deps.shareLinkRepo, err = constructors.shareLink(initCtx, m.DB)
 	if err != nil {
 		return nil, fmt.Errorf("initialize share link repository: %w", err)
 	}
-	deps.grantRepo, err = constructors.bucketGrant(m.DB)
+	deps.grantRepo, err = constructors.bucketGrant(initCtx, m.DB)
 	if err != nil {
 		return nil, fmt.Errorf("initialize bucket grant repository: %w", err)
 	}

--- a/api-go/internal/app/router_integration_test.go
+++ b/api-go/internal/app/router_integration_test.go
@@ -22,7 +22,7 @@ func TestRouterWithDB(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	r, err := SetupRouter(mongoConn, cfg)
+	r, err := SetupRouter(context.Background(), mongoConn, cfg)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/api-go/internal/app/router_test.go
+++ b/api-go/internal/app/router_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -21,7 +22,7 @@ import (
 func TestSetupRouter(t *testing.T) {
 	t.Parallel()
 
-	r, err := SetupRouter(nil, nil)
+	r, err := SetupRouter(context.Background(), nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -39,7 +40,7 @@ func TestSetupRouter(t *testing.T) {
 func TestSetupRouterNilMongoRouteSet(t *testing.T) {
 	t.Parallel()
 
-	r, err := SetupRouter(nil, nil)
+	r, err := SetupRouter(context.Background(), nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -82,7 +83,7 @@ func TestSetupRouterNilMongoRouteSet(t *testing.T) {
 func TestOpenAPIJSONRoute(t *testing.T) {
 	t.Parallel()
 
-	r, err := SetupRouter(nil, nil)
+	r, err := SetupRouter(context.Background(), nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -178,7 +179,7 @@ func TestRegisterS3RoutesIncludesRootAndLegacyEndpoints(t *testing.T) {
 func TestOpenAPIDocsRouteRedirectsToIndex(t *testing.T) {
 	t.Parallel()
 
-	r, err := SetupRouter(nil, nil)
+	r, err := SetupRouter(context.Background(), nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -260,7 +261,7 @@ func TestNewRouterDependenciesReturnsRepositoryErrors(t *testing.T) {
 		{
 			name: "user repository",
 			fail: func(constructors routerDependencyConstructors, failure error) routerDependencyConstructors {
-				constructors.user = func(*mongo.Database) (*repository.UserRepository, error) {
+				constructors.user = func(context.Context, *mongo.Database) (*repository.UserRepository, error) {
 					return nil, failure
 				}
 				return constructors
@@ -269,7 +270,7 @@ func TestNewRouterDependenciesReturnsRepositoryErrors(t *testing.T) {
 		{
 			name: "bucket repository",
 			fail: func(constructors routerDependencyConstructors, failure error) routerDependencyConstructors {
-				constructors.bucket = func(*mongo.Database) (*repository.BucketRepository, error) {
+				constructors.bucket = func(context.Context, *mongo.Database) (*repository.BucketRepository, error) {
 					return nil, failure
 				}
 				return constructors
@@ -278,7 +279,7 @@ func TestNewRouterDependenciesReturnsRepositoryErrors(t *testing.T) {
 		{
 			name: "source repository",
 			fail: func(constructors routerDependencyConstructors, failure error) routerDependencyConstructors {
-				constructors.source = func(*mongo.Database, ...string) (*repository.SourceRepository, error) {
+				constructors.source = func(context.Context, *mongo.Database, ...string) (*repository.SourceRepository, error) {
 					return nil, failure
 				}
 				return constructors
@@ -287,7 +288,7 @@ func TestNewRouterDependenciesReturnsRepositoryErrors(t *testing.T) {
 		{
 			name: "file repository",
 			fail: func(constructors routerDependencyConstructors, failure error) routerDependencyConstructors {
-				constructors.file = func(*mongo.Database) (*repository.FileRepository, error) {
+				constructors.file = func(context.Context, *mongo.Database) (*repository.FileRepository, error) {
 					return nil, failure
 				}
 				return constructors
@@ -296,7 +297,7 @@ func TestNewRouterDependenciesReturnsRepositoryErrors(t *testing.T) {
 		{
 			name: "multipart upload repository",
 			fail: func(constructors routerDependencyConstructors, failure error) routerDependencyConstructors {
-				constructors.multipartUpload = func(*mongo.Database) (*repository.MultipartUploadRepository, error) {
+				constructors.multipartUpload = func(context.Context, *mongo.Database) (*repository.MultipartUploadRepository, error) {
 					return nil, failure
 				}
 				return constructors
@@ -305,7 +306,7 @@ func TestNewRouterDependenciesReturnsRepositoryErrors(t *testing.T) {
 		{
 			name: "share link repository",
 			fail: func(constructors routerDependencyConstructors, failure error) routerDependencyConstructors {
-				constructors.shareLink = func(*mongo.Database) (*repository.ShareLinkRepository, error) {
+				constructors.shareLink = func(context.Context, *mongo.Database) (*repository.ShareLinkRepository, error) {
 					return nil, failure
 				}
 				return constructors
@@ -314,7 +315,7 @@ func TestNewRouterDependenciesReturnsRepositoryErrors(t *testing.T) {
 		{
 			name: "bucket grant repository",
 			fail: func(constructors routerDependencyConstructors, failure error) routerDependencyConstructors {
-				constructors.bucketGrant = func(*mongo.Database) (*repository.BucketGrantRepository, error) {
+				constructors.bucketGrant = func(context.Context, *mongo.Database) (*repository.BucketGrantRepository, error) {
 					return nil, failure
 				}
 				return constructors
@@ -330,7 +331,7 @@ func TestNewRouterDependenciesReturnsRepositoryErrors(t *testing.T) {
 			failure := errors.New("create index")
 			constructors := tt.fail(stubRouterRepositoryConstructors(), failure)
 
-			deps, err := newRouterDependencies(&db.Mongo{}, nil, constructors)
+			deps, err := newRouterDependencies(context.Background(), &db.Mongo{}, nil, constructors)
 			if err == nil {
 				t.Fatal("expected repository initialization error")
 			}
@@ -344,6 +345,59 @@ func TestNewRouterDependenciesReturnsRepositoryErrors(t *testing.T) {
 				t.Fatalf("expected repository name in error, got %v", err)
 			}
 		})
+	}
+}
+
+func TestNewRouterDependenciesAppliesRepositoryInitTimeout(t *testing.T) {
+	t.Parallel()
+
+	constructors := stubRouterRepositoryConstructors()
+	constructors.user = func(ctx context.Context, _ *mongo.Database) (*repository.UserRepository, error) {
+		deadline, ok := ctx.Deadline()
+		if !ok {
+			t.Fatal("expected repository init context deadline")
+		}
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			t.Fatalf("expected positive remaining deadline, got %s", remaining)
+		}
+		if remaining > repositoryInitTimeout {
+			t.Fatalf("expected deadline no later than %s, got %s", repositoryInitTimeout, remaining)
+		}
+		if remaining < repositoryInitTimeout-time.Second {
+			t.Fatalf("expected deadline close to %s, got %s", repositoryInitTimeout, remaining)
+		}
+		return &repository.UserRepository{}, nil
+	}
+
+	if _, err := newRouterDependencies(context.Background(), &db.Mongo{}, nil, constructors); err != nil {
+		t.Fatalf("expected repository initialization to succeed, got %v", err)
+	}
+}
+
+func TestNewRouterDependenciesUsesParentContextForRepositoryInit(t *testing.T) {
+	t.Parallel()
+
+	parent, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	constructors := stubRouterRepositoryConstructors()
+	constructors.user = func(ctx context.Context, _ *mongo.Database) (*repository.UserRepository, error) {
+		if !errors.Is(ctx.Err(), context.Canceled) {
+			t.Fatalf("expected canceled init context, got %v", ctx.Err())
+		}
+		return nil, ctx.Err()
+	}
+
+	deps, err := newRouterDependencies(parent, &db.Mongo{}, nil, constructors)
+	if err == nil {
+		t.Fatal("expected repository initialization error")
+	}
+	if deps != nil {
+		t.Fatal("expected nil dependencies on canceled initialization")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected canceled error, got %v", err)
 	}
 }
 
@@ -398,25 +452,25 @@ func hasRoute(r *gin.Engine, method, path string) bool {
 
 func stubRouterRepositoryConstructors() routerDependencyConstructors {
 	return routerDependencyConstructors{
-		user: func(*mongo.Database) (*repository.UserRepository, error) {
+		user: func(context.Context, *mongo.Database) (*repository.UserRepository, error) {
 			return &repository.UserRepository{}, nil
 		},
-		bucket: func(*mongo.Database) (*repository.BucketRepository, error) {
+		bucket: func(context.Context, *mongo.Database) (*repository.BucketRepository, error) {
 			return &repository.BucketRepository{}, nil
 		},
-		source: func(*mongo.Database, ...string) (*repository.SourceRepository, error) {
+		source: func(context.Context, *mongo.Database, ...string) (*repository.SourceRepository, error) {
 			return &repository.SourceRepository{}, nil
 		},
-		file: func(*mongo.Database) (*repository.FileRepository, error) {
+		file: func(context.Context, *mongo.Database) (*repository.FileRepository, error) {
 			return &repository.FileRepository{}, nil
 		},
-		multipartUpload: func(*mongo.Database) (*repository.MultipartUploadRepository, error) {
+		multipartUpload: func(context.Context, *mongo.Database) (*repository.MultipartUploadRepository, error) {
 			return &repository.MultipartUploadRepository{}, nil
 		},
-		shareLink: func(*mongo.Database) (*repository.ShareLinkRepository, error) {
+		shareLink: func(context.Context, *mongo.Database) (*repository.ShareLinkRepository, error) {
 			return &repository.ShareLinkRepository{}, nil
 		},
-		bucketGrant: func(*mongo.Database) (*repository.BucketGrantRepository, error) {
+		bucketGrant: func(context.Context, *mongo.Database) (*repository.BucketGrantRepository, error) {
 			return &repository.BucketGrantRepository{}, nil
 		},
 	}

--- a/api-go/internal/e2e/s3_compat_delete_test.go
+++ b/api-go/internal/e2e/s3_compat_delete_test.go
@@ -149,11 +149,11 @@ func TestS3CompatDeleteBucketCleansObjectMultipartAndChunks(t *testing.T) {
 	t.Cleanup(func() {
 		_ = mongoConn.Close(ctx)
 	})
-	fileRepo, err := repository.NewFileRepository(mongoConn.DB)
+	fileRepo, err := repository.NewFileRepository(context.Background(), mongoConn.DB)
 	if err != nil {
 		t.Fatalf("create file repository: %v", err)
 	}
-	mpRepo, err := repository.NewMultipartUploadRepository(mongoConn.DB)
+	mpRepo, err := repository.NewMultipartUploadRepository(context.Background(), mongoConn.DB)
 	if err != nil {
 		t.Fatalf("create multipart repository: %v", err)
 	}

--- a/api-go/internal/e2e/s3_compat_helpers_test.go
+++ b/api-go/internal/e2e/s3_compat_helpers_test.go
@@ -150,7 +150,7 @@ func newTestServer(t *testing.T) (*httptest.Server, *appconfig.Config) {
 	if err != nil {
 		t.Fatalf("connect mongo: %v", err)
 	}
-	router, err := app.SetupRouter(mongoConn, cfg)
+	router, err := app.SetupRouter(context.Background(), mongoConn, cfg)
 	if err != nil {
 		t.Fatalf("setup router: %v", err)
 	}

--- a/api-go/internal/e2e/server_test.go
+++ b/api-go/internal/e2e/server_test.go
@@ -23,7 +23,7 @@ func TestServerStartup(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	router, err := app.SetupRouter(mongoConn, cfg)
+	router, err := app.SetupRouter(context.Background(), mongoConn, cfg)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/api-go/internal/handlers/bucket_grant_integration_test.go
+++ b/api-go/internal/handlers/bucket_grant_integration_test.go
@@ -130,11 +130,11 @@ func newBucketGrantHandlerTestRepos(t *testing.T) (*repository.BucketRepository,
 		_ = testDB.Drop(context.Background())
 		_ = mongoConn.Close(context.Background())
 	})
-	bucketRepo, err := repository.NewBucketRepository(testDB)
+	bucketRepo, err := repository.NewBucketRepository(context.Background(), testDB)
 	if err != nil {
 		t.Fatal(err)
 	}
-	grantRepo, err := repository.NewBucketGrantRepository(testDB)
+	grantRepo, err := repository.NewBucketGrantRepository(context.Background(), testDB)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/api-go/internal/handlers/bucket_test.go
+++ b/api-go/internal/handlers/bucket_test.go
@@ -29,7 +29,7 @@ func TestCreateBucket(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	userRepo, err := repository.NewUserRepository(mongoConn.DB)
+	userRepo, err := repository.NewUserRepository(context.Background(), mongoConn.DB)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -42,11 +42,11 @@ func TestCreateBucket(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	repo, err := repository.NewBucketRepository(mongoConn.DB)
+	repo, err := repository.NewBucketRepository(context.Background(), mongoConn.DB)
 	if err != nil {
 		t.Fatal(err)
 	}
-	sourceRepo, err := repository.NewSourceRepository(mongoConn.DB)
+	sourceRepo, err := repository.NewSourceRepository(context.Background(), mongoConn.DB)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -164,15 +164,15 @@ func newBucketFileHandlerTestRepos(t *testing.T) (*repository.BucketRepository, 
 		_ = testDB.Drop(context.Background())
 		_ = mongoConn.Close(context.Background())
 	})
-	bucketRepo, err := repository.NewBucketRepository(testDB)
+	bucketRepo, err := repository.NewBucketRepository(context.Background(), testDB)
 	if err != nil {
 		t.Fatal(err)
 	}
-	fileRepo, err := repository.NewFileRepository(testDB)
+	fileRepo, err := repository.NewFileRepository(context.Background(), testDB)
 	if err != nil {
 		t.Fatal(err)
 	}
-	grantRepo, err := repository.NewBucketGrantRepository(testDB)
+	grantRepo, err := repository.NewBucketGrantRepository(context.Background(), testDB)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/api-go/internal/handlers/missing_source_upload_integration_test.go
+++ b/api-go/internal/handlers/missing_source_upload_integration_test.go
@@ -154,19 +154,19 @@ func newMissingSourceUploadHandlerFixture(t *testing.T) (*repository.BucketRepos
 		_ = testDB.Drop(context.Background())
 		_ = mongoConn.Close(context.Background())
 	})
-	bucketRepo, err := repository.NewBucketRepository(testDB)
+	bucketRepo, err := repository.NewBucketRepository(context.Background(), testDB)
 	if err != nil {
 		t.Fatal(err)
 	}
-	sourceRepo, err := repository.NewSourceRepository(testDB)
+	sourceRepo, err := repository.NewSourceRepository(context.Background(), testDB)
 	if err != nil {
 		t.Fatal(err)
 	}
-	fileRepo, err := repository.NewFileRepository(testDB)
+	fileRepo, err := repository.NewFileRepository(context.Background(), testDB)
 	if err != nil {
 		t.Fatal(err)
 	}
-	mpRepo, err := repository.NewMultipartUploadRepository(testDB)
+	mpRepo, err := repository.NewMultipartUploadRepository(context.Background(), testDB)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/api-go/internal/handlers/sharelink_integration_test.go
+++ b/api-go/internal/handlers/sharelink_integration_test.go
@@ -112,15 +112,15 @@ func newShareLinkHandlerTestRepos(t *testing.T) (*repository.BucketRepository, *
 		_ = testDB.Drop(context.Background())
 		_ = mongoConn.Close(context.Background())
 	})
-	bucketRepo, err := repository.NewBucketRepository(testDB)
+	bucketRepo, err := repository.NewBucketRepository(context.Background(), testDB)
 	if err != nil {
 		t.Fatal(err)
 	}
-	fileRepo, err := repository.NewFileRepository(testDB)
+	fileRepo, err := repository.NewFileRepository(context.Background(), testDB)
 	if err != nil {
 		t.Fatal(err)
 	}
-	shareLinkRepo, err := repository.NewShareLinkRepository(testDB)
+	shareLinkRepo, err := repository.NewShareLinkRepository(context.Background(), testDB)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/api-go/internal/handlers/source_test.go
+++ b/api-go/internal/handlers/source_test.go
@@ -29,7 +29,7 @@ func TestCreateGDriveSource(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	userRepo, err := repository.NewUserRepository(mongoConn.DB)
+	userRepo, err := repository.NewUserRepository(context.Background(), mongoConn.DB)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -42,7 +42,7 @@ func TestCreateGDriveSource(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	repo, err := repository.NewSourceRepository(mongoConn.DB)
+	repo, err := repository.NewSourceRepository(context.Background(), mongoConn.DB)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -93,7 +93,7 @@ func TestCreateTelegramSource(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	userRepo, err := repository.NewUserRepository(mongoConn.DB)
+	userRepo, err := repository.NewUserRepository(context.Background(), mongoConn.DB)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -106,7 +106,7 @@ func TestCreateTelegramSource(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	repo, err := repository.NewSourceRepository(mongoConn.DB)
+	repo, err := repository.NewSourceRepository(context.Background(), mongoConn.DB)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -157,7 +157,7 @@ func TestDeleteSourceBlockedWhenBucketUsesIt(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	userRepo, err := repository.NewUserRepository(mongoConn.DB)
+	userRepo, err := repository.NewUserRepository(context.Background(), mongoConn.DB)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -170,11 +170,11 @@ func TestDeleteSourceBlockedWhenBucketUsesIt(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	sourceRepo, err := repository.NewSourceRepository(mongoConn.DB)
+	sourceRepo, err := repository.NewSourceRepository(context.Background(), mongoConn.DB)
 	if err != nil {
 		t.Fatal(err)
 	}
-	bucketRepo, err := repository.NewBucketRepository(mongoConn.DB)
+	bucketRepo, err := repository.NewBucketRepository(context.Background(), mongoConn.DB)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/api-go/internal/handlers/user_test.go
+++ b/api-go/internal/handlers/user_test.go
@@ -28,7 +28,7 @@ func TestCreateUser(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	repo, err := repository.NewUserRepository(mongoConn.DB)
+	repo, err := repository.NewUserRepository(context.Background(), mongoConn.DB)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/api-go/internal/repository/bucket.go
+++ b/api-go/internal/repository/bucket.go
@@ -33,9 +33,9 @@ type BucketRepository struct {
 	coll *mongo.Collection
 }
 
-func NewBucketRepository(db *mongo.Database) (*BucketRepository, error) {
+func NewBucketRepository(ctx context.Context, db *mongo.Database) (*BucketRepository, error) {
 	coll := db.Collection("buckets")
-	_, err := coll.Indexes().CreateMany(context.Background(), []mongo.IndexModel{
+	_, err := coll.Indexes().CreateMany(ctx, []mongo.IndexModel{
 		{
 			Keys:    bson.D{{Key: "key", Value: 1}},
 			Options: options.Index().SetUnique(true),

--- a/api-go/internal/repository/bucket_grant.go
+++ b/api-go/internal/repository/bucket_grant.go
@@ -54,9 +54,9 @@ type BucketGrantRepository struct {
 	coll *mongo.Collection
 }
 
-func NewBucketGrantRepository(db *mongo.Database) (*BucketGrantRepository, error) {
+func NewBucketGrantRepository(ctx context.Context, db *mongo.Database) (*BucketGrantRepository, error) {
 	coll := db.Collection("bucket_grants")
-	_, err := coll.Indexes().CreateMany(context.Background(), []mongo.IndexModel{
+	_, err := coll.Indexes().CreateMany(ctx, []mongo.IndexModel{
 		{
 			Keys:    bson.D{{Key: "bucket_id", Value: 1}, {Key: "user_id", Value: 1}},
 			Options: options.Index().SetUnique(true),

--- a/api-go/internal/repository/bucket_test.go
+++ b/api-go/internal/repository/bucket_test.go
@@ -22,7 +22,7 @@ func TestBucketRepository(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	repo, err := NewBucketRepository(mongoConn.DB)
+	repo, err := NewBucketRepository(context.Background(), mongoConn.DB)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/api-go/internal/repository/file.go
+++ b/api-go/internal/repository/file.go
@@ -42,9 +42,8 @@ const (
 	fileChunkReferenceIndex   = "chunks_source_id_name"
 )
 
-func NewFileRepository(db *mongo.Database) (*FileRepository, error) {
+func NewFileRepository(ctx context.Context, db *mongo.Database) (*FileRepository, error) {
 	coll := db.Collection("files")
-	ctx := context.Background()
 	_, err := coll.Indexes().CreateMany(ctx, []mongo.IndexModel{
 		{
 			Keys: bson.D{{Key: "bucket_id", Value: 1}},

--- a/api-go/internal/repository/file_test.go
+++ b/api-go/internal/repository/file_test.go
@@ -193,7 +193,7 @@ func newFileRepositoryTestDB(t *testing.T) (*mongo.Database, *FileRepository) {
 		_ = testDB.Drop(context.Background())
 		_ = mongoConn.Close(context.Background())
 	})
-	repo, err := NewFileRepository(ctx, testDB)
+	repo, err := NewFileRepository(context.Background(), testDB)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/api-go/internal/repository/file_test.go
+++ b/api-go/internal/repository/file_test.go
@@ -112,7 +112,7 @@ func TestFileRepositoryMigratesLegacyBucketNameIndex(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	repo, err := NewFileRepository(testDB)
+	repo, err := NewFileRepository(ctx, testDB)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -193,7 +193,7 @@ func newFileRepositoryTestDB(t *testing.T) (*mongo.Database, *FileRepository) {
 		_ = testDB.Drop(context.Background())
 		_ = mongoConn.Close(context.Background())
 	})
-	repo, err := NewFileRepository(testDB)
+	repo, err := NewFileRepository(ctx, testDB)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/api-go/internal/repository/multipart.go
+++ b/api-go/internal/repository/multipart.go
@@ -36,9 +36,9 @@ type MultipartUploadRepository struct {
 const multipartPartChunkNameBucketIndex = "parts_chunks_name_bucket_id"
 const multipartBucketObjectUploadIndex = "bucket_id_object_key_upload_id"
 
-func NewMultipartUploadRepository(db *mongo.Database) (*MultipartUploadRepository, error) {
+func NewMultipartUploadRepository(ctx context.Context, db *mongo.Database) (*MultipartUploadRepository, error) {
 	coll := db.Collection("multipart_uploads")
-	_, err := coll.Indexes().CreateMany(context.Background(), []mongo.IndexModel{
+	_, err := coll.Indexes().CreateMany(ctx, []mongo.IndexModel{
 		{
 			Keys:    bson.D{{Key: "upload_id", Value: 1}},
 			Options: options.Index().SetUnique(true),

--- a/api-go/internal/repository/multipart_test.go
+++ b/api-go/internal/repository/multipart_test.go
@@ -228,7 +228,7 @@ func newMultipartRepositoryTestDB(t *testing.T) (*mongo.Database, *MultipartUplo
 		_ = testDB.Drop(context.Background())
 		_ = mongoConn.Close(context.Background())
 	})
-	repo, err := NewMultipartUploadRepository(testDB)
+	repo, err := NewMultipartUploadRepository(context.Background(), testDB)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/api-go/internal/repository/sharelink.go
+++ b/api-go/internal/repository/sharelink.go
@@ -24,9 +24,9 @@ type ShareLinkRepository struct {
 	coll *mongo.Collection
 }
 
-func NewShareLinkRepository(db *mongo.Database) (*ShareLinkRepository, error) {
+func NewShareLinkRepository(ctx context.Context, db *mongo.Database) (*ShareLinkRepository, error) {
 	coll := db.Collection("share_links")
-	_, err := coll.Indexes().CreateMany(context.Background(), []mongo.IndexModel{
+	_, err := coll.Indexes().CreateMany(ctx, []mongo.IndexModel{
 		{
 			Keys:    bson.D{{Key: "token", Value: 1}},
 			Options: options.Index().SetUnique(true),

--- a/api-go/internal/repository/sharelink_test.go
+++ b/api-go/internal/repository/sharelink_test.go
@@ -104,7 +104,7 @@ func newShareLinkRepositoryTestDB(t *testing.T) (*mongo.Database, *ShareLinkRepo
 		_ = testDB.Drop(context.Background())
 		_ = mongoConn.Close(context.Background())
 	})
-	repo, err := NewShareLinkRepository(testDB)
+	repo, err := NewShareLinkRepository(context.Background(), testDB)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/api-go/internal/repository/source.go
+++ b/api-go/internal/repository/source.go
@@ -57,9 +57,9 @@ type SourceRepository struct {
 	secretKey string
 }
 
-func NewSourceRepository(db *mongo.Database, secretKey ...string) (*SourceRepository, error) {
+func NewSourceRepository(ctx context.Context, db *mongo.Database, secretKey ...string) (*SourceRepository, error) {
 	coll := db.Collection("sources")
-	_, err := coll.Indexes().CreateOne(context.Background(), mongo.IndexModel{
+	_, err := coll.Indexes().CreateOne(ctx, mongo.IndexModel{
 		Keys: bson.D{{Key: "user_id", Value: 1}},
 	})
 	if err != nil {

--- a/api-go/internal/repository/source_test.go
+++ b/api-go/internal/repository/source_test.go
@@ -23,7 +23,7 @@ func TestCreateSource(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	repo, err := NewSourceRepository(mongoConn.DB)
+	repo, err := NewSourceRepository(context.Background(), mongoConn.DB)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -59,7 +59,7 @@ func TestListMetadataByUserDoesNotDecryptKeys(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	repo, err := NewSourceRepository(mongoConn.DB, "test-secret")
+	repo, err := NewSourceRepository(context.Background(), mongoConn.DB, "test-secret")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/api-go/internal/repository/user.go
+++ b/api-go/internal/repository/user.go
@@ -24,9 +24,9 @@ type UserRepository struct {
 	coll *mongo.Collection
 }
 
-func NewUserRepository(db *mongo.Database) (*UserRepository, error) {
+func NewUserRepository(ctx context.Context, db *mongo.Database) (*UserRepository, error) {
 	coll := db.Collection("users")
-	_, err := coll.Indexes().CreateOne(context.Background(), mongo.IndexModel{
+	_, err := coll.Indexes().CreateOne(ctx, mongo.IndexModel{
 		Keys:    bson.D{{Key: "username", Value: 1}},
 		Options: options.Index().SetUnique(true),
 	})

--- a/api-go/internal/repository/user_test.go
+++ b/api-go/internal/repository/user_test.go
@@ -22,7 +22,7 @@ func TestUserRepository(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	repo, err := NewUserRepository(mongoConn.DB)
+	repo, err := NewUserRepository(context.Background(), mongoConn.DB)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Summary
- pass the server startup context into `app.SetupRouter` and bound repository initialization with a 10s startup timeout
- make repository constructors accept an explicit init context instead of using `context.Background()` for index creation
- update call sites and add router tests covering init deadline propagation and parent-context cancellation

## Why
Repository index creation previously ran with `context.Background()` inside constructors, so startup work ignored server cancellation and could block indefinitely during index creation.

## Validation
- `cd api-go && go test ./... -run '^$'`
- `cd api-go && go test ./internal/app -run 'TestNewRouterDependencies(AppliesRepositoryInitTimeout|UsesParentContextForRepositoryInit|ReturnsRepositoryErrors)$'`