### PR TITLE
[codex] THE-611 make github oauth callback injectable

### DIFF
--- a/api-go/internal/handlers/oauth.go
+++ b/api-go/internal/handlers/oauth.go
@@ -1,7 +1,9 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -12,6 +14,7 @@ import (
 	"github.com/example/sfree/api-go/internal/repository"
 	"github.com/gin-gonic/gin"
 	"github.com/golang-jwt/jwt/v5"
+	"go.mongodb.org/mongo-driver/mongo"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/github"
 )
@@ -56,6 +59,30 @@ type githubUser struct {
 	AvatarURL string `json:"avatar_url"`
 }
 
+type gitHubOAuthUserRepository interface {
+	GetByGitHubID(ctx context.Context, githubID int64) (*repository.User, error)
+	Create(ctx context.Context, user repository.User) (*repository.User, error)
+}
+
+type gitHubOAuthCallbackDeps struct {
+	exchangeCode    func(ctx context.Context, code string) (*oauth2.Token, error)
+	fetchGitHubUser func(ctx context.Context, token *oauth2.Token) (*http.Response, error)
+	issueJWT        func(userID string, secret string) (string, error)
+}
+
+func newGitHubOAuthCallbackDeps(cfg *config.Config) gitHubOAuthCallbackDeps {
+	oauthCfg := newGitHubOAuthConfig(cfg)
+	return gitHubOAuthCallbackDeps{
+		exchangeCode: func(ctx context.Context, code string) (*oauth2.Token, error) {
+			return oauthCfg.Exchange(ctx, code)
+		},
+		fetchGitHubUser: func(ctx context.Context, token *oauth2.Token) (*http.Response, error) {
+			return oauthCfg.Client(ctx, token).Get("https://api.github.com/user")
+		},
+		issueJWT: IssueJWT,
+	}
+}
+
 // GitHubCallback godoc
 // @Summary Complete GitHub OAuth login
 // @Tags auth
@@ -65,7 +92,11 @@ type githubUser struct {
 // @Failure 400 {string} string ""
 // @Failure 500 {string} string ""
 // @Router /api/v1/auth/github/callback [get]
-func GitHubCallback(cfg *config.Config, userRepo *repository.UserRepository) gin.HandlerFunc {
+func GitHubCallback(cfg *config.Config, userRepo gitHubOAuthUserRepository) gin.HandlerFunc {
+	return gitHubCallback(cfg, userRepo, newGitHubOAuthCallbackDeps(cfg))
+}
+
+func gitHubCallback(cfg *config.Config, userRepo gitHubOAuthUserRepository, deps gitHubOAuthCallbackDeps) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		ctx := c.Request.Context()
 		savedState, err := c.Cookie("oauth_state")
@@ -76,16 +107,14 @@ func GitHubCallback(cfg *config.Config, userRepo *repository.UserRepository) gin
 		// Clear the state cookie immediately to prevent replay attacks.
 		c.SetCookie("oauth_state", "", -1, "/", "", true, true)
 
-		oauthCfg := newGitHubOAuthConfig(cfg)
-		token, err := oauthCfg.Exchange(ctx, c.Query("code"))
+		token, err := deps.exchangeCode(ctx, c.Query("code"))
 		if err != nil {
 			slog.ErrorContext(ctx, "oauth callback: token exchange failed", slog.String("error", err.Error()))
 			c.JSON(http.StatusBadRequest, gin.H{"error": "failed to exchange code"})
 			return
 		}
 
-		client := oauthCfg.Client(ctx, token)
-		resp, err := client.Get("https://api.github.com/user")
+		resp, err := deps.fetchGitHubUser(ctx, token)
 		if err != nil {
 			slog.ErrorContext(ctx, "oauth callback: github user fetch failed", slog.String("error", err.Error()))
 			c.Status(http.StatusInternalServerError)
@@ -94,6 +123,11 @@ func GitHubCallback(cfg *config.Config, userRepo *repository.UserRepository) gin
 		defer func() {
 			_ = resp.Body.Close()
 		}()
+		if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+			slog.ErrorContext(ctx, "oauth callback: github user fetch returned non-2xx", slog.Int("status", resp.StatusCode))
+			c.Status(http.StatusInternalServerError)
+			return
+		}
 
 		var ghUser githubUser
 		if err := json.NewDecoder(resp.Body).Decode(&ghUser); err != nil {
@@ -105,6 +139,11 @@ func GitHubCallback(cfg *config.Config, userRepo *repository.UserRepository) gin
 		// Find or create user by GitHub ID.
 		user, err := userRepo.GetByGitHubID(ctx, ghUser.ID)
 		if err != nil {
+			if !errors.Is(err, mongo.ErrNoDocuments) {
+				slog.ErrorContext(ctx, "oauth callback: failed to load github user", slog.String("error", err.Error()))
+				c.Status(http.StatusInternalServerError)
+				return
+			}
 			// User not found — create a new one.
 			newUser := repository.User{
 				Username:  ghUser.Login,
@@ -114,6 +153,11 @@ func GitHubCallback(cfg *config.Config, userRepo *repository.UserRepository) gin
 			}
 			user, err = userRepo.Create(ctx, newUser)
 			if err != nil {
+				if !mongo.IsDuplicateKeyError(err) {
+					slog.ErrorContext(ctx, "oauth callback: failed to create user", slog.String("error", err.Error()))
+					c.Status(http.StatusInternalServerError)
+					return
+				}
 				// Username conflict — try with GitHub ID suffix.
 				newUser.Username = fmt.Sprintf("%s-%d", ghUser.Login, ghUser.ID)
 				user, err = userRepo.Create(ctx, newUser)
@@ -130,7 +174,7 @@ func GitHubCallback(cfg *config.Config, userRepo *repository.UserRepository) gin
 		if jwtSecret == "" {
 			jwtSecret = cfg.AccessSecretKey
 		}
-		jwtToken, err := IssueJWT(user.ID.Hex(), jwtSecret)
+		jwtToken, err := deps.issueJWT(user.ID.Hex(), jwtSecret)
 		if err != nil {
 			slog.ErrorContext(ctx, "oauth callback: failed to issue jwt", slog.String("error", err.Error()))
 			c.Status(http.StatusInternalServerError)

--- a/api-go/internal/handlers/oauth_test.go
+++ b/api-go/internal/handlers/oauth_test.go
@@ -1,0 +1,335 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/example/sfree/api-go/internal/config"
+	"github.com/example/sfree/api-go/internal/repository"
+	"github.com/gin-gonic/gin"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+	"golang.org/x/oauth2"
+)
+
+type stubGitHubOAuthUserRepo struct {
+	getByGitHubIDFunc func(context.Context, int64) (*repository.User, error)
+	createFunc        func(context.Context, repository.User) (*repository.User, error)
+	createCalls       []repository.User
+}
+
+func (s *stubGitHubOAuthUserRepo) GetByGitHubID(ctx context.Context, githubID int64) (*repository.User, error) {
+	if s.getByGitHubIDFunc == nil {
+		return nil, mongo.ErrNoDocuments
+	}
+	return s.getByGitHubIDFunc(ctx, githubID)
+}
+
+func (s *stubGitHubOAuthUserRepo) Create(ctx context.Context, user repository.User) (*repository.User, error) {
+	s.createCalls = append(s.createCalls, user)
+	if s.createFunc == nil {
+		if user.ID.IsZero() {
+			user.ID = primitive.NewObjectID()
+		}
+		return &user, nil
+	}
+	return s.createFunc(ctx, user)
+}
+
+func TestGitHubCallbackRejectsInvalidState(t *testing.T) {
+	t.Parallel()
+
+	exchangeCalled := false
+	w := serveOAuthCallback(t, &config.Config{}, &stubGitHubOAuthUserRepo{}, gitHubOAuthCallbackDeps{
+		exchangeCode: func(context.Context, string) (*oauth2.Token, error) {
+			exchangeCalled = true
+			return nil, nil
+		},
+		fetchGitHubUser: func(context.Context, *oauth2.Token) (*http.Response, error) {
+			t.Fatal("fetchGitHubUser should not be called")
+			return nil, nil
+		},
+		issueJWT: func(string, string) (string, error) {
+			t.Fatal("issueJWT should not be called")
+			return "", nil
+		},
+	}, oauthCallbackRequest("/api/v1/auth/github/callback?code=test-code&state=wrong", "expected-state"))
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+	if exchangeCalled {
+		t.Fatal("exchangeCode should not be called")
+	}
+}
+
+func TestGitHubCallbackReturnsBadRequestOnExchangeFailure(t *testing.T) {
+	t.Parallel()
+
+	fetchCalled := false
+	w := serveOAuthCallback(t, &config.Config{}, &stubGitHubOAuthUserRepo{}, gitHubOAuthCallbackDeps{
+		exchangeCode: func(context.Context, string) (*oauth2.Token, error) {
+			return nil, errors.New("exchange failed")
+		},
+		fetchGitHubUser: func(context.Context, *oauth2.Token) (*http.Response, error) {
+			fetchCalled = true
+			return nil, nil
+		},
+		issueJWT: func(string, string) (string, error) {
+			t.Fatal("issueJWT should not be called")
+			return "", nil
+		},
+	}, oauthCallbackRequest("/api/v1/auth/github/callback?code=test-code&state=expected-state", "expected-state"))
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+	if fetchCalled {
+		t.Fatal("fetchGitHubUser should not be called after exchange failure")
+	}
+}
+
+func TestGitHubCallbackRejectsNon2xxGitHubUserResponse(t *testing.T) {
+	t.Parallel()
+
+	repo := &stubGitHubOAuthUserRepo{}
+	w := serveOAuthCallback(t, &config.Config{}, repo, gitHubOAuthCallbackDeps{
+		exchangeCode: func(context.Context, string) (*oauth2.Token, error) {
+			return &oauth2.Token{AccessToken: "token"}, nil
+		},
+		fetchGitHubUser: func(context.Context, *oauth2.Token) (*http.Response, error) {
+			return oauthUserResponse(http.StatusForbidden, `{"id":99,"login":"ignored"}`), nil
+		},
+		issueJWT: func(string, string) (string, error) {
+			t.Fatal("issueJWT should not be called")
+			return "", nil
+		},
+	}, oauthCallbackRequest("/api/v1/auth/github/callback?code=test-code&state=expected-state", "expected-state"))
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", w.Code)
+	}
+	if len(repo.createCalls) != 0 {
+		t.Fatalf("expected no create calls, got %d", len(repo.createCalls))
+	}
+}
+
+func TestGitHubCallbackRejectsInvalidGitHubUserJSON(t *testing.T) {
+	t.Parallel()
+
+	repo := &stubGitHubOAuthUserRepo{}
+	getByIDCalled := false
+	repo.getByGitHubIDFunc = func(context.Context, int64) (*repository.User, error) {
+		getByIDCalled = true
+		return nil, nil
+	}
+
+	w := serveOAuthCallback(t, &config.Config{}, repo, gitHubOAuthCallbackDeps{
+		exchangeCode: func(context.Context, string) (*oauth2.Token, error) {
+			return &oauth2.Token{AccessToken: "token"}, nil
+		},
+		fetchGitHubUser: func(context.Context, *oauth2.Token) (*http.Response, error) {
+			return oauthUserResponse(http.StatusOK, `{`), nil
+		},
+		issueJWT: func(string, string) (string, error) {
+			t.Fatal("issueJWT should not be called")
+			return "", nil
+		},
+	}, oauthCallbackRequest("/api/v1/auth/github/callback?code=test-code&state=expected-state", "expected-state"))
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", w.Code)
+	}
+	if getByIDCalled {
+		t.Fatal("GetByGitHubID should not be called for invalid user JSON")
+	}
+	if len(repo.createCalls) != 0 {
+		t.Fatalf("expected no create calls, got %d", len(repo.createCalls))
+	}
+}
+
+func TestGitHubCallbackExistingUserSetsCookieAndRedirects(t *testing.T) {
+	t.Parallel()
+
+	existingUser := &repository.User{
+		ID:        primitive.NewObjectID(),
+		Username:  "existing-user",
+		GitHubID:  42,
+		AvatarURL: "https://avatars.example/existing.png",
+	}
+	repo := &stubGitHubOAuthUserRepo{
+		getByGitHubIDFunc: func(context.Context, int64) (*repository.User, error) {
+			return existingUser, nil
+		},
+	}
+
+	w := serveOAuthCallback(t, testOAuthConfig(), repo, gitHubOAuthCallbackDeps{
+		exchangeCode: func(context.Context, string) (*oauth2.Token, error) {
+			return &oauth2.Token{AccessToken: "token"}, nil
+		},
+		fetchGitHubUser: func(context.Context, *oauth2.Token) (*http.Response, error) {
+			return oauthUserResponse(http.StatusOK, `{"id":42,"login":"octocat","avatar_url":"https://avatars.example/octocat.png"}`), nil
+		},
+		issueJWT: func(userID, secret string) (string, error) {
+			if userID != existingUser.ID.Hex() {
+				t.Fatalf("issueJWT userID = %q, want %q", userID, existingUser.ID.Hex())
+			}
+			if secret != "jwt-secret" {
+				t.Fatalf("issueJWT secret = %q, want %q", secret, "jwt-secret")
+			}
+			return "signed-token", nil
+		},
+	}, oauthCallbackRequest("/api/v1/auth/github/callback?code=test-code&state=expected-state", "expected-state"))
+
+	if w.Code != http.StatusTemporaryRedirect {
+		t.Fatalf("expected 307, got %d", w.Code)
+	}
+	if len(repo.createCalls) != 0 {
+		t.Fatalf("expected no create calls, got %d", len(repo.createCalls))
+	}
+
+	authCookie := findCookie(t, w.Result(), "auth_token")
+	if authCookie.Value != "signed-token" {
+		t.Fatalf("auth_token value = %q, want %q", authCookie.Value, "signed-token")
+	}
+	if !authCookie.HttpOnly {
+		t.Fatal("auth_token should be HttpOnly")
+	}
+	if !authCookie.Secure {
+		t.Fatal("auth_token should be Secure")
+	}
+	if authCookie.SameSite != http.SameSiteLaxMode {
+		t.Fatalf("auth_token SameSite = %v, want %v", authCookie.SameSite, http.SameSiteLaxMode)
+	}
+	if authCookie.MaxAge != 7*24*3600 {
+		t.Fatalf("auth_token MaxAge = %d, want %d", authCookie.MaxAge, 7*24*3600)
+	}
+
+	redirectURL, err := url.Parse(w.Header().Get("Location"))
+	if err != nil {
+		t.Fatalf("parse redirect location: %v", err)
+	}
+	if redirectURL.String() != "https://frontend.example/auth/callback?username=existing-user" {
+		t.Fatalf("redirect location = %q", redirectURL.String())
+	}
+	if redirectURL.Query().Get("auth_token") != "" {
+		t.Fatal("redirect URL should not include auth_token")
+	}
+}
+
+func TestGitHubCallbackUsernameConflictFallsBackToGitHubIDSuffix(t *testing.T) {
+	t.Parallel()
+
+	createdUser := &repository.User{
+		ID:       primitive.NewObjectID(),
+		Username: "octocat-42",
+		GitHubID: 42,
+	}
+	repo := &stubGitHubOAuthUserRepo{
+		getByGitHubIDFunc: func(context.Context, int64) (*repository.User, error) {
+			return nil, mongo.ErrNoDocuments
+		},
+	}
+	createAttempt := 0
+	repo.createFunc = func(_ context.Context, user repository.User) (*repository.User, error) {
+		createAttempt++
+		if createAttempt == 1 {
+			return nil, mongo.WriteException{
+				WriteErrors: []mongo.WriteError{{Code: 11000, Message: "duplicate key"}},
+			}
+		}
+		createdUser.AvatarURL = user.AvatarURL
+		return createdUser, nil
+	}
+
+	w := serveOAuthCallback(t, testOAuthConfig(), repo, gitHubOAuthCallbackDeps{
+		exchangeCode: func(context.Context, string) (*oauth2.Token, error) {
+			return &oauth2.Token{AccessToken: "token"}, nil
+		},
+		fetchGitHubUser: func(context.Context, *oauth2.Token) (*http.Response, error) {
+			return oauthUserResponse(http.StatusOK, `{"id":42,"login":"octocat","avatar_url":"https://avatars.example/octocat.png"}`), nil
+		},
+		issueJWT: func(userID, secret string) (string, error) {
+			if userID != createdUser.ID.Hex() {
+				t.Fatalf("issueJWT userID = %q, want %q", userID, createdUser.ID.Hex())
+			}
+			if secret != "jwt-secret" {
+				t.Fatalf("issueJWT secret = %q, want %q", secret, "jwt-secret")
+			}
+			return "signed-token", nil
+		},
+	}, oauthCallbackRequest("/api/v1/auth/github/callback?code=test-code&state=expected-state", "expected-state"))
+
+	if w.Code != http.StatusTemporaryRedirect {
+		t.Fatalf("expected 307, got %d", w.Code)
+	}
+	if len(repo.createCalls) != 2 {
+		t.Fatalf("expected 2 create calls, got %d", len(repo.createCalls))
+	}
+	if repo.createCalls[0].Username != "octocat" {
+		t.Fatalf("first username = %q, want %q", repo.createCalls[0].Username, "octocat")
+	}
+	if repo.createCalls[1].Username != "octocat-42" {
+		t.Fatalf("second username = %q, want %q", repo.createCalls[1].Username, "octocat-42")
+	}
+
+	redirectURL, err := url.Parse(w.Header().Get("Location"))
+	if err != nil {
+		t.Fatalf("parse redirect location: %v", err)
+	}
+	if redirectURL.Query().Get("username") != "octocat-42" {
+		t.Fatalf("redirect username = %q, want %q", redirectURL.Query().Get("username"), "octocat-42")
+	}
+}
+
+func serveOAuthCallback(t *testing.T, cfg *config.Config, repo gitHubOAuthUserRepository, deps gitHubOAuthCallbackDeps, req *http.Request) *httptest.ResponseRecorder {
+	t.Helper()
+
+	router := gin.New()
+	router.GET("/api/v1/auth/github/callback", gitHubCallback(cfg, repo, deps))
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	return w
+}
+
+func oauthCallbackRequest(target string, state string) *http.Request {
+	req := httptest.NewRequest(http.MethodGet, target, nil)
+	if state != "" {
+		req.AddCookie(&http.Cookie{Name: "oauth_state", Value: state})
+	}
+	return req
+}
+
+func oauthUserResponse(statusCode int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: statusCode,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     make(http.Header),
+	}
+}
+
+func findCookie(t *testing.T, resp *http.Response, name string) *http.Cookie {
+	t.Helper()
+
+	for _, cookie := range resp.Cookies() {
+		if cookie.Name == name {
+			return cookie
+		}
+	}
+	t.Fatalf("cookie %q not found", name)
+	return nil
+}
+
+func testOAuthConfig() *config.Config {
+	return &config.Config{
+		JWTSecret:   "jwt-secret",
+		FrontendURL: "https://frontend.example",
+	}
+}


### PR DESCRIPTION
## Summary
- inject the GitHub OAuth callback exchange, userinfo fetch, and JWT issuance seams behind a small internal dependency struct
- reject non-2xx GitHub userinfo responses before decoding and tighten user lookup/create error handling around `mongo.ErrNoDocuments` and duplicate-key fallback
- add focused callback handler tests for invalid state, exchange failure, non-2xx and invalid JSON userinfo responses, existing-user login, username conflict fallback, cookie attributes, and redirect behavior

## Why
The callback mixed external OAuth behavior with persistence and redirect logic, which made the public auth path hard to unit test. The handler also decoded GitHub userinfo bodies without checking the upstream HTTP status first.

## Impact
This keeps the public OAuth routes unchanged while making the callback boundary testable and preventing user creation from GitHub error payloads.

## Validation
- `go test ./internal/handlers -run 'TestGitHubCallback|TestOAuthCallbackSetsHttpOnlyCookie'`
- `go test ./internal/handlers ./internal/app`
- `golangci-lint run ./internal/handlers ./internal/app` was not available locally because `golangci-lint` is not installed in this workspace
