### PR TITLE
THE-830 Mobile and tablet usability pass

### DIFF
--- a/webui/src/features/bucket/ui/share-bucket-dialog.tsx
+++ b/webui/src/features/bucket/ui/share-bucket-dialog.tsx
@@ -133,13 +133,14 @@ export function ShareBucketDialog({isOpen, onOpenChange, bucketId}: Props) {
         onOpenChange();
       }}
       size="lg"
+      scrollBehavior="inside"
     >
       <ModalContent>
         {(onClose) => (
           <>
             <ModalHeader>Share Bucket</ModalHeader>
             <ModalBody>
-              <div className="flex gap-2 items-end">
+              <div className="flex flex-col sm:flex-row gap-2 sm:items-end">
                 <Input
                   label="Username"
                   placeholder="Enter username"
@@ -147,29 +148,31 @@ export function ShareBucketDialog({isOpen, onOpenChange, bucketId}: Props) {
                   onValueChange={setUsername}
                   className="flex-1"
                 />
-                <Select
-                  label="Role"
-                  selectedKeys={new Set([role])}
-                  onSelectionChange={(keys) => {
-                    const val = Array.from(keys)[0] as string;
-                    if (val) setRole(val as BucketGrant["role"]);
-                  }}
-                  className="w-32"
-                >
-                  {ROLES.map((r) => (
-                    <SelectItem key={r.key}>{r.label}</SelectItem>
-                  ))}
-                </Select>
-                <Button
-                  color="primary"
-                  isLoading={isAdding}
-                  onPress={handleAdd}
-                  isDisabled={
-                    !username.trim() || isLoadingGrants || !!grantLoadError
-                  }
-                >
-                  Add
-                </Button>
+                <div className="flex gap-2 items-end">
+                  <Select
+                    label="Role"
+                    selectedKeys={new Set([role])}
+                    onSelectionChange={(keys) => {
+                      const val = Array.from(keys)[0] as string;
+                      if (val) setRole(val as BucketGrant["role"]);
+                    }}
+                    className="w-full sm:w-32"
+                  >
+                    {ROLES.map((r) => (
+                      <SelectItem key={r.key}>{r.label}</SelectItem>
+                    ))}
+                  </Select>
+                  <Button
+                    color="primary"
+                    isLoading={isAdding}
+                    onPress={handleAdd}
+                    isDisabled={
+                      !username.trim() || isLoadingGrants || !!grantLoadError
+                    }
+                  >
+                    Add
+                  </Button>
+                </div>
               </div>
 
               {isLoadingGrants && (
@@ -197,35 +200,37 @@ export function ShareBucketDialog({isOpen, onOpenChange, bucketId}: Props) {
                   {grants.map((g) => (
                     <div
                       key={g.id}
-                      className="flex items-center gap-2 border rounded p-2"
+                      className="flex flex-wrap items-center gap-2 border rounded p-2"
                     >
-                      <span className="flex-1 text-sm font-medium">
+                      <span className="flex-1 min-w-0 text-sm font-medium truncate">
                         {g.username}
                       </span>
-                      <Select
-                        size="sm"
-                        selectedKeys={new Set([g.role])}
-                        onSelectionChange={(keys) => {
-                          const val = Array.from(keys)[0] as string;
-                          if (val && val !== g.role)
-                            handleRoleChange(g.id, val);
-                        }}
-                        className="w-28"
-                        aria-label="Role"
-                      >
-                        {ROLES.map((r) => (
-                          <SelectItem key={r.key}>{r.label}</SelectItem>
-                        ))}
-                      </Select>
-                      <Button
-                        isIconOnly
-                        size="sm"
-                        variant="light"
-                        color="danger"
-                        onPress={() => handleRevoke(g.id)}
-                      >
-                        <DeleteIcon className="w-4 h-4" />
-                      </Button>
+                      <div className="flex items-center gap-2">
+                        <Select
+                          size="sm"
+                          selectedKeys={new Set([g.role])}
+                          onSelectionChange={(keys) => {
+                            const val = Array.from(keys)[0] as string;
+                            if (val && val !== g.role)
+                              handleRoleChange(g.id, val);
+                          }}
+                          className="w-28"
+                          aria-label="Role"
+                        >
+                          {ROLES.map((r) => (
+                            <SelectItem key={r.key}>{r.label}</SelectItem>
+                          ))}
+                        </Select>
+                        <Button
+                          isIconOnly
+                          size="sm"
+                          variant="light"
+                          color="danger"
+                          onPress={() => handleRevoke(g.id)}
+                        >
+                          <DeleteIcon className="w-4 h-4" />
+                        </Button>
+                      </div>
                     </div>
                   ))}
                 </div>

--- a/webui/src/features/bucket/ui/share-file-dialog.tsx
+++ b/webui/src/features/bucket/ui/share-file-dialog.tsx
@@ -76,6 +76,7 @@ export function ShareFileDialog({bucketId, file, onClose}: Props) {
         if (!open) handleClose();
       }}
       size="lg"
+      scrollBehavior="inside"
     >
       <ModalContent>
         {(closeModal) => (
@@ -91,28 +92,30 @@ export function ShareFileDialog({bucketId, file, onClose}: Props) {
                   {shareLinks.map((link) => (
                     <div
                       key={link.id}
-                      className="flex items-center gap-2 border rounded p-2 text-sm"
+                      className="flex flex-col sm:flex-row sm:items-center gap-2 border rounded p-2 text-sm"
                     >
-                      <code className="flex-1 truncate">
+                      <code className="flex-1 min-w-0 break-all text-xs sm:text-sm">
                         {window.location.origin}{link.url}
                       </code>
-                      <Button
-                        size="sm"
-                        variant="flat"
-                        onPress={() => copyShareUrl(link)}
-                      >
-                        {copiedToken === link.token ? "Copied!" : "Copy"}
-                      </Button>
-                      <Button
-                        size="sm"
-                        variant="flat"
-                        color="danger"
-                        onPress={() => handleDeleteShare(link.id)}
-                      >
-                        Revoke
-                      </Button>
+                      <div className="flex items-center gap-2 shrink-0">
+                        <Button
+                          size="sm"
+                          variant="flat"
+                          onPress={() => copyShareUrl(link)}
+                        >
+                          {copiedToken === link.token ? "Copied!" : "Copy"}
+                        </Button>
+                        <Button
+                          size="sm"
+                          variant="flat"
+                          color="danger"
+                          onPress={() => handleDeleteShare(link.id)}
+                        >
+                          Revoke
+                        </Button>
+                      </div>
                       {link.expires_at && (
-                        <span className="text-xs text-gray-400">
+                        <span className="text-xs text-default-400">
                           expires {new Date(link.expires_at).toLocaleString()}
                         </span>
                       )}

--- a/webui/src/pages/bucket/ui/bucket-page.tsx
+++ b/webui/src/pages/bucket/ui/bucket-page.tsx
@@ -251,15 +251,15 @@ export function BucketPage() {
         &larr; Buckets
       </Link>
       <div className="flex flex-col gap-2">
-        <div className="flex items-center gap-3">
-          <h1 className="text-3xl font-bold">{bucket.key}</h1>
+        <div className="flex flex-wrap items-center gap-3">
+          <h1 className="text-3xl font-bold break-all">{bucket.key}</h1>
           <Chip size="sm" variant="flat" color={ROLE_COLOR[bucket.role] ?? "default"}>
             {bucket.role}
           </Chip>
         </div>
         <CredentialsPanel bucket={bucket} />
       </div>
-      <div className="flex justify-end gap-2">
+      <div className="flex flex-wrap justify-end gap-2">
         {canManage && (
           <Button variant="flat" onPress={shareBucket.onOpen}>
             Share Bucket
@@ -313,77 +313,82 @@ export function BucketPage() {
             onCtaPress={!activeSearchQuery && canWrite ? () => fileInput.current?.click() : undefined}
           />
         ) : (
-          <table className="w-full text-left">
-            <thead>
-              <tr>
-                <th className="pb-2 cursor-pointer select-none" onClick={() => toggleSort("name")}>
-                  Name<SortArrow field="name" sortBy={sortBy} sortAsc={sortAsc} />
-                </th>
-                <th className="pb-2 cursor-pointer select-none" onClick={() => toggleSort("size")}>
-                  Size<SortArrow field="size" sortBy={sortBy} sortAsc={sortAsc} />
-                </th>
-                <th className="pb-2 cursor-pointer select-none" onClick={() => toggleSort("created_at")}>
-                  Created<SortArrow field="created_at" sortBy={sortBy} sortAsc={sortAsc} />
-                </th>
-                <th className="pb-2"></th>
-              </tr>
-            </thead>
-            <tbody>
-              {sortedFiles.map((f) => (
-                <tr key={f.id} className="border-t">
-                  <td className="py-2">
-                    <button
-                      type="button"
-                      className="text-left hover:text-primary transition-colors cursor-pointer"
-                      onClick={() => setPreviewFile(f)}
-                    >
-                      {f.name}
-                    </button>
-                  </td>
-                  <td className="py-2">{formatSize(f.size)}</td>
-                  <td className="py-2">
-                    {new Date(f.created_at).toLocaleString()}
-                  </td>
-                  <td className="py-2">
-                    <div className="flex gap-2">
-                      {canWrite && (
-                        <Button
-                          isIconOnly
-                          aria-label={`Share ${f.name}`}
-                          variant="light"
-                          onPress={() => openShareModal(f)}
-                        >
-                          <ShareIcon className="w-5 h-5" />
-                        </Button>
-                      )}
-                      <Button
-                        isIconOnly
-                        aria-label={`Download ${f.name}`}
-                        variant="light"
-                        onPress={() => handleDownload(f)}
-                      >
-                        <DownloadIcon className="w-5 h-5" />
-                      </Button>
-                      {canWrite && (
-                        <Button
-                          isIconOnly
-                          aria-label={`Delete ${f.name}`}
-                          variant="light"
-                          color="danger"
-                          onPress={() => {
-                            setDeleteId(f.id);
-                            confirm.onOpen();
-                          }}
-                        >
-                          <DeleteIcon className="w-5 h-5" />
-                        </Button>
-                      )}
-                    </div>
-                  </td>
+          <div className="overflow-x-auto -mx-4 px-4">
+            <table className="w-full text-left">
+              <thead>
+                <tr>
+                  <th className="pb-2 cursor-pointer select-none" onClick={() => toggleSort("name")}>
+                    Name<SortArrow field="name" sortBy={sortBy} sortAsc={sortAsc} />
+                  </th>
+                  <th className="pb-2 cursor-pointer select-none whitespace-nowrap" onClick={() => toggleSort("size")}>
+                    Size<SortArrow field="size" sortBy={sortBy} sortAsc={sortAsc} />
+                  </th>
+                  <th className="pb-2 cursor-pointer select-none whitespace-nowrap hidden sm:table-cell" onClick={() => toggleSort("created_at")}>
+                    Created<SortArrow field="created_at" sortBy={sortBy} sortAsc={sortAsc} />
+                  </th>
+                  <th className="pb-2"></th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
+              </thead>
+              <tbody>
+                {sortedFiles.map((f) => (
+                  <tr key={f.id} className="border-t">
+                    <td className="py-2">
+                      <button
+                        type="button"
+                        className="text-left hover:text-primary transition-colors cursor-pointer break-all"
+                        onClick={() => setPreviewFile(f)}
+                      >
+                        {f.name}
+                      </button>
+                    </td>
+                    <td className="py-2 whitespace-nowrap">{formatSize(f.size)}</td>
+                    <td className="py-2 whitespace-nowrap hidden sm:table-cell">
+                      {new Date(f.created_at).toLocaleString()}
+                    </td>
+                    <td className="py-2">
+                      <div className="flex gap-1 sm:gap-2">
+                        {canWrite && (
+                          <Button
+                            isIconOnly
+                            size="sm"
+                            aria-label={`Share ${f.name}`}
+                            variant="light"
+                            onPress={() => openShareModal(f)}
+                          >
+                            <ShareIcon className="w-4 h-4 sm:w-5 sm:h-5" />
+                          </Button>
+                        )}
+                        <Button
+                          isIconOnly
+                          size="sm"
+                          aria-label={`Download ${f.name}`}
+                          variant="light"
+                          onPress={() => handleDownload(f)}
+                        >
+                          <DownloadIcon className="w-4 h-4 sm:w-5 sm:h-5" />
+                        </Button>
+                        {canWrite && (
+                          <Button
+                            isIconOnly
+                            size="sm"
+                            aria-label={`Delete ${f.name}`}
+                            variant="light"
+                            color="danger"
+                            onPress={() => {
+                              setDeleteId(f.id);
+                              confirm.onOpen();
+                            }}
+                          >
+                            <DeleteIcon className="w-4 h-4 sm:w-5 sm:h-5" />
+                          </Button>
+                        )}
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         )}
       </div>
       <ConfirmDialog
@@ -440,14 +445,14 @@ function CredentialsPanel({bucket}: {bucket: Bucket}) {
         </svg>
       </button>
       {open && (
-        <div className="px-4 pb-4 flex flex-col gap-3">
-          <div>
+        <div className="px-4 pb-4 flex flex-col gap-3 overflow-hidden">
+          <div className="min-w-0">
             <p className="text-xs text-default-500 mb-1">Bucket ID</p>
-            <Snippet size="sm" variant="flat" symbol="">{bucket.id}</Snippet>
+            <Snippet size="sm" variant="flat" symbol="" classNames={{base: "max-w-full", pre: "whitespace-pre-wrap break-all"}}>{bucket.id}</Snippet>
           </div>
-          <div>
+          <div className="min-w-0">
             <p className="text-xs text-default-500 mb-1">Access Key</p>
-            <Snippet size="sm" variant="flat" symbol="">{bucket.access_key}</Snippet>
+            <Snippet size="sm" variant="flat" symbol="" classNames={{base: "max-w-full", pre: "whitespace-pre-wrap break-all"}}>{bucket.access_key}</Snippet>
           </div>
           <p className="text-xs text-default-500">
             Created {new Date(bucket.created_at).toLocaleString()}

--- a/webui/src/pages/landing/ui/landing-page.tsx
+++ b/webui/src/pages/landing/ui/landing-page.tsx
@@ -125,7 +125,7 @@ export function LandingPage() {
         <p className="text-default-500 text-center mb-12 max-w-xl mx-auto">
           Three steps from sign-up to a working distributed object store.
         </p>
-        <div className="grid sm:grid-cols-3 gap-8">
+        <div className="grid sm:grid-cols-2 md:grid-cols-3 gap-8">
           {steps.map((s) => (
             <div key={s.num} className="flex flex-col items-center text-center gap-3">
               <div className="flex items-center justify-center w-12 h-12 rounded-full bg-primary text-primary-foreground text-lg font-bold">
@@ -145,7 +145,7 @@ export function LandingPage() {
           <p className="text-default-500 text-center mb-12 max-w-xl mx-auto">
             Bring the storage you already have. SFree handles the rest.
           </p>
-          <div className="grid sm:grid-cols-3 gap-6">
+          <div className="grid sm:grid-cols-2 md:grid-cols-3 gap-6">
             {sources.map((s) => (
               <Card key={s.name} className="border border-default-200">
                 <CardBody className="flex flex-col items-center text-center gap-3 p-6">
@@ -184,7 +184,7 @@ export function LandingPage() {
           <p className="text-default-500 mb-8 max-w-xl mx-auto">
             SFree is in early access. Here is what that means right now.
           </p>
-          <div className="grid sm:grid-cols-3 gap-6 text-left">
+          <div className="grid sm:grid-cols-2 md:grid-cols-3 gap-6 text-left">
             <div className="p-5 rounded-xl border border-default-200 bg-background">
               <h3 className="font-semibold mb-2">Not for production-critical data</h3>
               <p className="text-default-500 text-sm">

--- a/webui/src/pages/source/ui/source-page.tsx
+++ b/webui/src/pages/source/ui/source-page.tsx
@@ -124,7 +124,7 @@ export function SourcePage() {
               <>
                 <CircularProgress
                   classNames={{
-                    svg: "w-36 h-36",
+                    svg: "w-24 h-24 sm:w-36 sm:h-36",
                     indicator:
                       health?.status === "healthy"
                         ? "stroke-success"
@@ -194,32 +194,34 @@ export function SourcePage() {
             description="Files will appear here once synced from the connected service."
           />
         ) : (
-          <table className="w-full text-left">
-            <thead>
-              <tr>
-                <th className="pb-2">Name</th>
-                <th className="pb-2">Size</th>
-                <th className="pb-2"></th>
-              </tr>
-            </thead>
-            <tbody>
-              {info.files.map((f) => (
-                <tr key={f.id} className="border-t">
-                  <td className="py-2">{f.name}</td>
-                  <td className="py-2">{formatSize(f.size)}</td>
-                  <td className="py-2">
-                    <Button
-                      isIconOnly
-                      variant="light"
-                      onPress={() => handleDownload(f)}
-                    >
-                      <DownloadIcon className="w-5 h-5" />
-                    </Button>
-                  </td>
+          <div className="overflow-x-auto -mx-4 px-4">
+            <table className="w-full text-left">
+              <thead>
+                <tr>
+                  <th className="pb-2">Name</th>
+                  <th className="pb-2 whitespace-nowrap">Size</th>
+                  <th className="pb-2"></th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
+              </thead>
+              <tbody>
+                {info.files.map((f) => (
+                  <tr key={f.id} className="border-t">
+                    <td className="py-2 break-all">{f.name}</td>
+                    <td className="py-2 whitespace-nowrap">{formatSize(f.size)}</td>
+                    <td className="py-2">
+                      <Button
+                        isIconOnly
+                        variant="light"
+                        onPress={() => handleDownload(f)}
+                      >
+                        <DownloadIcon className="w-5 h-5" />
+                      </Button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         )}
       </div>
     </div>

--- a/webui/src/shared/ui/confirm-dialog.tsx
+++ b/webui/src/shared/ui/confirm-dialog.tsx
@@ -20,7 +20,7 @@ export function ConfirmDialog({
   isConfirmLoading,
 }: Props) {
   return (
-    <Modal isOpen={isOpen} onOpenChange={onOpenChange}>
+    <Modal isOpen={isOpen} onOpenChange={onOpenChange} scrollBehavior="inside">
       <ModalContent>
         {(onClose) => (
           <>


### PR DESCRIPTION
## Summary
- Wraps tables (source files, bucket files) in horizontal scroll containers and hides the Created column on mobile to prevent layout overflow
- Fixes bucket page header/button wrapping and credentials Snippet overflow on small screens
- Makes CircularProgress responsive (smaller on mobile) and adds scroll behavior to all modals
- Restructures share dialogs for mobile: form inputs stack vertically, share URLs use break-all instead of truncate
- Adjusts landing page grids from `sm:grid-cols-3` to `sm:grid-cols-2 md:grid-cols-3` for better tablet readability

## Test plan
- [ ] Resize browser to 375px width — verify all core routes (landing, dashboard, sources, source detail, buckets, bucket detail) render without horizontal scroll traps
- [ ] Open share bucket dialog on mobile width — verify form fields stack properly and role select is full-width
- [ ] Open share file dialog on mobile width — verify URL is readable (break-all) and buttons are grouped
- [ ] Verify S3 credentials panel wraps long IDs/keys on narrow screens
- [ ] Check file table on bucket detail at ~640px — Created column should be hidden
- [ ] Verify landing page "How it works", "Supported sources", and "What to know" sections show 2 columns on tablet (~640px) and 3 on desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)