### PR TITLE
THE-840 Add batch file actions for bucket workspace

### DIFF
--- a/api-go/internal/app/router_routes.go
+++ b/api-go/internal/app/router_routes.go
@@ -78,6 +78,7 @@ func registerBucketFileRoutes(router *gin.Engine, cfg *config.Config, deps *rout
 	}
 	router.POST("/api/v1/buckets/:id/upload", protectedHandlers(limits, deps.auth, handlers.UploadFileWithFactory(deps.bucketRepo, deps.sourceRepo, deps.fileRepo, deps.grantRepo, routerUploadChunkSize(cfg), deps.sourceFactory))...)
 	router.GET("/api/v1/buckets/:id/files", protectedHandlers(limits, deps.auth, handlers.ListFiles(deps.bucketRepo, deps.fileRepo, deps.grantRepo))...)
+	router.POST("/api/v1/buckets/:id/files/batch-delete", protectedHandlers(limits, deps.auth, handlers.BatchDeleteFilesWithFactory(deps.bucketRepo, deps.sourceRepo, deps.fileRepo, deps.shareLinkRepo, deps.grantRepo, deps.sourceFactory))...)
 	router.GET("/api/v1/buckets/:id/files/:file_id/download", protectedHandlers(limits, deps.auth, handlers.DownloadFileWithFactory(deps.bucketRepo, deps.sourceRepo, deps.fileRepo, deps.grantRepo, deps.sourceFactory))...)
 	router.DELETE("/api/v1/buckets/:id/files/:file_id", protectedHandlers(limits, deps.auth, handlers.DeleteFileWithFactory(deps.bucketRepo, deps.sourceRepo, deps.fileRepo, deps.shareLinkRepo, deps.grantRepo, deps.sourceFactory))...)
 	if deps.shareLinkRepo == nil {

--- a/api-go/internal/docs/docs.go
+++ b/api-go/internal/docs/docs.go
@@ -797,6 +797,75 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/buckets/{id}/files/batch-delete": {
+            "post": {
+                "security": [
+                    {
+                        "BasicAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "buckets"
+                ],
+                "summary": "Delete multiple bucket files",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Bucket ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "File IDs",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.batchDeleteFilesRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.batchDeleteFilesResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/buckets/{id}/files/{file_id}": {
             "delete": {
                 "security": [
@@ -2348,6 +2417,65 @@ const docTemplate = `{
         }
     },
     "definitions": {
+        "handlers.batchDeleteFileIssue": {
+            "type": "object",
+            "properties": {
+                "error": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.batchDeleteFileResponse": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.batchDeleteFilesRequest": {
+            "type": "object",
+            "properties": {
+                "file_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "handlers.batchDeleteFilesResponse": {
+            "type": "object",
+            "properties": {
+                "deleted": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/handlers.batchDeleteFileResponse"
+                    }
+                },
+                "failed": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/handlers.batchDeleteFileIssue"
+                    }
+                },
+                "warnings": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/handlers.batchDeleteFileIssue"
+                    }
+                }
+            }
+        },
         "handlers.bucketResponse": {
             "type": "object",
             "properties": {

--- a/api-go/internal/handlers/bucket_delete_cleanup_test.go
+++ b/api-go/internal/handlers/bucket_delete_cleanup_test.go
@@ -1,7 +1,9 @@
 package handlers
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -13,6 +15,7 @@ import (
 	"github.com/example/sfree/api-go/internal/repository"
 	"github.com/gin-gonic/gin"
 	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
 )
 
 func TestDeleteFileCleansShareLinksBeforeObjectDelete(t *testing.T) {
@@ -82,6 +85,108 @@ func TestDeleteFileShareCleanupFailureReturns500AndSkipsObjectDelete(t *testing.
 	}
 	if !reflect.DeepEqual(events, []string{"share_file"}) {
 		t.Fatalf("unexpected event order: %v", events)
+	}
+}
+
+func TestBatchDeleteFilesDeletesUniqueRequestedFiles(t *testing.T) {
+	t.Parallel()
+
+	userID := primitive.NewObjectID()
+	bucketID := primitive.NewObjectID()
+	fileAID := primitive.NewObjectID()
+	fileBID := primitive.NewObjectID()
+	shareDeleted := []primitive.ObjectID{}
+	objectDeleted := []primitive.ObjectID{}
+
+	router := gin.New()
+	router.POST("/buckets/:id/files/batch-delete",
+		setUserID(userID.Hex()),
+		func(c *gin.Context) {
+			handleBatchDeleteFiles(
+				c,
+				fakeBucketDeleteStore{bucket: testDeleteBucket(bucketID, userID)},
+				fakeBatchDeleteFileReader{files: map[primitive.ObjectID]*repository.File{
+					fileAID: {ID: fileAID, BucketID: bucketID, Name: "alpha.txt", CreatedAt: time.Now().UTC()},
+					fileBID: {ID: fileBID, BucketID: bucketID, Name: "beta.txt", CreatedAt: time.Now().UTC()},
+				}},
+				&fakeBatchShareLinkCleanup{deletedIDs: &shareDeleted},
+				&fakeBatchObjectFileDelete{deletedIDs: &objectDeleted},
+				nil,
+			)
+		},
+	)
+
+	body, _ := json.Marshal(batchDeleteFilesRequest{
+		FileIDs: []string{fileAID.Hex(), fileAID.Hex(), fileBID.Hex()},
+	})
+	req, _ := http.NewRequest(http.MethodPost, "/buckets/"+bucketID.Hex()+"/files/batch-delete", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var resp batchDeleteFilesResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+	if len(resp.Deleted) != 2 || len(resp.Failed) != 0 || len(resp.Warnings) != 0 {
+		t.Fatalf("unexpected response: %+v", resp)
+	}
+	if !reflect.DeepEqual(shareDeleted, []primitive.ObjectID{fileAID, fileBID}) {
+		t.Fatalf("unexpected share cleanup ids: %v", shareDeleted)
+	}
+	if !reflect.DeepEqual(objectDeleted, []primitive.ObjectID{fileAID, fileBID}) {
+		t.Fatalf("unexpected object delete ids: %v", objectDeleted)
+	}
+}
+
+func TestBatchDeleteFilesReportsMissingFilesWithoutStopping(t *testing.T) {
+	t.Parallel()
+
+	userID := primitive.NewObjectID()
+	bucketID := primitive.NewObjectID()
+	fileID := primitive.NewObjectID()
+	missingID := primitive.NewObjectID()
+
+	router := gin.New()
+	router.POST("/buckets/:id/files/batch-delete",
+		setUserID(userID.Hex()),
+		func(c *gin.Context) {
+			handleBatchDeleteFiles(
+				c,
+				fakeBucketDeleteStore{bucket: testDeleteBucket(bucketID, userID)},
+				fakeBatchDeleteFileReader{files: map[primitive.ObjectID]*repository.File{
+					fileID: {ID: fileID, BucketID: bucketID, Name: "keep-going.txt", CreatedAt: time.Now().UTC()},
+				}},
+				&fakeBatchShareLinkCleanup{},
+				&fakeBatchObjectFileDelete{},
+				nil,
+			)
+		},
+	)
+
+	body, _ := json.Marshal(batchDeleteFilesRequest{
+		FileIDs: []string{fileID.Hex(), missingID.Hex()},
+	})
+	req, _ := http.NewRequest(http.MethodPost, "/buckets/"+bucketID.Hex()+"/files/batch-delete", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var resp batchDeleteFilesResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+	if len(resp.Deleted) != 1 || resp.Deleted[0].ID != fileID.Hex() {
+		t.Fatalf("unexpected deleted response: %+v", resp.Deleted)
+	}
+	if len(resp.Failed) != 1 || resp.Failed[0].ID != missingID.Hex() || resp.Failed[0].Error != "File not found" {
+		t.Fatalf("unexpected failed response: %+v", resp.Failed)
 	}
 }
 
@@ -219,6 +324,22 @@ func (f fakeDeleteFileReader) GetByID(_ context.Context, _ primitive.ObjectID) (
 	return f.file, nil
 }
 
+type fakeBatchDeleteFileReader struct {
+	files map[primitive.ObjectID]*repository.File
+	err   error
+}
+
+func (f fakeBatchDeleteFileReader) GetByID(_ context.Context, id primitive.ObjectID) (*repository.File, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	file, ok := f.files[id]
+	if !ok {
+		return nil, mongo.ErrNoDocuments
+	}
+	return file, nil
+}
+
 type fakeShareLinkCleanup struct {
 	events *[]string
 	err    error
@@ -259,6 +380,31 @@ type fakeObjectFileDelete struct {
 func (f *fakeObjectFileDelete) DeleteFile(_ context.Context, _ primitive.ObjectID, _ primitive.ObjectID) (manager.DeleteObjectResult, error) {
 	if f.events != nil {
 		*f.events = append(*f.events, "object_file")
+	}
+	return f.result, f.err
+}
+
+type fakeBatchShareLinkCleanup struct {
+	deletedIDs *[]primitive.ObjectID
+	err        error
+}
+
+func (f *fakeBatchShareLinkCleanup) DeleteByFile(_ context.Context, fileID primitive.ObjectID) error {
+	if f.deletedIDs != nil {
+		*f.deletedIDs = append(*f.deletedIDs, fileID)
+	}
+	return f.err
+}
+
+type fakeBatchObjectFileDelete struct {
+	deletedIDs *[]primitive.ObjectID
+	err        error
+	result     manager.DeleteObjectResult
+}
+
+func (f *fakeBatchObjectFileDelete) DeleteFile(_ context.Context, _ primitive.ObjectID, fileID primitive.ObjectID) (manager.DeleteObjectResult, error) {
+	if f.deletedIDs != nil {
+		*f.deletedIDs = append(*f.deletedIDs, fileID)
 	}
 	return f.result, f.err
 }

--- a/api-go/internal/handlers/bucket_files.go
+++ b/api-go/internal/handlers/bucket_files.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"errors"
 	"log/slog"
 	"net/http"
@@ -10,6 +11,7 @@ import (
 	"github.com/example/sfree/api-go/internal/manager"
 	"github.com/example/sfree/api-go/internal/repository"
 	"github.com/gin-gonic/gin"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
@@ -24,6 +26,29 @@ type fileResponse struct {
 	Name      string    `json:"name"`
 	CreatedAt time.Time `json:"created_at"`
 	Size      int64     `json:"size"`
+}
+
+const maxBatchDeleteFiles = 100
+
+type batchDeleteFilesRequest struct {
+	FileIDs []string `json:"file_ids"`
+}
+
+type batchDeleteFileResponse struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type batchDeleteFileIssue struct {
+	ID    string `json:"id"`
+	Name  string `json:"name,omitempty"`
+	Error string `json:"error"`
+}
+
+type batchDeleteFilesResponse struct {
+	Deleted  []batchDeleteFileResponse `json:"deleted"`
+	Failed   []batchDeleteFileIssue    `json:"failed"`
+	Warnings []batchDeleteFileIssue    `json:"warnings,omitempty"`
 }
 
 // UploadFile godoc
@@ -258,6 +283,107 @@ func DeleteFileWithFactory(bucketRepo *repository.BucketRepository, sourceRepo *
 	}
 }
 
+// BatchDeleteFiles godoc
+// @Summary Delete multiple bucket files
+// @Tags buckets
+// @Accept json
+// @Produce json
+// @Param id path string true "Bucket ID"
+// @Param request body batchDeleteFilesRequest true "File IDs"
+// @Success 200 {object} batchDeleteFilesResponse
+// @Failure 400 {string} string ""
+// @Failure 401 {string} string ""
+// @Failure 404 {string} string ""
+// @Failure 500 {string} string ""
+// @Security BasicAuth
+// @Router /api/v1/buckets/{id}/files/batch-delete [post]
+func BatchDeleteFiles(bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository, shareLinkRepo *repository.ShareLinkRepository, grantRepo *repository.BucketGrantRepository) gin.HandlerFunc {
+	return BatchDeleteFilesWithFactory(bucketRepo, sourceRepo, fileRepo, shareLinkRepo, grantRepo, nil)
+}
+
+func BatchDeleteFilesWithFactory(bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository, shareLinkRepo *repository.ShareLinkRepository, grantRepo *repository.BucketGrantRepository, factory manager.SourceClientFactory) gin.HandlerFunc {
+	objectSvc := manager.NewObjectDeleteServiceWithSourceClientFactory(sourceRepo, fileRepo, factory)
+	return func(c *gin.Context) {
+		ctx := c.Request.Context()
+		if bucketRepo == nil || sourceRepo == nil || fileRepo == nil || shareLinkRepo == nil {
+			slog.ErrorContext(ctx, "batch delete files: repository is nil")
+			c.Status(http.StatusServiceUnavailable)
+			return
+		}
+		var grantReader bucketAccessGrantReader
+		if grantRepo != nil {
+			grantReader = grantRepo
+		}
+		handleBatchDeleteFiles(c, bucketRepo, fileRepo, shareLinkRepo, objectSvc, grantReader)
+	}
+}
+
+func handleBatchDeleteFiles(c *gin.Context, bucketRepo bucketAccessBucketReader, fileRepo fileByIDReader, shareLinkRepo shareLinkFileDeleter, objectSvc objectFileDeleter, grantRepo bucketAccessGrantReader) {
+	ctx := c.Request.Context()
+	if bucketRepo == nil || fileRepo == nil || shareLinkRepo == nil || objectSvc == nil {
+		slog.ErrorContext(ctx, "batch delete files: repository is nil")
+		c.Status(http.StatusServiceUnavailable)
+		return
+	}
+
+	acc := requireBucketAccessFor(c, bucketRepo, grantRepo, repository.RoleEditor)
+	if acc == nil {
+		return
+	}
+	bucketID := acc.Bucket.ID
+
+	var req batchDeleteFilesRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "file_ids must be a non-empty JSON array"})
+		return
+	}
+	fileIDs, ok := normalizeBatchDeleteFileIDs(req.FileIDs)
+	if !ok {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "file_ids must contain between 1 and 100 valid file IDs"})
+		return
+	}
+
+	resp := batchDeleteFilesResponse{
+		Deleted: make([]batchDeleteFileResponse, 0, len(fileIDs)),
+		Failed:  make([]batchDeleteFileIssue, 0),
+	}
+
+	for _, fileID := range fileIDs {
+		fileDoc, result, err := deleteBucketFile(ctx, bucketID, fileID, fileRepo, shareLinkRepo, objectSvc)
+		if err != nil {
+			if errors.Is(err, manager.ErrObjectNotFound) {
+				resp.Failed = append(resp.Failed, batchDeleteFileIssue{
+					ID:    fileID.Hex(),
+					Error: "File not found",
+				})
+				continue
+			}
+			slog.ErrorContext(ctx, "batch delete files: delete file", slog.String("file_id", fileID.Hex()), slog.String("error", err.Error()))
+			resp.Failed = append(resp.Failed, batchDeleteFileIssue{
+				ID:    fileID.Hex(),
+				Name:  batchDeleteFileName(fileDoc),
+				Error: "Delete failed",
+			})
+			continue
+		}
+
+		resp.Deleted = append(resp.Deleted, batchDeleteFileResponse{
+			ID:   fileID.Hex(),
+			Name: fileDoc.Name,
+		})
+		if result.CleanupErr != nil {
+			slog.WarnContext(ctx, "batch delete files: chunk cleanup warning", slog.String("file_id", fileID.Hex()), slog.String("error", result.CleanupErr.Error()))
+			resp.Warnings = append(resp.Warnings, batchDeleteFileIssue{
+				ID:    fileID.Hex(),
+				Name:  fileDoc.Name,
+				Error: "File deleted, but chunk cleanup needs follow-up",
+			})
+		}
+	}
+
+	c.JSON(http.StatusOK, resp)
+}
+
 func handleDeleteFile(c *gin.Context, bucketRepo bucketAccessBucketReader, fileRepo fileByIDReader, shareLinkRepo shareLinkFileDeleter, objectSvc objectFileDeleter, grantRepo bucketAccessGrantReader) {
 	ctx := c.Request.Context()
 	if bucketRepo == nil || fileRepo == nil || shareLinkRepo == nil || objectSvc == nil {
@@ -276,26 +402,7 @@ func handleDeleteFile(c *gin.Context, bucketRepo bucketAccessBucketReader, fileR
 	if !ok {
 		return
 	}
-	fileDoc, err := fileRepo.GetByID(ctx, fileID)
-	if err != nil {
-		if err == mongo.ErrNoDocuments {
-			c.Status(http.StatusNotFound)
-			return
-		}
-		slog.ErrorContext(ctx, "delete file: get file", slog.String("error", err.Error()))
-		c.Status(http.StatusInternalServerError)
-		return
-	}
-	if fileDoc.BucketID != bucketID {
-		c.Status(http.StatusNotFound)
-		return
-	}
-	if err := shareLinkRepo.DeleteByFile(ctx, fileID); err != nil {
-		slog.ErrorContext(ctx, "delete file: cleanup share links", slog.String("error", err.Error()))
-		c.Status(http.StatusInternalServerError)
-		return
-	}
-	result, err := objectSvc.DeleteFile(ctx, bucketID, fileID)
+	_, result, err := deleteBucketFile(ctx, bucketID, fileID, fileRepo, shareLinkRepo, objectSvc)
 	if err != nil {
 		if errors.Is(err, manager.ErrObjectNotFound) {
 			c.Status(http.StatusNotFound)
@@ -311,4 +418,55 @@ func handleDeleteFile(c *gin.Context, bucketRepo bucketAccessBucketReader, fileR
 		return
 	}
 	c.Status(http.StatusOK)
+}
+
+func deleteBucketFile(ctx context.Context, bucketID, fileID primitive.ObjectID, fileRepo fileByIDReader, shareLinkRepo shareLinkFileDeleter, objectSvc objectFileDeleter) (*repository.File, manager.DeleteObjectResult, error) {
+	fileDoc, err := fileRepo.GetByID(ctx, fileID)
+	if err != nil {
+		if err == mongo.ErrNoDocuments {
+			return nil, manager.DeleteObjectResult{}, manager.ErrObjectNotFound
+		}
+		return nil, manager.DeleteObjectResult{}, err
+	}
+	if fileDoc.BucketID != bucketID {
+		return nil, manager.DeleteObjectResult{}, manager.ErrObjectNotFound
+	}
+	if err := shareLinkRepo.DeleteByFile(ctx, fileID); err != nil {
+		return fileDoc, manager.DeleteObjectResult{}, err
+	}
+	result, err := objectSvc.DeleteFile(ctx, bucketID, fileID)
+	if err != nil {
+		return fileDoc, result, err
+	}
+	return fileDoc, result, nil
+}
+
+func normalizeBatchDeleteFileIDs(raw []string) ([]primitive.ObjectID, bool) {
+	if len(raw) == 0 || len(raw) > maxBatchDeleteFiles {
+		return nil, false
+	}
+	seen := make(map[primitive.ObjectID]struct{}, len(raw))
+	fileIDs := make([]primitive.ObjectID, 0, len(raw))
+	for _, fileIDHex := range raw {
+		fileID, err := primitive.ObjectIDFromHex(strings.TrimSpace(fileIDHex))
+		if err != nil {
+			return nil, false
+		}
+		if _, ok := seen[fileID]; ok {
+			continue
+		}
+		seen[fileID] = struct{}{}
+		fileIDs = append(fileIDs, fileID)
+	}
+	if len(fileIDs) == 0 {
+		return nil, false
+	}
+	return fileIDs, true
+}
+
+func batchDeleteFileName(file *repository.File) string {
+	if file == nil {
+		return ""
+	}
+	return file.Name
 }

--- a/webui/src/pages/bucket/ui/bucket-page.tsx
+++ b/webui/src/pages/bucket/ui/bucket-page.tsx
@@ -1,5 +1,6 @@
 import {
   Button,
+  Checkbox,
   Chip,
   Input,
   Snippet,
@@ -11,12 +12,13 @@ import {useCallback, useDeferredValue, useEffect, useMemo, useRef, useState} fro
 import {Link, useNavigate, useParams} from "react-router-dom";
 import {
   deleteFile,
+  deleteFiles,
   downloadFile,
   getBucket,
   listFiles,
   uploadFile,
 } from "../../../shared/api/buckets";
-import type {Bucket, FileInfo} from "../../../shared/api/buckets";
+import type {BatchDeleteFilesResponse, Bucket, FileInfo} from "../../../shared/api/buckets";
 import {DownloadIcon, ShareIcon} from "../../../shared/icons";
 import {DeleteIcon} from "@heroui/shared-icons";
 import {ConfirmDialog, EmptyState} from "../../../shared/ui";
@@ -47,9 +49,10 @@ export function BucketPage() {
   const hasLoadedRef = useRef(false);
   const requestIDRef = useRef(0);
   const confirm = useDisclosure();
-  const [deleteId, setDeleteId] = useState<string | null>(null);
+  const [pendingDeleteFiles, setPendingDeleteFiles] = useState<FileInfo[]>([]);
   const [isDeleting, setIsDeleting] = useState(false);
   const [previewFile, setPreviewFile] = useState<FileInfo | null>(null);
+  const [selectedFileIds, setSelectedFileIds] = useState<string[]>([]);
 
   const shareBucket = useDisclosure();
   const [shareFile, setShareFile] = useState<FileInfo | null>(null);
@@ -133,12 +136,19 @@ export function BucketPage() {
   useEffect(() => {
     hasLoadedRef.current = false;
     setSearchQuery("");
+    setSelectedFileIds([]);
+    setPendingDeleteFiles([]);
   }, [id]);
 
   useEffect(() => {
     if (!id) return;
     void load(hasLoadedRef.current ? "refresh" : "initial");
   }, [id, load]);
+
+  useEffect(() => {
+    const visibleFileIDs = new Set(files.map((file) => file.id));
+    setSelectedFileIds((prev) => prev.filter((fileID) => visibleFileIDs.has(fileID)));
+  }, [files]);
 
   async function handleUpload(file: File) {
     if (!id || !bucket || !canWriteFiles(bucket)) return;
@@ -164,16 +174,27 @@ export function BucketPage() {
   }
 
   async function handleDelete() {
-    if (!id || !deleteId) return;
+    if (!id || pendingDeleteFiles.length === 0) return;
     setIsDeleting(true);
     try {
-      await deleteFile(id, deleteId);
-      addToast({title: "File deleted", color: "success", timeout: 4000});
+      if (pendingDeleteFiles.length === 1) {
+        await deleteFile(id, pendingDeleteFiles[0].id);
+        addToast({title: "File deleted", color: "success", timeout: 4000});
+        setSelectedFileIds((prev) => prev.filter((fileID) => fileID !== pendingDeleteFiles[0].id));
+      } else {
+        const result = await deleteFiles(id, pendingDeleteFiles.map((file) => file.id));
+        setSelectedFileIds((prev) => {
+          const deleted = new Set(result.deleted.map((file) => file.id));
+          return prev.filter((fileID) => !deleted.has(fileID));
+        });
+        showBatchDeleteToast(result, pendingDeleteFiles.length);
+      }
       await load("refresh");
     } catch (err) {
       showErrorToast(err);
     } finally {
       setIsDeleting(false);
+      setPendingDeleteFiles([]);
       confirm.onClose();
     }
   }
@@ -189,6 +210,38 @@ export function BucketPage() {
     } catch (err) {
       showErrorToast(err);
     }
+  }
+
+  const selectedFileIDSet = useMemo(() => new Set(selectedFileIds), [selectedFileIds]);
+  const selectedFiles = useMemo(
+    () => sortedFiles.filter((file) => selectedFileIDSet.has(file.id)),
+    [selectedFileIDSet, sortedFiles],
+  );
+  const selectedCount = selectedFiles.length;
+  const allVisibleSelected = sortedFiles.length > 0 && selectedCount === sortedFiles.length;
+  const someVisibleSelected = selectedCount > 0 && !allVisibleSelected;
+
+  function setFileSelected(fileID: string, selected: boolean) {
+    setSelectedFileIds((prev) => {
+      if (selected) {
+        return prev.includes(fileID) ? prev : [...prev, fileID];
+      }
+      return prev.filter((currentID) => currentID !== fileID);
+    });
+  }
+
+  function setAllVisibleSelected(selected: boolean) {
+    if (selected) {
+      setSelectedFileIds(sortedFiles.map((file) => file.id));
+      return;
+    }
+    setSelectedFileIds([]);
+  }
+
+  function openDeleteDialog(filesToDelete: FileInfo[]) {
+    if (filesToDelete.length === 0) return;
+    setPendingDeleteFiles(filesToDelete);
+    confirm.onOpen();
   }
 
   if (isLoading) {
@@ -305,6 +358,30 @@ export function BucketPage() {
             </p>
           ) : null}
         </div>
+        {canWrite ? (
+          <div className="mb-4 flex flex-col gap-3 rounded-lg border border-divider bg-content2/60 p-3 md:flex-row md:items-center md:justify-between">
+            <div className="flex flex-col gap-1">
+              <p className="text-sm font-medium">
+                {selectedCount === 0
+                  ? "Select files to delete in one step"
+                  : selectedCount === 1
+                    ? "1 file selected"
+                    : `${selectedCount} files selected`}
+              </p>
+              <p className="text-xs text-default-500">
+                Multi-file download is deferred for now. Use the row download action for each file.
+              </p>
+            </div>
+            <div className="flex gap-2">
+              <Button variant="flat" onPress={() => setSelectedFileIds([])} isDisabled={selectedCount === 0}>
+                Clear
+              </Button>
+              <Button color="danger" onPress={() => openDeleteDialog(selectedFiles)} isDisabled={selectedCount === 0}>
+                Delete Selected
+              </Button>
+            </div>
+          </div>
+        ) : null}
         {sortedFiles.length === 0 ? (
           <EmptyState
             title={emptyTitle}
@@ -316,6 +393,16 @@ export function BucketPage() {
           <table className="w-full text-left">
             <thead>
               <tr>
+                {canWrite ? (
+                  <th className="w-12 pb-2">
+                    <Checkbox
+                      aria-label={allVisibleSelected ? "Unselect all visible files" : "Select all visible files"}
+                      isSelected={allVisibleSelected}
+                      isIndeterminate={someVisibleSelected}
+                      onValueChange={setAllVisibleSelected}
+                    />
+                  </th>
+                ) : null}
                 <th className="pb-2 cursor-pointer select-none" onClick={() => toggleSort("name")}>
                   Name<SortArrow field="name" sortBy={sortBy} sortAsc={sortAsc} />
                 </th>
@@ -331,6 +418,15 @@ export function BucketPage() {
             <tbody>
               {sortedFiles.map((f) => (
                 <tr key={f.id} className="border-t">
+                  {canWrite ? (
+                    <td className="py-2 pr-3 align-middle">
+                      <Checkbox
+                        aria-label={`Select ${f.name}`}
+                        isSelected={selectedFileIDSet.has(f.id)}
+                        onValueChange={(selected) => setFileSelected(f.id, selected)}
+                      />
+                    </td>
+                  ) : null}
                   <td className="py-2">
                     <button
                       type="button"
@@ -370,10 +466,7 @@ export function BucketPage() {
                           aria-label={`Delete ${f.name}`}
                           variant="light"
                           color="danger"
-                          onPress={() => {
-                            setDeleteId(f.id);
-                            confirm.onOpen();
-                          }}
+                          onPress={() => openDeleteDialog([f])}
                         >
                           <DeleteIcon className="w-5 h-5" />
                         </Button>
@@ -389,13 +482,17 @@ export function BucketPage() {
       <ConfirmDialog
         isOpen={confirm.isOpen}
         onOpenChange={(open) => {
-          if (!open) setDeleteId(null);
+          if (!open) setPendingDeleteFiles([]);
           confirm.onOpenChange();
         }}
-        title="Delete file?"
-        message="Are you sure you want to delete this file?"
+        title={pendingDeleteFiles.length > 1 ? "Delete selected files?" : "Delete file?"}
+        message={
+          pendingDeleteFiles.length > 1
+            ? `Are you sure you want to delete ${pendingDeleteFiles.length} files? This cannot be undone.`
+            : "Are you sure you want to delete this file?"
+        }
         onConfirm={handleDelete}
-        confirmLabel="Delete"
+        confirmLabel={pendingDeleteFiles.length > 1 ? "Delete Selected" : "Delete"}
         isConfirmLoading={isDeleting}
       />
       <FilePreviewModal
@@ -473,4 +570,50 @@ function canManageBucket(bucket: Bucket) {
 
 function canWriteFiles(bucket: Bucket) {
   return bucket.role === "owner" || bucket.role === "editor";
+}
+
+function showBatchDeleteToast(result: BatchDeleteFilesResponse, requestedCount: number) {
+  const deletedCount = result.deleted.length;
+  const failedCount = result.failed.length;
+  const warningCount = result.warnings.length;
+
+  if (deletedCount === requestedCount && failedCount === 0 && warningCount === 0) {
+    addToast({
+      title: deletedCount === 1 ? "File deleted" : `${deletedCount} files deleted`,
+      color: "success",
+      timeout: 4000,
+    });
+    return;
+  }
+
+  if (deletedCount > 0 && failedCount === 0) {
+    addToast({
+      title: deletedCount === 1 ? "File deleted" : `${deletedCount} files deleted`,
+      description: warningCount === 1
+        ? "Server cleanup reported a warning for 1 file."
+        : `Server cleanup reported warnings for ${warningCount} files.`,
+      color: "warning",
+      timeout: 6000,
+    });
+    return;
+  }
+
+  if (deletedCount > 0) {
+    addToast({
+      title: `Deleted ${deletedCount} of ${requestedCount} files`,
+      description: failedCount === 1
+        ? "1 file could not be deleted."
+        : `${failedCount} files could not be deleted.`,
+      color: "warning",
+      timeout: 6000,
+    });
+    return;
+  }
+
+  addToast({
+    title: "No files deleted",
+    description: failedCount === 1 ? result.failed[0].error : `${failedCount} files could not be deleted.`,
+    color: "danger",
+    timeout: 6000,
+  });
 }

--- a/webui/src/shared/api/buckets.ts
+++ b/webui/src/shared/api/buckets.ts
@@ -141,7 +141,7 @@ export async function deleteFiles(
   bucketId: string,
   fileIds: string[],
 ): Promise<BatchDeleteFilesResponse> {
-  return apiJson<BatchDeleteFilesResponse>(
+  const result = await apiJson<Partial<BatchDeleteFilesResponse>>(
     `/buckets/${bucketId}/files/batch-delete`,
     "Failed to delete files",
     {
@@ -149,4 +149,9 @@ export async function deleteFiles(
       json: {file_ids: fileIds},
     },
   );
+  return {
+    deleted: result.deleted ?? [],
+    failed: result.failed ?? [],
+    warnings: result.warnings ?? [],
+  };
 }

--- a/webui/src/shared/api/buckets.ts
+++ b/webui/src/shared/api/buckets.ts
@@ -16,6 +16,23 @@ export type FileInfo = {
   size: number;
 };
 
+export type BatchDeleteFileResult = {
+  id: string;
+  name: string;
+};
+
+export type BatchDeleteFileIssue = {
+  id: string;
+  name?: string;
+  error: string;
+};
+
+export type BatchDeleteFilesResponse = {
+  deleted: BatchDeleteFileResult[];
+  failed: BatchDeleteFileIssue[];
+  warnings: BatchDeleteFileIssue[];
+};
+
 type CreateBucketResponse = {
   key: string;
   access_key: string;
@@ -116,6 +133,20 @@ export async function deleteFile(
     "Failed to delete file",
     {
       method: "DELETE",
+    },
+  );
+}
+
+export async function deleteFiles(
+  bucketId: string,
+  fileIds: string[],
+): Promise<BatchDeleteFilesResponse> {
+  return apiJson<BatchDeleteFilesResponse>(
+    `/buckets/${bucketId}/files/batch-delete`,
+    "Failed to delete files",
+    {
+      method: "POST",
+      json: {file_ids: fileIds},
     },
   );
 }


### PR DESCRIPTION
## Summary
- add a bounded batch delete API for bucket files with per-file deleted/failed/warning results
- add bucket workspace multi-select and batch delete UI flow
- explicitly defer multi-file download in this slice instead of shipping an implicit archive path

## Validation
- go test ./internal/handlers -run 'Test(BatchDeleteFiles|DeleteFile)'\n- ./node_modules/.bin/tsc -b --pretty false\n\n## Links\n- THE-840\n- public issue #152\n