### PR TITLE
[codex] Add first-slice S3 conditional reads for GET and HEAD

### DIFF
--- a/api-go/internal/e2e/s3_compat_object_test.go
+++ b/api-go/internal/e2e/s3_compat_object_test.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 )
 
 // against the SFree S3-compatible API.
@@ -438,4 +439,68 @@ func TestS3CompatHeadObject(t *testing.T) {
 
 	// Cleanup
 	s3Do(t, http.MethodDelete, s3URL, bucket.AccessKey, bucket.AccessSecret, env.Region, nil)
+}
+
+func TestS3CompatObjectConditionalReads(t *testing.T) {
+	env, ok := loadS3E2EEnv()
+	if !ok {
+		t.Skip("E2E_S3_ENDPOINT not set; skipping S3 E2E tests")
+	}
+
+	suffix := uniqueSuffix()
+	ts, bucket := setupS3CompatTest(t, env, suffix)
+
+	objectKey := "conditional-" + suffix + ".txt"
+	objectContent := []byte("conditional read test payload")
+	s3URL := fmt.Sprintf("%s/api/s3/%s/%s", ts.URL, bucket.Key, objectKey)
+
+	status, body := s3Do(t, http.MethodPut, s3URL, bucket.AccessKey, bucket.AccessSecret, env.Region, objectContent)
+	if status != http.StatusOK {
+		t.Fatalf("PUT object: expected 200, got %d: %s", status, body)
+	}
+
+	status, headers, body := s3DoWithHeaders(t, http.MethodHead, s3URL, bucket.AccessKey, bucket.AccessSecret, env.Region, nil, nil)
+	if status != http.StatusOK {
+		t.Fatalf("HEAD object: expected 200, got %d: %s", status, body)
+	}
+	etag := headers.Get("ETag")
+	lastModified := headers.Get("Last-Modified")
+	if etag == "" || lastModified == "" {
+		t.Fatalf("expected ETag and Last-Modified, got etag=%q last-modified=%q", etag, lastModified)
+	}
+
+	status, _, body = s3DoWithHeaders(t, http.MethodGet, s3URL, bucket.AccessKey, bucket.AccessSecret, env.Region, nil, map[string]string{"If-Match": etag})
+	if status != http.StatusOK || !bytes.Equal(body, objectContent) {
+		t.Fatalf("GET If-Match mismatch: status=%d body=%q", status, body)
+	}
+
+	status, _, body = s3DoWithHeaders(t, http.MethodHead, s3URL, bucket.AccessKey, bucket.AccessSecret, env.Region, nil, map[string]string{"If-None-Match": etag})
+	if status != http.StatusNotModified || len(body) != 0 {
+		t.Fatalf("HEAD If-None-Match mismatch: status=%d body=%q", status, body)
+	}
+
+	status, _, body = s3DoWithHeaders(t, http.MethodGet, s3URL, bucket.AccessKey, bucket.AccessSecret, env.Region, nil, map[string]string{"If-Match": `"other-etag"`})
+	if status != http.StatusPreconditionFailed {
+		t.Fatalf("GET If-Match mismatch: expected 412, got %d: %s", status, body)
+	}
+
+	status, _, body = s3DoWithHeaders(t, http.MethodGet, s3URL, bucket.AccessKey, bucket.AccessSecret, env.Region, nil, map[string]string{"If-Modified-Since": lastModified})
+	if status != http.StatusNotModified {
+		t.Fatalf("GET If-Modified-Since: expected 304, got %d: %s", status, body)
+	}
+
+	status, _, body = s3DoWithHeaders(t, http.MethodHead, s3URL, bucket.AccessKey, bucket.AccessSecret, env.Region, nil, map[string]string{
+		"If-Unmodified-Since": time.Unix(0, 0).UTC().Format(http.TimeFormat),
+	})
+	if status != http.StatusPreconditionFailed {
+		t.Fatalf("HEAD If-Unmodified-Since: expected 412, got %d: %s", status, body)
+	}
+
+	status, _, body = s3DoWithHeaders(t, http.MethodGet, s3URL, bucket.AccessKey, bucket.AccessSecret, env.Region, nil, map[string]string{
+		"If-None-Match":     `"other-etag"`,
+		"If-Modified-Since": time.Now().UTC().Add(time.Hour).Format(http.TimeFormat),
+	})
+	if status != http.StatusOK || !bytes.Equal(body, objectContent) {
+		t.Fatalf("GET combined conditional headers mismatch: status=%d body=%q", status, body)
+	}
 }

--- a/api-go/internal/handlers/s3_get_test.go
+++ b/api-go/internal/handlers/s3_get_test.go
@@ -372,3 +372,160 @@ func TestGetObjectRangeStreamsBodyOnce(t *testing.T) {
 		t.Fatalf("expected Content-Range bytes 1-3/7, got %q", got)
 	}
 }
+
+func TestGetObjectIfNoneMatchReturnsNotModifiedWithoutStreaming(t *testing.T) {
+	origStream := streamS3Object
+	origStreamRange := streamS3ObjectRange
+	t.Cleanup(func() {
+		streamS3Object = origStream
+		streamS3ObjectRange = origStreamRange
+	})
+	streamS3Object = func(_ context.Context, _ *repository.SourceRepository, _ *repository.File, _ io.Writer) error {
+		t.Fatal("expected no full-object stream")
+		return nil
+	}
+	streamS3ObjectRange = func(_ context.Context, _ *repository.SourceRepository, _ *repository.File, _ io.Writer, _, _ int64) error {
+		t.Fatal("expected no range stream")
+		return nil
+	}
+
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("accessKey", "access-key")
+		c.Next()
+	})
+	r.GET("/api/s3/:bucket/*object", getObjectFailureTestHandler(t))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/s3/bucket/object.txt", nil)
+	req.Header.Set("If-None-Match", `"persisted-etag"`)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotModified {
+		t.Fatalf("expected 304, got %d", w.Code)
+	}
+	if body := w.Body.String(); body != "" {
+		t.Fatalf("expected empty body, got %q", body)
+	}
+	if got := w.Header().Get("ETag"); got != `"persisted-etag"` {
+		t.Fatalf("expected persisted ETag header, got %q", got)
+	}
+}
+
+func TestGetObjectIfMatchMismatchReturnsPreconditionFailedWithoutStreaming(t *testing.T) {
+	origStream := streamS3Object
+	origStreamRange := streamS3ObjectRange
+	t.Cleanup(func() {
+		streamS3Object = origStream
+		streamS3ObjectRange = origStreamRange
+	})
+	streamS3Object = func(_ context.Context, _ *repository.SourceRepository, _ *repository.File, _ io.Writer) error {
+		t.Fatal("expected no full-object stream")
+		return nil
+	}
+	streamS3ObjectRange = func(_ context.Context, _ *repository.SourceRepository, _ *repository.File, _ io.Writer, _, _ int64) error {
+		t.Fatal("expected no range stream")
+		return nil
+	}
+
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("accessKey", "access-key")
+		c.Next()
+	})
+	r.GET("/api/s3/:bucket/*object", getObjectFailureTestHandler(t))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/s3/bucket/object.txt", nil)
+	req.Header.Set("If-Match", `"other-etag"`)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusPreconditionFailed {
+		t.Fatalf("expected 412, got %d", w.Code)
+	}
+	if body := w.Body.String(); body != "" {
+		t.Fatalf("expected empty body, got %q", body)
+	}
+	if got := w.Header().Get("ETag"); got != `"persisted-etag"` {
+		t.Fatalf("expected persisted ETag header, got %q", got)
+	}
+}
+
+func TestGetObjectIfNoneMatchTakesPrecedenceOverIfModifiedSince(t *testing.T) {
+	origStream := streamS3Object
+	origStreamRange := streamS3ObjectRange
+	t.Cleanup(func() {
+		streamS3Object = origStream
+		streamS3ObjectRange = origStreamRange
+	})
+	streamS3ObjectRange = func(_ context.Context, _ *repository.SourceRepository, _ *repository.File, _ io.Writer, _, _ int64) error {
+		t.Fatal("expected full-object stream path")
+		return nil
+	}
+	streamS3Object = func(_ context.Context, _ *repository.SourceRepository, _ *repository.File, w io.Writer) error {
+		_, err := io.WriteString(w, "complete")
+		return err
+	}
+
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("accessKey", "access-key")
+		c.Next()
+	})
+	r.GET("/api/s3/:bucket/*object", getObjectFailureTestHandler(t))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/s3/bucket/object.txt", nil)
+	req.Header.Set("If-None-Match", `"other-etag"`)
+	req.Header.Set("If-Modified-Since", time.Unix(1700000000, 0).Add(24*time.Hour).UTC().Format(http.TimeFormat))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if body := w.Body.String(); body != "complete" {
+		t.Fatalf("unexpected body: %s", body)
+	}
+}
+
+func TestHeadObjectIfUnmodifiedSinceReturnsPreconditionFailed(t *testing.T) {
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("accessKey", "access-key")
+		c.Next()
+	})
+	bucketID := primitive.NewObjectID()
+	r.HEAD("/api/s3/:bucket/*object", headObject(
+		fakeObjectBucketReader{
+			bucket: &repository.Bucket{
+				ID:        bucketID,
+				Key:       "bucket",
+				AccessKey: "access-key",
+			},
+		},
+		fakeObjectFileReader{
+			file: &repository.File{
+				ID:        primitive.NewObjectID(),
+				BucketID:  bucketID,
+				Name:      "object.txt",
+				CreatedAt: time.Unix(1700000000, 0).UTC(),
+				ETag:      `"persisted-etag"`,
+			},
+		},
+	))
+
+	req := httptest.NewRequest(http.MethodHead, "/api/s3/bucket/object.txt", nil)
+	req.Header.Set("If-Unmodified-Since", time.Unix(1700000000, 0).Add(-time.Hour).UTC().Format(http.TimeFormat))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusPreconditionFailed {
+		t.Fatalf("expected 412, got %d", w.Code)
+	}
+	if body := w.Body.String(); body != "" {
+		t.Fatalf("expected empty body, got %q", body)
+	}
+	if got := w.Header().Get("ETag"); got != `"persisted-etag"` {
+		t.Fatalf("expected persisted ETag header, got %q", got)
+	}
+}

--- a/api-go/internal/handlers/s3_object.go
+++ b/api-go/internal/handlers/s3_object.go
@@ -181,6 +181,10 @@ func requestObjectUserMetadata(r *http.Request) map[string]string {
 // @Router /{bucket}/{object} [head]
 // @Router /api/s3/{bucket}/{object} [head]
 func HeadObject(bucketRepo *repository.BucketRepository, fileRepo *repository.FileRepository) gin.HandlerFunc {
+	return headObject(bucketRepo, fileRepo)
+}
+
+func headObject(bucketRepo objectBucketReader, fileRepo objectFileReader) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		if bucketRepo == nil || fileRepo == nil {
 			c.Status(http.StatusServiceUnavailable)
@@ -188,6 +192,9 @@ func HeadObject(bucketRepo *repository.BucketRepository, fileRepo *repository.Fi
 		}
 		fileDoc, total, ok := lookupObject(c, bucketRepo, fileRepo)
 		if !ok {
+			return
+		}
+		if writeObjectConditionalResponse(c, fileDoc) {
 			return
 		}
 		setObjectHeaders(c, fileDoc, total)
@@ -237,6 +244,9 @@ func getObject(bucketRepo objectBucketReader, sourceRepo *repository.SourceRepos
 		}
 		fileDoc, total, ok := lookupObject(c, bucketRepo, fileRepo)
 		if !ok {
+			return
+		}
+		if writeObjectConditionalResponse(c, fileDoc) {
 			return
 		}
 		rangeHeader := c.GetHeader("Range")

--- a/api-go/internal/handlers/s3_object_conditions.go
+++ b/api-go/internal/handlers/s3_object_conditions.go
@@ -1,0 +1,73 @@
+package handlers
+
+import (
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/example/sfree/api-go/internal/manager"
+	"github.com/example/sfree/api-go/internal/repository"
+	"github.com/gin-gonic/gin"
+)
+
+func writeObjectConditionalResponse(c *gin.Context, fileDoc *repository.File) bool {
+	status, ok := evaluateObjectReadPreconditions(c.Request, manager.ObjectETag(*fileDoc), fileDoc.CreatedAt)
+	if !ok {
+		return false
+	}
+	c.Header("Accept-Ranges", "bytes")
+	c.Header("ETag", manager.ObjectETag(*fileDoc))
+	c.Header("Last-Modified", fileDoc.CreatedAt.UTC().Format(http.TimeFormat))
+	c.Status(status)
+	return true
+}
+
+func evaluateObjectReadPreconditions(r *http.Request, etag string, modifiedAt time.Time) (int, bool) {
+	if raw := strings.TrimSpace(r.Header.Get("If-Match")); raw != "" {
+		if !etagListMatches(raw, etag) {
+			return http.StatusPreconditionFailed, true
+		}
+	} else if t, ok := parseConditionalTime(r.Header.Get("If-Unmodified-Since")); ok && objectModifiedAfter(modifiedAt, t) {
+		return http.StatusPreconditionFailed, true
+	}
+
+	if raw := strings.TrimSpace(r.Header.Get("If-None-Match")); raw != "" {
+		if etagListMatches(raw, etag) {
+			return http.StatusNotModified, true
+		}
+		return 0, false
+	}
+	if t, ok := parseConditionalTime(r.Header.Get("If-Modified-Since")); ok && !objectModifiedAfter(modifiedAt, t) {
+		return http.StatusNotModified, true
+	}
+	return 0, false
+}
+
+func parseConditionalTime(raw string) (time.Time, bool) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return time.Time{}, false
+	}
+	t, err := http.ParseTime(raw)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return t.UTC(), true
+}
+
+func objectModifiedAfter(modifiedAt, t time.Time) bool {
+	return modifiedAt.UTC().Truncate(time.Second).After(t.UTC())
+}
+
+func etagListMatches(raw, etag string) bool {
+	for _, candidate := range strings.Split(raw, ",") {
+		candidate = strings.TrimSpace(candidate)
+		if candidate == "" {
+			continue
+		}
+		if candidate == "*" || candidate == etag {
+			return true
+		}
+	}
+	return false
+}

--- a/docs/s3-compatibility.md
+++ b/docs/s3-compatibility.md
@@ -1,6 +1,6 @@
 # S3 Compatibility Matrix
 
-Last updated: 2026-04-24
+Last updated: 2026-04-25
 
 Baseline: `origin/main` at `ea8c3bcc33b4edc6a0474c70c86b155371aaf773`. SFree exposes its S3-compatible API on the root path using path-style addressing: `/{bucket}/{key}`. The legacy `/api/s3/{bucket}/{key}` alias remains supported for backward compatibility.
 
@@ -28,10 +28,10 @@ Bucket administration APIs, ACLs, versioning, lifecycle, object lock, tagging, a
 
 | S3 operation | Status | Notes |
 | --- | --- | --- |
-| GetObject | Partial | Basic full-object download and byte `Range` requests work. Stored Content-Type and user metadata are returned. Conditional headers, response header overrides, and checksum-related response semantics are missing. |
+| GetObject | Partial | Basic full-object download and byte `Range` requests work. Stored Content-Type and user metadata are returned. `If-Match`, `If-None-Match`, `If-Modified-Since`, and `If-Unmodified-Since` now gate full-object and ranged reads with `304`/`412` responses before streaming. Response header overrides and checksum-related response semantics are still missing. |
 | PutObject | Partial | Basic upload and overwrite work. Content-Type and `x-amz-meta-*` user metadata are persisted. Object tags, storage class, checksum validation, and server-side encryption headers are ignored. |
 | DeleteObject | Implemented | Single-object delete is idempotent and returns no content for missing keys. |
-| HeadObject | Partial | Returns ETag, Last-Modified, Content-Length, Content-Type, and user metadata. Range awareness, checksum headers, and conditional request behavior are missing. |
+| HeadObject | Partial | Returns ETag, Last-Modified, Content-Length, Content-Type, and user metadata. `If-Match`, `If-None-Match`, `If-Modified-Since`, and `If-Unmodified-Since` are now honored with `304`/`412` responses. Range awareness and checksum headers remain missing. |
 | CopyObject | Partial | Basic same-bucket and cross-bucket copies are implemented and covered by Go and Python SDK E2E. COPY preserves object bytes, Content-Type, and user metadata. `x-amz-metadata-directive: REPLACE` returns XML `NotImplemented`. |
 | DeleteObjects | Implemented | SDK multi-delete is covered by `test_s3_sdk_delete_objects_removes_multiple_keys`, including missing-key idempotency. |
 | GetObjectAcl / PutObjectAcl | Missing | ACLs are not modeled in the S3 API. |
@@ -79,7 +79,7 @@ Bucket administration APIs, ACLs, versioning, lifecycle, object lock, tagging, a
 | Anonymous access | Missing | S3 API requests require signed bucket credentials. |
 | Virtual-hosted-style addressing | Missing | Path-style routing is supported on `/{bucket}` and the legacy `/api/s3/{bucket}` alias, but bucket-in-host virtual-hosted requests are still unsupported. |
 | Range requests | Partial | GetObject byte ranges and `Accept-Ranges` are covered by Go e2e and the Python SDK e2e fixture. HeadObject range behavior is not validated as a v0.2 SDK path. |
-| Conditional requests | Missing | `If-Match`, `If-None-Match`, `If-Modified-Since`, and related headers are not evaluated. |
+| Conditional requests | Partial | `If-Match`, `If-None-Match`, `If-Modified-Since`, and `If-Unmodified-Since` are evaluated for `GetObject` and `HeadObject`, including combined-header precedence where ETag validators win over date validators. `If-Range`, copy-condition headers, and non-object conditional APIs remain unsupported. |
 | User metadata | Partial | `x-amz-meta-*` headers are stored with lowercase keys, returned on HeadObject/GetObject, replaced on overwrite, and preserved by CopyObject COPY. Metadata search/listing and tags are not supported. |
 | Content-Type persistence | Partial | PutObject and CreateMultipartUpload store request Content-Type; HeadObject/GetObject return it and legacy objects default to `application/octet-stream`. |
 | Checksums | Missing | S3 checksum headers are not validated or returned. |


### PR DESCRIPTION
## Summary
- add bounded `If-Match`, `If-None-Match`, `If-Modified-Since`, and `If-Unmodified-Since` handling for `GetObject` and `HeadObject`
- evaluate preconditions before any object stream starts so ranged and full-object reads keep existing behavior when conditions pass
- document the shipped slice in the S3 compatibility matrix and add focused handler plus tagged e2e coverage

## Why
SFree returned `ETag` and `Last-Modified` headers but ignored conditional read headers entirely, which broke ordinary cache validation and optimistic-read flows tracked in Paperclip `THE-899` and public issue #337.

## Impact
Clients can now use first-slice conditional requests on object reads without widening scope into `If-Range`, copy-condition headers, or checksum redesign.

## Validation
- `go test ./internal/handlers -run 'TestGetObject|TestHeadObjectIfUnmodifiedSinceReturnsPreconditionFailed'`
- `go test -tags e2e ./internal/e2e -run TestS3CompatObjectConditionalReads`

## Notes
- combined-header precedence is covered so ETag validators win over date validators for this slice
- public issue #337 should be updated again when this PR merges