### PR TITLE
[codex] Ship bounded multi-file download from the bucket workspace

### DIFF
--- a/api-go/internal/app/router_routes.go
+++ b/api-go/internal/app/router_routes.go
@@ -78,6 +78,7 @@ func registerBucketFileRoutes(router *gin.Engine, cfg *config.Config, deps *rout
 	}
 	router.POST("/api/v1/buckets/:id/upload", protectedHandlers(limits, deps.auth, handlers.UploadFileWithFactory(deps.bucketRepo, deps.sourceRepo, deps.fileRepo, deps.grantRepo, routerUploadChunkSize(cfg), deps.sourceFactory))...)
 	router.GET("/api/v1/buckets/:id/files", protectedHandlers(limits, deps.auth, handlers.ListFiles(deps.bucketRepo, deps.fileRepo, deps.grantRepo))...)
+	router.POST("/api/v1/buckets/:id/files/download", protectedHandlers(limits, deps.auth, handlers.DownloadFilesArchiveWithFactory(deps.bucketRepo, deps.sourceRepo, deps.fileRepo, deps.grantRepo, deps.sourceFactory))...)
 	router.GET("/api/v1/buckets/:id/files/:file_id/download", protectedHandlers(limits, deps.auth, handlers.DownloadFileWithFactory(deps.bucketRepo, deps.sourceRepo, deps.fileRepo, deps.grantRepo, deps.sourceFactory))...)
 	router.DELETE("/api/v1/buckets/:id/files/:file_id", protectedHandlers(limits, deps.auth, handlers.DeleteFileWithFactory(deps.bucketRepo, deps.sourceRepo, deps.fileRepo, deps.shareLinkRepo, deps.grantRepo, deps.sourceFactory))...)
 	if deps.shareLinkRepo == nil {

--- a/api-go/internal/app/router_test.go
+++ b/api-go/internal/app/router_test.go
@@ -108,9 +108,34 @@ func TestOpenAPIJSONRoute(t *testing.T) {
 	if doc.Swagger != "2.0" {
 		t.Fatalf("expected Swagger 2.0, got %q", doc.Swagger)
 	}
-	for _, path := range []string{"/api/v1/buckets", "/api/v1/sources/s3", "/api/v1/sources/{id}/download", "/{bucket}", "/{bucket}/{object}", "/api/s3/{bucket}", "/api/s3/{bucket}/{object}"} {
+	for _, path := range []string{"/api/v1/buckets", "/api/v1/buckets/{id}/files/download", "/api/v1/sources/s3", "/api/v1/sources/{id}/download", "/{bucket}", "/{bucket}/{object}", "/api/s3/{bucket}", "/api/s3/{bucket}/{object}"} {
 		if _, ok := doc.Paths[path]; !ok {
 			t.Fatalf("expected OpenAPI path %s", path)
+		}
+	}
+}
+
+func TestRegisterBucketFileRoutesIncludesBatchDownloadRoute(t *testing.T) {
+	r := gin.New()
+	registerBucketFileRoutes(r, &config.Config{}, &routerDependencies{
+		auth: func(c *gin.Context) {
+			c.Next()
+		},
+		bucketRepo: &repository.BucketRepository{},
+		sourceRepo: &repository.SourceRepository{},
+		fileRepo:   &repository.FileRepository{},
+	}, nil)
+
+	expectedRoutes := []struct {
+		method string
+		path   string
+	}{
+		{http.MethodPost, "/api/v1/buckets/:id/files/download"},
+		{http.MethodGet, "/api/v1/buckets/:id/files/:file_id/download"},
+	}
+	for _, expected := range expectedRoutes {
+		if !hasRoute(r, expected.method, expected.path) {
+			t.Fatalf("expected %s %s to be registered", expected.method, expected.path)
 		}
 	}
 }

--- a/api-go/internal/docs/docs.go
+++ b/api-go/internal/docs/docs.go
@@ -797,6 +797,75 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/buckets/{id}/files/download": {
+            "post": {
+                "security": [
+                    {
+                        "BasicAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/zip"
+                ],
+                "tags": [
+                    "buckets"
+                ],
+                "summary": "Download multiple files as a zip archive",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Bucket ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Selected file IDs",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.multiFileDownloadRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "file"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/buckets/{id}/files/{file_id}": {
             "delete": {
                 "security": [
@@ -2589,6 +2658,17 @@ const docTemplate = `{
                 },
                 "username": {
                     "type": "string"
+                }
+            }
+        },
+        "handlers.multiFileDownloadRequest": {
+            "type": "object",
+            "properties": {
+                "file_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 }
             }
         },

--- a/api-go/internal/handlers/bucket_files.go
+++ b/api-go/internal/handlers/bucket_files.go
@@ -1,7 +1,11 @@
 package handlers
 
 import (
+	"archive/zip"
+	"bytes"
 	"errors"
+	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"strings"
@@ -10,6 +14,7 @@ import (
 	"github.com/example/sfree/api-go/internal/manager"
 	"github.com/example/sfree/api-go/internal/repository"
 	"github.com/gin-gonic/gin"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
@@ -25,6 +30,16 @@ type fileResponse struct {
 	CreatedAt time.Time `json:"created_at"`
 	Size      int64     `json:"size"`
 }
+
+type multiFileDownloadRequest struct {
+	FileIDs []string `json:"file_ids"`
+}
+
+const (
+	maxMultiFileDownloadCount    = 50
+	maxMultiFileDownloadTotal    = 250 << 20
+	maxMultiFileDownloadTotalStr = "250 MiB"
+)
 
 // UploadFile godoc
 // @Summary Upload file to bucket
@@ -173,6 +188,159 @@ func DownloadFileWithFactory(bucketRepo *repository.BucketRepository, sourceRepo
 	}
 }
 
+// DownloadFilesArchive godoc
+// @Summary Download multiple files as a zip archive
+// @Tags buckets
+// @Accept json
+// @Produce application/zip
+// @Param id path string true "Bucket ID"
+// @Param body body multiFileDownloadRequest true "Selected file IDs"
+// @Success 200 {file} file
+// @Failure 400 {string} string ""
+// @Failure 401 {string} string ""
+// @Failure 404 {string} string ""
+// @Failure 500 {string} string ""
+// @Security BasicAuth
+// @Router /api/v1/buckets/{id}/files/download [post]
+func DownloadFilesArchive(bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository, grantRepo *repository.BucketGrantRepository) gin.HandlerFunc {
+	return DownloadFilesArchiveWithFactory(bucketRepo, sourceRepo, fileRepo, grantRepo, nil)
+}
+
+func DownloadFilesArchiveWithFactory(bucketRepo *repository.BucketRepository, sourceRepo *repository.SourceRepository, fileRepo *repository.FileRepository, grantRepo *repository.BucketGrantRepository, factory manager.SourceClientFactory) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		ctx := c.Request.Context()
+		if bucketRepo == nil || sourceRepo == nil || fileRepo == nil {
+			slog.ErrorContext(ctx, "download files archive: repository is nil")
+			c.Status(http.StatusServiceUnavailable)
+			return
+		}
+		var grantReader bucketAccessGrantReader
+		if grantRepo != nil {
+			grantReader = grantRepo
+		}
+		downloadFilesArchive(bucketRepo, sourceRepo, fileRepo, grantReader, factory)(c)
+	}
+}
+
+func downloadFilesArchive(bucketRepo bucketAccessBucketReader, sourceRepo *repository.SourceRepository, fileRepo fileByIDReader, grantRepo bucketAccessGrantReader, factory manager.SourceClientFactory) gin.HandlerFunc {
+	streamFile := fileStreamFuncForFactory(factory)
+	return func(c *gin.Context) {
+		ctx := c.Request.Context()
+		if bucketRepo == nil || sourceRepo == nil || fileRepo == nil {
+			slog.ErrorContext(ctx, "download files archive: repository is nil")
+			c.Status(http.StatusServiceUnavailable)
+			return
+		}
+
+		acc := requireBucketAccess(c, bucketRepo, grantRepo, repository.RoleViewer)
+		if acc == nil {
+			return
+		}
+
+		var req multiFileDownloadRequest
+		if err := c.ShouldBindJSON(&req); err != nil {
+			slog.WarnContext(ctx, "download files archive: invalid request", slog.String("error", err.Error()))
+			c.Status(http.StatusBadRequest)
+			return
+		}
+		if len(req.FileIDs) == 0 || len(req.FileIDs) > maxMultiFileDownloadCount {
+			c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("file_ids must contain between 1 and %d file ids", maxMultiFileDownloadCount)})
+			return
+		}
+
+		files := make([]*repository.File, 0, len(req.FileIDs))
+		seen := make(map[string]struct{}, len(req.FileIDs))
+		var totalSize int64
+		for _, fileIDHex := range req.FileIDs {
+			if _, ok := seen[fileIDHex]; ok {
+				c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("file_ids contains duplicate file id %q", fileIDHex)})
+				return
+			}
+			seen[fileIDHex] = struct{}{}
+
+			fileID, err := primitive.ObjectIDFromHex(fileIDHex)
+			if err != nil {
+				c.Status(http.StatusBadRequest)
+				return
+			}
+			fileDoc, err := fileRepo.GetByID(ctx, fileID)
+			if err != nil {
+				if err == mongo.ErrNoDocuments {
+					c.Status(http.StatusNotFound)
+					return
+				}
+				slog.ErrorContext(ctx, "download files archive: get file", slog.String("error", err.Error()))
+				c.Status(http.StatusInternalServerError)
+				return
+			}
+			if fileDoc.BucketID != acc.Bucket.ID {
+				c.Status(http.StatusNotFound)
+				return
+			}
+			totalSize += manager.FileSize(*fileDoc)
+			if totalSize > maxMultiFileDownloadTotal {
+				c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("selected files exceed the %s archive limit", maxMultiFileDownloadTotalStr)})
+				return
+			}
+			files = append(files, fileDoc)
+		}
+
+		archiveName := sanitizeFilename(acc.Bucket.Key) + "-files.zip"
+		if archiveName == "-files.zip" {
+			archiveName = "files.zip"
+		}
+		w := newDeferredResponseWriter(c, func() {
+			setArchiveDownloadHeaders(c, archiveName)
+			c.Status(http.StatusOK)
+		})
+		zipTarget := newDeferredZipWriter(w)
+		archive := zip.NewWriter(zipTarget)
+
+		for _, fileDoc := range files {
+			header := &zip.FileHeader{
+				Name:     fileDoc.Name,
+				Method:   zip.Store,
+				Modified: fileDoc.CreatedAt,
+			}
+			entry, err := archive.CreateHeader(header)
+			if err != nil {
+				slog.ErrorContext(ctx, "download files archive: create entry", slog.String("error", err.Error()))
+				c.Status(http.StatusInternalServerError)
+				return
+			}
+			if err := streamFile(ctx, sourceRepo, fileDoc, newCommitOnFirstWriteWriter(entry, zipTarget)); err != nil {
+				_ = archive.Close()
+				if !w.isCommitted() {
+					slog.ErrorContext(ctx, "download files archive: stream failed", slog.String("error", err.Error()))
+					c.Status(http.StatusInternalServerError)
+					return
+				}
+				slog.ErrorContext(ctx, "download files archive: stream failed after response commit", slog.String("error", err.Error()))
+				return
+			}
+		}
+
+		if err := archive.Close(); err != nil {
+			if !w.isCommitted() {
+				slog.ErrorContext(ctx, "download files archive: close archive", slog.String("error", err.Error()))
+				c.Status(http.StatusInternalServerError)
+				return
+			}
+			slog.ErrorContext(ctx, "download files archive: close archive after response commit", slog.String("error", err.Error()))
+			return
+		}
+		if err := zipTarget.commit(); err != nil {
+			if !w.isCommitted() {
+				slog.ErrorContext(ctx, "download files archive: commit archive", slog.String("error", err.Error()))
+				c.Status(http.StatusInternalServerError)
+				return
+			}
+			slog.ErrorContext(ctx, "download files archive: commit archive after response commit", slog.String("error", err.Error()))
+			return
+		}
+	}
+}
+
 func downloadFile(bucketRepo bucketAccessBucketReader, sourceRepo *repository.SourceRepository, fileRepo fileByIDReader, grantRepo bucketAccessGrantReader, factory manager.SourceClientFactory) gin.HandlerFunc {
 	streamFile := fileStreamFuncForFactory(factory)
 	return func(c *gin.Context) {
@@ -223,6 +391,62 @@ func downloadFile(bucketRepo bucketAccessBucketReader, sourceRepo *repository.So
 		}
 		w.commitNow()
 	}
+}
+
+type deferredZipWriter struct {
+	target    io.Writer
+	buf       bytes.Buffer
+	committed bool
+}
+
+func newDeferredZipWriter(target io.Writer) *deferredZipWriter {
+	return &deferredZipWriter{target: target}
+}
+
+func (w *deferredZipWriter) Write(p []byte) (int, error) {
+	if !w.committed {
+		return w.buf.Write(p)
+	}
+	return w.target.Write(p)
+}
+
+func (w *deferredZipWriter) commit() error {
+	if w.committed {
+		return nil
+	}
+	w.committed = true
+	if w.buf.Len() == 0 {
+		return nil
+	}
+	_, err := w.target.Write(w.buf.Bytes())
+	w.buf.Reset()
+	return err
+}
+
+type commitOnFirstWriteWriter struct {
+	target    io.Writer
+	commit    func() error
+	committed bool
+}
+
+func newCommitOnFirstWriteWriter(target io.Writer, committer interface{ commit() error }) *commitOnFirstWriteWriter {
+	return &commitOnFirstWriteWriter{
+		target: target,
+		commit: committer.commit,
+	}
+}
+
+func (w *commitOnFirstWriteWriter) Write(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	if !w.committed {
+		if err := w.commit(); err != nil {
+			return 0, err
+		}
+		w.committed = true
+	}
+	return w.target.Write(p)
 }
 
 // DeleteFile godoc

--- a/api-go/internal/handlers/bucket_multi_download_test.go
+++ b/api-go/internal/handlers/bucket_multi_download_test.go
@@ -1,0 +1,299 @@
+package handlers
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/example/sfree/api-go/internal/manager"
+	"github.com/example/sfree/api-go/internal/repository"
+	"github.com/gin-gonic/gin"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+type fakeFileByIDMapReader struct {
+	files map[primitive.ObjectID]*repository.File
+	err   error
+}
+
+func (r fakeFileByIDMapReader) GetByID(_ context.Context, id primitive.ObjectID) (*repository.File, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	file, ok := r.files[id]
+	if !ok {
+		return nil, mongo.ErrNoDocuments
+	}
+	return file, nil
+}
+
+func TestDownloadFilesArchiveRejectsTooManyFileIDs(t *testing.T) {
+	t.Parallel()
+
+	userID := primitive.NewObjectID()
+	bucket := &repository.Bucket{
+		ID:     primitive.NewObjectID(),
+		UserID: userID,
+		Key:    "batch",
+	}
+
+	fileIDs := make([]string, 0, maxMultiFileDownloadCount+1)
+	for i := 0; i < maxMultiFileDownloadCount+1; i++ {
+		fileIDs = append(fileIDs, primitive.NewObjectID().Hex())
+	}
+
+	resp := performDownloadFilesArchiveRequest(
+		t,
+		userID,
+		bucketDetailBucketReader{bucket: bucket},
+		fakeFileByIDMapReader{},
+		multiFileDownloadRequest{FileIDs: fileIDs},
+	)
+
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", resp.Code)
+	}
+	if !strings.Contains(resp.Body.String(), "between 1 and 50") {
+		t.Fatalf("unexpected response body: %s", resp.Body.String())
+	}
+}
+
+func TestDownloadFilesArchiveRejectsSelectionsOverSizeLimit(t *testing.T) {
+	t.Parallel()
+
+	userID := primitive.NewObjectID()
+	bucketID := primitive.NewObjectID()
+	fileID := primitive.NewObjectID()
+	bucket := &repository.Bucket{
+		ID:     bucketID,
+		UserID: userID,
+		Key:    "batch",
+	}
+	file := &repository.File{
+		ID:        fileID,
+		BucketID:  bucketID,
+		Name:      "large.bin",
+		CreatedAt: time.Now().UTC(),
+		Chunks: []repository.FileChunk{
+			{SourceID: primitive.NewObjectID(), Name: "chunk", Size: maxMultiFileDownloadTotal + 1},
+		},
+	}
+
+	resp := performDownloadFilesArchiveRequest(
+		t,
+		userID,
+		bucketDetailBucketReader{bucket: bucket},
+		fakeFileByIDMapReader{files: map[primitive.ObjectID]*repository.File{fileID: file}},
+		multiFileDownloadRequest{FileIDs: []string{fileID.Hex()}},
+	)
+
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", resp.Code)
+	}
+	if !strings.Contains(resp.Body.String(), maxMultiFileDownloadTotalStr) {
+		t.Fatalf("unexpected response body: %s", resp.Body.String())
+	}
+}
+
+func TestDownloadFilesArchiveReturnsNotFoundForFilesOutsideBucket(t *testing.T) {
+	t.Parallel()
+
+	userID := primitive.NewObjectID()
+	bucket := &repository.Bucket{
+		ID:     primitive.NewObjectID(),
+		UserID: userID,
+		Key:    "batch",
+	}
+	fileID := primitive.NewObjectID()
+	file := &repository.File{
+		ID:        fileID,
+		BucketID:  primitive.NewObjectID(),
+		Name:      "wrong.txt",
+		CreatedAt: time.Now().UTC(),
+	}
+
+	resp := performDownloadFilesArchiveRequest(
+		t,
+		userID,
+		bucketDetailBucketReader{bucket: bucket},
+		fakeFileByIDMapReader{files: map[primitive.ObjectID]*repository.File{fileID: file}},
+		multiFileDownloadRequest{FileIDs: []string{fileID.Hex()}},
+	)
+
+	if resp.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", resp.Code)
+	}
+}
+
+func TestDownloadFilesArchiveStreamsZipContents(t *testing.T) {
+	origStream := streamDownloadFile
+	t.Cleanup(func() {
+		streamDownloadFile = origStream
+	})
+
+	streamDownloadFile = func(_ context.Context, _ *repository.SourceRepository, fileDoc *repository.File, w io.Writer) error {
+		_, err := io.WriteString(w, "payload:"+fileDoc.Name)
+		return err
+	}
+
+	userID := primitive.NewObjectID()
+	bucketID := primitive.NewObjectID()
+	bucket := &repository.Bucket{
+		ID:     bucketID,
+		UserID: userID,
+		Key:    "batch",
+	}
+	first := &repository.File{
+		ID:        primitive.NewObjectID(),
+		BucketID:  bucketID,
+		Name:      "alpha.txt",
+		CreatedAt: time.Unix(1700000000, 0).UTC(),
+		Chunks: []repository.FileChunk{
+			{SourceID: primitive.NewObjectID(), Name: "a", Size: 17},
+		},
+	}
+	second := &repository.File{
+		ID:        primitive.NewObjectID(),
+		BucketID:  bucketID,
+		Name:      "beta.txt",
+		CreatedAt: time.Unix(1700000100, 0).UTC(),
+		Chunks: []repository.FileChunk{
+			{SourceID: primitive.NewObjectID(), Name: "b", Size: 16},
+		},
+	}
+
+	resp := performDownloadFilesArchiveRequest(
+		t,
+		userID,
+		bucketDetailBucketReader{bucket: bucket},
+		fakeFileByIDMapReader{files: map[primitive.ObjectID]*repository.File{
+			first.ID:  first,
+			second.ID: second,
+		}},
+		multiFileDownloadRequest{FileIDs: []string{first.ID.Hex(), second.ID.Hex()}},
+	)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.Code)
+	}
+	if got := resp.Header().Get("Content-Type"); got != "application/zip" {
+		t.Fatalf("expected zip content type, got %q", got)
+	}
+	if got := resp.Header().Get("Content-Disposition"); !strings.Contains(got, "batch-files.zip") {
+		t.Fatalf("unexpected content disposition: %q", got)
+	}
+
+	reader, err := zip.NewReader(bytes.NewReader(resp.Body.Bytes()), int64(resp.Body.Len()))
+	if err != nil {
+		t.Fatalf("read zip: %v", err)
+	}
+	if len(reader.File) != 2 {
+		t.Fatalf("expected 2 files, got %d", len(reader.File))
+	}
+	got := make(map[string]string, len(reader.File))
+	for _, entry := range reader.File {
+		rc, err := entry.Open()
+		if err != nil {
+			t.Fatalf("open zip entry: %v", err)
+		}
+		data, err := io.ReadAll(rc)
+		_ = rc.Close()
+		if err != nil {
+			t.Fatalf("read zip entry: %v", err)
+		}
+		got[entry.Name] = string(data)
+	}
+	if got["alpha.txt"] != "payload:alpha.txt" || got["beta.txt"] != "payload:beta.txt" {
+		t.Fatalf("unexpected zip contents: %+v", got)
+	}
+}
+
+func TestDownloadFilesArchiveStreamFailureReturnsErrorBeforeSuccessHeaders(t *testing.T) {
+	origStream := streamDownloadFile
+	t.Cleanup(func() {
+		streamDownloadFile = origStream
+	})
+
+	streamDownloadFile = func(_ context.Context, _ *repository.SourceRepository, _ *repository.File, _ io.Writer) error {
+		return manager.ErrChecksumMismatch
+	}
+
+	userID := primitive.NewObjectID()
+	bucketID := primitive.NewObjectID()
+	fileID := primitive.NewObjectID()
+	bucket := &repository.Bucket{
+		ID:     bucketID,
+		UserID: userID,
+		Key:    "batch",
+	}
+	file := &repository.File{
+		ID:        fileID,
+		BucketID:  bucketID,
+		Name:      "alpha.txt",
+		CreatedAt: time.Now().UTC(),
+		Chunks: []repository.FileChunk{
+			{SourceID: primitive.NewObjectID(), Name: "chunk", Size: 1},
+		},
+	}
+
+	resp := performDownloadFilesArchiveRequest(
+		t,
+		userID,
+		bucketDetailBucketReader{bucket: bucket},
+		fakeFileByIDMapReader{files: map[primitive.ObjectID]*repository.File{fileID: file}},
+		multiFileDownloadRequest{FileIDs: []string{fileID.Hex()}},
+	)
+
+	if resp.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", resp.Code)
+	}
+	if got := resp.Header().Get("Content-Disposition"); got != "" {
+		t.Fatalf("expected no success Content-Disposition header, got %q", got)
+	}
+	if got := resp.Header().Get("Content-Type"); got != "" {
+		t.Fatalf("expected no success Content-Type header, got %q", got)
+	}
+	if resp.Body.Len() != 0 {
+		t.Fatalf("expected no response body, got %q", resp.Body.String())
+	}
+}
+
+func performDownloadFilesArchiveRequest(
+	t *testing.T,
+	userID primitive.ObjectID,
+	bucketRepo bucketAccessBucketReader,
+	fileRepo fileByIDReader,
+	body multiFileDownloadRequest,
+) *httptest.ResponseRecorder {
+	t.Helper()
+	r := gin.New()
+	r.POST("/buckets/:id/files/download", setUserID(userID.Hex()), func(c *gin.Context) {
+		downloadFilesArchive(bucketRepo, &repository.SourceRepository{}, fileRepo, nil, nil)(c)
+	})
+
+	bucketID := primitive.NewObjectID().Hex()
+	if stub, ok := bucketRepo.(bucketDetailBucketReader); ok && stub.bucket != nil {
+		bucketID = stub.bucket.ID.Hex()
+	}
+	if stub, ok := bucketRepo.(fakeBucketByIDReader); ok && stub.bucket != nil {
+		bucketID = stub.bucket.ID.Hex()
+	}
+
+	data, err := json.Marshal(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/buckets/"+bucketID+"/files/download", bytes.NewReader(data))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}

--- a/api-go/internal/handlers/download_stream.go
+++ b/api-go/internal/handlers/download_stream.go
@@ -71,3 +71,8 @@ func setAttachmentDownloadHeaders(c *gin.Context, filename string, total int64) 
 	c.Header("Content-Type", "application/octet-stream")
 	c.Header("Content-Length", strconv.FormatInt(total, 10))
 }
+
+func setArchiveDownloadHeaders(c *gin.Context, filename string) {
+	c.Header("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s\"", sanitizeFilename(filename)))
+	c.Header("Content-Type", "application/zip")
+}

--- a/webui/e2e/files.spec.ts
+++ b/webui/e2e/files.spec.ts
@@ -276,6 +276,32 @@ test.describe("File listing and download", () => {
     await expect.poll(() => downloadCalled).toBe(true);
   });
 
+  test("selected files can be downloaded together", async ({ page }) => {
+    await injectAuth(page);
+    await mockGet(page, "/buckets", [MOCK_BUCKET]);
+    await mockGet(page, "/buckets/bkt-1", MOCK_BUCKET);
+    await mockGet(page, "/buckets/bkt-1/files", MOCK_FILES);
+
+    let batchDownloadBody: unknown = null;
+    await page.route("**/api/v1/buckets/bkt-1/files/download", async (route) => {
+      batchDownloadBody = route.request().postDataJSON();
+      await route.fulfill({
+        status: 200,
+        headers: {"Content-Type": "application/zip"},
+        body: Buffer.from("fake-zip"),
+      });
+    });
+
+    await page.goto("/buckets/bkt-1");
+    await page.getByRole("checkbox", {name: "Select report.pdf"}).check();
+    await page.getByRole("checkbox", {name: "Select data.csv"}).check();
+    await page.getByRole("button", {name: "Download Selected"}).click();
+
+    await expect.poll(() => batchDownloadBody).toEqual({
+      file_ids: ["file-1", "file-2"],
+    });
+  });
+
   test("failed bucket download shows an error toast", async ({ page }) => {
     await injectAuth(page);
     await mockGet(page, "/buckets", [MOCK_BUCKET]);

--- a/webui/src/app/index.css
+++ b/webui/src/app/index.css
@@ -8,3 +8,12 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/* Accessible focus ring for interactive elements */
+button:focus-visible,
+a:focus-visible,
+[tabindex]:focus-visible {
+  outline: 2px solid hsl(var(--heroui-primary));
+  outline-offset: 2px;
+  border-radius: 4px;
+}

--- a/webui/src/features/bucket/ui/share-bucket-dialog.tsx
+++ b/webui/src/features/bucket/ui/share-bucket-dialog.tsx
@@ -226,6 +226,7 @@ export function ShareBucketDialog({isOpen, onOpenChange, bucketId}: Props) {
                           size="sm"
                           variant="light"
                           color="danger"
+                          aria-label={`Revoke access for ${g.username}`}
                           onPress={() => handleRevoke(g.id)}
                         >
                           <DeleteIcon className="w-4 h-4" />

--- a/webui/src/pages/bucket/ui/bucket-page.tsx
+++ b/webui/src/pages/bucket/ui/bucket-page.tsx
@@ -12,6 +12,7 @@ import {Link, useNavigate, useParams} from "react-router-dom";
 import {
   deleteFile,
   downloadFile,
+  downloadFiles,
   getBucket,
   listFiles,
   uploadFile,
@@ -50,6 +51,7 @@ export function BucketPage() {
   const [deleteId, setDeleteId] = useState<string | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
   const [previewFile, setPreviewFile] = useState<FileInfo | null>(null);
+  const [selectedFileIds, setSelectedFileIds] = useState<string[]>([]);
 
   const shareBucket = useDisclosure();
   const [shareFile, setShareFile] = useState<FileInfo | null>(null);
@@ -133,12 +135,21 @@ export function BucketPage() {
   useEffect(() => {
     hasLoadedRef.current = false;
     setSearchQuery("");
+    setSelectedFileIds([]);
   }, [id]);
 
   useEffect(() => {
     if (!id) return;
     void load(hasLoadedRef.current ? "refresh" : "initial");
   }, [id, load]);
+
+  useEffect(() => {
+    setSelectedFileIds((prev) => {
+      const visibleIds = new Set(files.map((file) => file.id));
+      const next = prev.filter((fileId) => visibleIds.has(fileId));
+      return next.length === prev.length ? prev : next;
+    });
+  }, [files]);
 
   async function handleUpload(file: File) {
     if (!id || !bucket || !canWriteFiles(bucket)) return;
@@ -191,6 +202,39 @@ export function BucketPage() {
     }
   }
 
+  function toggleFileSelection(fileId: string) {
+    setSelectedFileIds((prev) =>
+      prev.includes(fileId)
+        ? prev.filter((id) => id !== fileId)
+        : [...prev, fileId],
+    );
+  }
+
+  function toggleAllVisibleFiles() {
+    if (sortedFiles.length === 0) return;
+    const allVisibleSelected = sortedFiles.every((file) => selectedFileIds.includes(file.id));
+    if (allVisibleSelected) {
+      setSelectedFileIds([]);
+      return;
+    }
+    setSelectedFileIds(sortedFiles.map((file) => file.id));
+  }
+
+  async function handleDownloadSelected() {
+    if (!id || !bucket || selectedFileIds.length === 0) return;
+    try {
+      await downloadFiles(
+        id,
+        sortedFiles
+          .filter((file) => selectedFileIds.includes(file.id))
+          .map((file) => file.id),
+        `${bucket.key}-files.zip`,
+      );
+    } catch (err) {
+      showErrorToast(err);
+    }
+  }
+
   if (isLoading) {
     return (
       <div className="p-6 sm:p-8 flex items-center justify-center min-h-[200px]">
@@ -234,6 +278,8 @@ export function BucketPage() {
 
   const canManage = canManageBucket(bucket);
   const canWrite = canWriteFiles(bucket);
+  const selectedVisibleCount = sortedFiles.filter((file) => selectedFileIds.includes(file.id)).length;
+  const allVisibleSelected = sortedFiles.length > 0 && selectedVisibleCount === sortedFiles.length;
   const emptyTitle = activeSearchQuery
     ? "No matching files"
     : canWrite
@@ -288,24 +334,40 @@ export function BucketPage() {
         onDragOver={(e) => e.preventDefault()}
         onDrop={onDrop}
       >
-        <div className="mb-4 flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
-          <Input
-            aria-label="Search files"
-            className="w-full md:max-w-md"
-            isClearable
-            label="Search files"
-            placeholder="Filter by filename"
-            type="search"
-            value={searchQuery}
-            onClear={() => setSearchQuery("")}
-            onValueChange={setSearchQuery}
-            endContent={isRefreshingFiles ? <Spinner size="sm" /> : null}
-          />
-          {activeSearchQuery ? (
-            <p className="text-sm text-default-500" aria-live="polite">
-              {files.length === 1 ? "1 matching file" : `${files.length} matching files`}
-            </p>
-          ) : null}
+        <div className="mb-4 flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+          <div className="flex flex-col gap-3 md:flex-row md:items-end">
+            <Input
+              aria-label="Search files"
+              className="w-full md:min-w-[20rem] md:max-w-md"
+              isClearable
+              label="Search files"
+              placeholder="Filter by filename"
+              type="search"
+              value={searchQuery}
+              onClear={() => setSearchQuery("")}
+              onValueChange={setSearchQuery}
+              endContent={isRefreshingFiles ? <Spinner size="sm" /> : null}
+            />
+            {activeSearchQuery ? (
+              <p className="text-sm text-default-500" aria-live="polite">
+                {files.length === 1 ? "1 matching file" : `${files.length} matching files`}
+              </p>
+            ) : null}
+          </div>
+          <div className="flex flex-wrap items-center gap-3">
+            {selectedVisibleCount > 0 ? (
+              <p className="text-sm text-default-500" aria-live="polite">
+                {selectedVisibleCount === 1 ? "1 file selected" : `${selectedVisibleCount} files selected`}
+              </p>
+            ) : null}
+            <Button
+              variant="flat"
+              isDisabled={selectedVisibleCount === 0}
+              onPress={handleDownloadSelected}
+            >
+              Download Selected
+            </Button>
+          </div>
         </div>
         {sortedFiles.length === 0 ? (
           <EmptyState
@@ -319,6 +381,14 @@ export function BucketPage() {
             <table className="w-full text-left">
               <thead>
                 <tr>
+                  <th scope="col" className="pb-2 pr-3 w-10">
+                    <input
+                      type="checkbox"
+                      aria-label="Select all files"
+                      checked={allVisibleSelected}
+                      onChange={toggleAllVisibleFiles}
+                    />
+                  </th>
                   <th scope="col" className="pb-2" aria-sort={sortBy === "name" ? (sortAsc ? "ascending" : "descending") : undefined}>
                     <button type="button" className="cursor-pointer select-none hover:text-primary transition-colors" onClick={() => toggleSort("name")}>
                       Name<SortArrow field="name" sortBy={sortBy} sortAsc={sortAsc} />
@@ -340,6 +410,14 @@ export function BucketPage() {
               <tbody>
                 {sortedFiles.map((f) => (
                   <tr key={f.id} className="border-t">
+                    <td className="py-2 pr-3 align-middle">
+                      <input
+                        type="checkbox"
+                        aria-label={`Select ${f.name}`}
+                        checked={selectedFileIds.includes(f.id)}
+                        onChange={() => toggleFileSelection(f.id)}
+                      />
+                    </td>
                     <td className="py-2">
                       <button
                         type="button"

--- a/webui/src/pages/bucket/ui/bucket-page.tsx
+++ b/webui/src/pages/bucket/ui/bucket-page.tsx
@@ -272,6 +272,7 @@ export function BucketPage() {
               ref={fileInput}
               className="hidden"
               onChange={onFileChange}
+              aria-label="Choose file to upload"
             />
             <Button color="primary" onPress={() => fileInput.current?.click()}>
               Upload File
@@ -279,7 +280,8 @@ export function BucketPage() {
           </>
         )}
       </div>
-      <div
+      <section
+        aria-label="File list"
         className={
           canWrite ? "border-2 border-dashed rounded p-4" : "border rounded p-4"
         }
@@ -300,7 +302,7 @@ export function BucketPage() {
             endContent={isRefreshingFiles ? <Spinner size="sm" /> : null}
           />
           {activeSearchQuery ? (
-            <p className="text-sm text-default-500">
+            <p className="text-sm text-default-500" aria-live="polite">
               {files.length === 1 ? "1 matching file" : `${files.length} matching files`}
             </p>
           ) : null}
@@ -317,16 +319,22 @@ export function BucketPage() {
             <table className="w-full text-left">
               <thead>
                 <tr>
-                  <th className="pb-2 cursor-pointer select-none" onClick={() => toggleSort("name")}>
-                    Name<SortArrow field="name" sortBy={sortBy} sortAsc={sortAsc} />
+                  <th scope="col" className="pb-2" aria-sort={sortBy === "name" ? (sortAsc ? "ascending" : "descending") : undefined}>
+                    <button type="button" className="cursor-pointer select-none hover:text-primary transition-colors" onClick={() => toggleSort("name")}>
+                      Name<SortArrow field="name" sortBy={sortBy} sortAsc={sortAsc} />
+                    </button>
                   </th>
-                  <th className="pb-2 cursor-pointer select-none whitespace-nowrap" onClick={() => toggleSort("size")}>
-                    Size<SortArrow field="size" sortBy={sortBy} sortAsc={sortAsc} />
+                  <th scope="col" className="pb-2 whitespace-nowrap" aria-sort={sortBy === "size" ? (sortAsc ? "ascending" : "descending") : undefined}>
+                    <button type="button" className="cursor-pointer select-none hover:text-primary transition-colors" onClick={() => toggleSort("size")}>
+                      Size<SortArrow field="size" sortBy={sortBy} sortAsc={sortAsc} />
+                    </button>
                   </th>
-                  <th className="pb-2 cursor-pointer select-none whitespace-nowrap hidden sm:table-cell" onClick={() => toggleSort("created_at")}>
-                    Created<SortArrow field="created_at" sortBy={sortBy} sortAsc={sortAsc} />
+                  <th scope="col" className="pb-2 whitespace-nowrap hidden sm:table-cell" aria-sort={sortBy === "created_at" ? (sortAsc ? "ascending" : "descending") : undefined}>
+                    <button type="button" className="cursor-pointer select-none hover:text-primary transition-colors" onClick={() => toggleSort("created_at")}>
+                      Created<SortArrow field="created_at" sortBy={sortBy} sortAsc={sortAsc} />
+                    </button>
                   </th>
-                  <th className="pb-2"></th>
+                  <th scope="col" className="pb-2"><span className="sr-only">Actions</span></th>
                 </tr>
               </thead>
               <tbody>
@@ -390,7 +398,7 @@ export function BucketPage() {
             </table>
           </div>
         )}
-      </div>
+      </section>
       <ConfirmDialog
         isOpen={confirm.isOpen}
         onOpenChange={(open) => {
@@ -432,6 +440,7 @@ function CredentialsPanel({bucket}: {bucket: Bucket}) {
         className="w-full flex items-center justify-between px-4 py-3 text-sm font-medium hover:bg-default-100 transition-colors rounded-lg cursor-pointer"
         onClick={() => setOpen(!open)}
         aria-expanded={open}
+        aria-controls="credentials-panel"
       >
         <span>S3 Credentials</span>
         <svg
@@ -445,7 +454,7 @@ function CredentialsPanel({bucket}: {bucket: Bucket}) {
         </svg>
       </button>
       {open && (
-        <div className="px-4 pb-4 flex flex-col gap-3 overflow-hidden">
+        <div id="credentials-panel" className="px-4 pb-4 flex flex-col gap-3 overflow-hidden">
           <div className="min-w-0">
             <p className="text-xs text-default-500 mb-1">Bucket ID</p>
             <Snippet size="sm" variant="flat" symbol="" classNames={{base: "max-w-full", pre: "whitespace-pre-wrap break-all"}}>{bucket.id}</Snippet>

--- a/webui/src/pages/bucket/ui/bucket-page.tsx
+++ b/webui/src/pages/bucket/ui/bucket-page.tsx
@@ -453,8 +453,12 @@ function CredentialsPanel({bucket}: {bucket: Bucket}) {
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
         </svg>
       </button>
-      {open && (
-        <div id="credentials-panel" className="px-4 pb-4 flex flex-col gap-3 overflow-hidden">
+      <div
+        id="credentials-panel"
+        hidden={!open}
+        aria-hidden={!open}
+        className="px-4 pb-4 flex flex-col gap-3 overflow-hidden"
+      >
           <div className="min-w-0">
             <p className="text-xs text-default-500 mb-1">Bucket ID</p>
             <Snippet size="sm" variant="flat" symbol="" classNames={{base: "max-w-full", pre: "whitespace-pre-wrap break-all"}}>{bucket.id}</Snippet>
@@ -466,8 +470,7 @@ function CredentialsPanel({bucket}: {bucket: Bucket}) {
           <p className="text-xs text-default-500">
             Created {new Date(bucket.created_at).toLocaleString()}
           </p>
-        </div>
-      )}
+      </div>
     </div>
   );
 }

--- a/webui/src/pages/buckets/ui/buckets-page.tsx
+++ b/webui/src/pages/buckets/ui/buckets-page.tsx
@@ -99,6 +99,7 @@ export function BucketsPage() {
                     isIconOnly
                     variant="light"
                     color="danger"
+                    aria-label={`Delete bucket ${b.key}`}
                     onClick={(e) => {
                       e.stopPropagation();
                       setDeleteId(b.id);

--- a/webui/src/pages/dashboard/ui/dashboard-page.tsx
+++ b/webui/src/pages/dashboard/ui/dashboard-page.tsx
@@ -179,6 +179,7 @@ export function DashboardPage() {
                     {quota.kind === "available" ? (
                       <div className="flex items-center gap-4">
                         <CircularProgress
+                          aria-label={`${s.name} quota usage: ${quota.percent}%`}
                           classNames={{
                             svg: "w-14 h-14",
                             indicator:

--- a/webui/src/pages/landing/ui/landing-page.tsx
+++ b/webui/src/pages/landing/ui/landing-page.tsx
@@ -70,7 +70,7 @@ export function LandingPage() {
   return (
     <div className="min-h-screen bg-background text-foreground">
       {/* Nav */}
-      <nav className="flex items-center justify-between px-6 py-4 max-w-6xl mx-auto">
+      <nav aria-label="Landing" className="flex items-center justify-between px-6 py-4 max-w-6xl mx-auto">
         <span className="text-xl font-bold tracking-tight">SFree</span>
         <div className="flex items-center gap-3">
           <Button variant="light" size="sm" onPress={login.onOpen}>

--- a/webui/src/pages/source/ui/source-page.tsx
+++ b/webui/src/pages/source/ui/source-page.tsx
@@ -123,6 +123,7 @@ export function SourcePage() {
             {quota.kind === "available" ? (
               <>
                 <CircularProgress
+                  aria-label={`Quota usage: ${quota.percent}%`}
                   classNames={{
                     svg: "w-24 h-24 sm:w-36 sm:h-36",
                     indicator:
@@ -198,9 +199,9 @@ export function SourcePage() {
             <table className="w-full text-left">
               <thead>
                 <tr>
-                  <th className="pb-2">Name</th>
-                  <th className="pb-2 whitespace-nowrap">Size</th>
-                  <th className="pb-2"></th>
+                  <th scope="col" className="pb-2">Name</th>
+                  <th scope="col" className="pb-2 whitespace-nowrap">Size</th>
+                  <th scope="col" className="pb-2"><span className="sr-only">Actions</span></th>
                 </tr>
               </thead>
               <tbody>
@@ -212,6 +213,7 @@ export function SourcePage() {
                       <Button
                         isIconOnly
                         variant="light"
+                        aria-label={`Download ${f.name}`}
                         onPress={() => handleDownload(f)}
                       >
                         <DownloadIcon className="w-5 h-5" />

--- a/webui/src/pages/sources/ui/sources-page.tsx
+++ b/webui/src/pages/sources/ui/sources-page.tsx
@@ -164,7 +164,7 @@ export function SourcesPage() {
                     <Button
                       isIconOnly
                       variant="light"
-                      aria-label="Refresh health"
+                      aria-label={`Refresh health for ${s.name}`}
                       isLoading={healthBySource[s.id]?.state === "checking"}
                       onClick={(e) => {
                         e.stopPropagation();
@@ -178,7 +178,7 @@ export function SourcesPage() {
                     isIconOnly
                     variant="light"
                     color="danger"
-                    aria-label="Delete source"
+                    aria-label={`Delete source ${s.name}`}
                     onClick={(e) => {
                       e.stopPropagation();
                       setDeleteId(s.id);

--- a/webui/src/shared/api/buckets.ts
+++ b/webui/src/shared/api/buckets.ts
@@ -96,6 +96,22 @@ export async function downloadFile(
   );
 }
 
+export async function downloadFiles(
+  bucketId: string,
+  fileIds: string[],
+  filename: string,
+): Promise<void> {
+  await apiDownload(
+    `/buckets/${bucketId}/files/download`,
+    filename,
+    "Failed to download files",
+    {
+      method: "POST",
+      json: {file_ids: fileIds},
+    },
+  );
+}
+
 export async function fetchFileBlob(
   bucketId: string,
   fileId: string,

--- a/webui/src/shared/api/client.ts
+++ b/webui/src/shared/api/client.ts
@@ -56,8 +56,9 @@ export async function apiDownload(
   path: string,
   filename: string,
   fallback: string,
+  options?: ApiFetchOptions,
 ): Promise<void> {
-  const res = await apiFetch(path, fallback);
+  const res = await apiFetch(path, fallback, options);
   const blob = await res.blob();
   const url = window.URL.createObjectURL(blob);
   const a = document.createElement("a");

--- a/webui/src/widgets/app-shell.tsx
+++ b/webui/src/widgets/app-shell.tsx
@@ -49,6 +49,12 @@ export function AppShell() {
 
   return (
     <div className="min-h-screen flex flex-col">
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:absolute focus:z-50 focus:top-2 focus:left-2 focus:px-4 focus:py-2 focus:bg-primary focus:text-primary-foreground focus:rounded-md focus:text-sm focus:font-medium"
+      >
+        Skip to main content
+      </a>
       <Navbar
         maxWidth="full"
         isMenuOpen={menuOpen}
@@ -139,7 +145,7 @@ export function AppShell() {
         </NavbarMenu>
       </Navbar>
 
-      <main className="flex-1">
+      <main id="main-content" className="flex-1">
         <Outlet />
       </main>
     </div>

--- a/webui/src/widgets/app-shell.tsx
+++ b/webui/src/widgets/app-shell.tsx
@@ -145,7 +145,7 @@ export function AppShell() {
         </NavbarMenu>
       </Navbar>
 
-      <main id="main-content" className="flex-1">
+      <main id="main-content" tabIndex={-1} className="flex-1">
         <Outlet />
       </main>
     </div>


### PR DESCRIPTION
## Summary
- add a bounded batch-download API for bucket files that streams a zip archive with bucket/file ownership checks and size/count limits
- wire bucket workspace multi-select plus a Download Selected action to the new endpoint
- add backend handler/router coverage, regenerate Swagger docs, and extend bucket workspace E2E coverage for batch download requests

## Why
Bucket workspace downloads were limited to one file at a time. This change ships the bounded multi-file flow behind an explicit zip endpoint so the UI can batch-download safely without unbounded archive work.

## Validation
- `go test ./...` in `api-go`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4 run --allow-parallel-runners --timeout 5m ./internal/handlers ./internal/app`
- `git diff --check`

## Notes
- Frontend build/Playwright were not run locally because repo guidance pushes CPU-heavy validation to Woodpecker/CI.
