### PR TITLE
[codex] THE-916 split source handler semantics from provider capabilities

### DIFF
--- a/api-go/internal/manager/source.go
+++ b/api-go/internal/manager/source.go
@@ -52,48 +52,17 @@ func InspectSource(ctx context.Context, src *repository.Source, factory SourceCl
 	if src == nil {
 		return SourceInfo{}, errors.New("nil source")
 	}
-	switch src.Type {
-	case repository.SourceTypeGDrive:
-		cli, err := sourceClientFor(ctx, src, factory)
-		if err != nil {
-			return SourceInfo{}, err
-		}
-		infoClient, ok := cli.(sourcecap.InfoProvider)
-		if !ok {
-			return SourceInfo{}, ErrUnsupportedSourceType
-		}
-		info, err := infoClient.SourceInfo(ctx)
-		if err != nil {
-			return SourceInfo{}, err
-		}
-		respFiles := make([]SourceInfoFile, 0, len(info.Files))
-		for _, f := range info.Files {
-			respFiles = append(respFiles, SourceInfoFile{ID: f.ID, Name: f.Name, Size: f.Size})
-		}
-		return SourceInfo{Files: respFiles, StorageTotal: info.StorageTotal, StorageUsed: info.StorageUsed, StorageFree: info.StorageFree}, nil
-	case repository.SourceTypeTelegram:
-		return SourceInfo{Files: []SourceInfoFile{}}, nil
-	case repository.SourceTypeS3:
-		cli, err := sourceClientFor(ctx, src, factory)
-		if err != nil {
-			return SourceInfo{}, err
-		}
-		infoClient, ok := cli.(sourcecap.InfoProvider)
-		if !ok {
-			return SourceInfo{}, ErrUnsupportedSourceType
-		}
-		info, err := infoClient.SourceInfo(ctx)
-		if err != nil {
-			return SourceInfo{}, err
-		}
-		respFiles := make([]SourceInfoFile, 0, len(info.Files))
-		for _, f := range info.Files {
-			respFiles = append(respFiles, SourceInfoFile{ID: f.ID, Name: f.Name, Size: f.Size})
-		}
-		return SourceInfo{Files: respFiles, StorageTotal: info.StorageTotal, StorageUsed: info.StorageUsed, StorageFree: info.StorageFree}, nil
-	default:
+	if info, ok := sourceTypeDefaultInfo(src.Type); ok {
+		return info, nil
+	}
+	if !sourceTypeSupportsProviderInfo(src.Type) {
 		return SourceInfo{}, ErrUnsupportedSourceType
 	}
+	cli, err := sourceClientFor(ctx, src, factory)
+	if err != nil {
+		return SourceInfo{}, err
+	}
+	return inspectSourceProvider(ctx, cli)
 }
 
 func CheckSourceHealth(ctx context.Context, src *repository.Source, factory SourceClientFactory) (SourceHealth, error) {
@@ -125,28 +94,22 @@ func CheckSourceHealth(ctx context.Context, src *repository.Source, factory Sour
 		return finish(SourceHealthUnhealthy, "client_error", "Source configuration could not be initialized."), nil
 	}
 
-	switch src.Type {
-	case repository.SourceTypeGDrive, repository.SourceTypeTelegram, repository.SourceTypeS3:
-		healthClient, ok := cli.(sourcecap.HealthProber)
-		if !ok {
-			return SourceHealth{}, ErrUnsupportedSourceType
-		}
-		result, err := healthClient.ProbeSourceHealth(ctx)
-		if errors.Is(err, sourcecap.ErrUnsupportedCapability) {
-			return SourceHealth{}, ErrUnsupportedSourceType
-		}
-		if err != nil && result.ReasonCode == "" {
-			result = sourcecap.Health{
-				Status:     sourcecap.HealthUnhealthy,
-				ReasonCode: "probe_failed",
-				Message:    "Source health probe failed.",
-			}
-		}
-		health.Quota = sourceQuotaFromCapability(result.Quota)
-		return finish(sourceHealthStatusFromCapability(result.Status), result.ReasonCode, result.Message), nil
-	default:
+	if !sourceTypeSupportsHealth(src.Type) {
 		return SourceHealth{}, ErrUnsupportedSourceType
 	}
+	result, err := probeSourceHealthProvider(ctx, cli)
+	if errors.Is(err, sourcecap.ErrUnsupportedCapability) {
+		return SourceHealth{}, ErrUnsupportedSourceType
+	}
+	if err != nil && result.ReasonCode == "" {
+		result = sourcecap.Health{
+			Status:     sourcecap.HealthUnhealthy,
+			ReasonCode: "probe_failed",
+			Message:    "Source health probe failed.",
+		}
+	}
+	health.Quota = sourceQuotaFromCapability(result.Quota)
+	return finish(sourceHealthStatusFromCapability(result.Status), result.ReasonCode, result.Message), nil
 }
 
 func sourceHealthStatusFromCapability(status sourcecap.HealthStatus) SourceHealthStatus {
@@ -172,21 +135,14 @@ func DownloadSourceFile(ctx context.Context, src *repository.Source, fileID stri
 	if src == nil {
 		return nil, errors.New("nil source")
 	}
-	switch src.Type {
-	case repository.SourceTypeGDrive, repository.SourceTypeS3:
-		cli, err := sourceClientFor(ctx, src, factory)
-		if err != nil {
-			return nil, err
-		}
-		if streamClient, ok := cli.(interface {
-			DownloadStream(context.Context, string) (io.ReadCloser, error)
-		}); ok {
-			return streamClient.DownloadStream(ctx, fileID)
-		}
-		return cli.Download(ctx, fileID)
-	default:
+	if !sourceTypeSupportsDirectDownload(src.Type) {
 		return nil, ErrUnsupportedSourceType
 	}
+	cli, err := sourceClientFor(ctx, src, factory)
+	if err != nil {
+		return nil, err
+	}
+	return downloadSourceProviderFile(ctx, cli, fileID)
 }
 
 func sourceClientFor(ctx context.Context, src *repository.Source, factory SourceClientFactory) (SourceClient, error) {
@@ -194,4 +150,40 @@ func sourceClientFor(ctx context.Context, src *repository.Source, factory Source
 		factory = NewSourceClient
 	}
 	return factory(ctx, src)
+}
+
+func sourceTypeDefaultInfo(sourceType repository.SourceType) (SourceInfo, bool) {
+	switch sourceType {
+	case repository.SourceTypeTelegram:
+		return SourceInfo{Files: []SourceInfoFile{}}, true
+	default:
+		return SourceInfo{}, false
+	}
+}
+
+func sourceTypeSupportsProviderInfo(sourceType repository.SourceType) bool {
+	switch sourceType {
+	case repository.SourceTypeGDrive, repository.SourceTypeS3:
+		return true
+	default:
+		return false
+	}
+}
+
+func sourceTypeSupportsHealth(sourceType repository.SourceType) bool {
+	switch sourceType {
+	case repository.SourceTypeGDrive, repository.SourceTypeTelegram, repository.SourceTypeS3:
+		return true
+	default:
+		return false
+	}
+}
+
+func sourceTypeSupportsDirectDownload(sourceType repository.SourceType) bool {
+	switch sourceType {
+	case repository.SourceTypeGDrive, repository.SourceTypeS3:
+		return true
+	default:
+		return false
+	}
 }

--- a/api-go/internal/manager/source_provider_capabilities.go
+++ b/api-go/internal/manager/source_provider_capabilities.go
@@ -1,0 +1,52 @@
+package manager
+
+import (
+	"context"
+	"io"
+
+	"github.com/example/sfree/api-go/internal/sourcecap"
+)
+
+type sourceStreamDownloader interface {
+	DownloadStream(context.Context, string) (io.ReadCloser, error)
+}
+
+func inspectSourceProvider(ctx context.Context, cli SourceClient) (SourceInfo, error) {
+	infoClient, ok := cli.(sourcecap.InfoProvider)
+	if !ok {
+		return SourceInfo{}, ErrUnsupportedSourceType
+	}
+	info, err := infoClient.SourceInfo(ctx)
+	if err != nil {
+		return SourceInfo{}, err
+	}
+	return sourceInfoFromCapability(info), nil
+}
+
+func probeSourceHealthProvider(ctx context.Context, cli SourceClient) (sourcecap.Health, error) {
+	healthClient, ok := cli.(sourcecap.HealthProber)
+	if !ok {
+		return sourcecap.Health{}, sourcecap.ErrUnsupportedCapability
+	}
+	return healthClient.ProbeSourceHealth(ctx)
+}
+
+func downloadSourceProviderFile(ctx context.Context, cli SourceClient, fileID string) (io.ReadCloser, error) {
+	if streamClient, ok := cli.(sourceStreamDownloader); ok {
+		return streamClient.DownloadStream(ctx, fileID)
+	}
+	return cli.Download(ctx, fileID)
+}
+
+func sourceInfoFromCapability(info sourcecap.Info) SourceInfo {
+	respFiles := make([]SourceInfoFile, 0, len(info.Files))
+	for _, f := range info.Files {
+		respFiles = append(respFiles, SourceInfoFile{ID: f.ID, Name: f.Name, Size: f.Size})
+	}
+	return SourceInfo{
+		Files:        respFiles,
+		StorageTotal: info.StorageTotal,
+		StorageUsed:  info.StorageUsed,
+		StorageFree:  info.StorageFree,
+	}
+}

--- a/api-go/internal/manager/source_provider_capabilities_test.go
+++ b/api-go/internal/manager/source_provider_capabilities_test.go
@@ -1,0 +1,112 @@
+package manager
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/example/sfree/api-go/internal/sourcecap"
+)
+
+type bareSourceClient struct{}
+
+func (bareSourceClient) Upload(context.Context, string, io.Reader) (string, error) {
+	return "", nil
+}
+
+func (bareSourceClient) Download(context.Context, string) (io.ReadCloser, error) {
+	return io.NopCloser(strings.NewReader("download")), nil
+}
+
+func (bareSourceClient) Delete(context.Context, string) error {
+	return nil
+}
+
+type streamingSourceClient struct {
+	downloadCalls       int
+	downloadStreamCalls int
+}
+
+func (c *streamingSourceClient) Upload(context.Context, string, io.Reader) (string, error) {
+	return "", nil
+}
+
+func (c *streamingSourceClient) Download(context.Context, string) (io.ReadCloser, error) {
+	c.downloadCalls++
+	return io.NopCloser(strings.NewReader("download")), nil
+}
+
+func (c *streamingSourceClient) DownloadStream(context.Context, string) (io.ReadCloser, error) {
+	c.downloadStreamCalls++
+	return io.NopCloser(strings.NewReader("stream")), nil
+}
+
+func (c *streamingSourceClient) Delete(context.Context, string) error {
+	return nil
+}
+
+func TestInspectSourceProviderMapsCapabilityInfo(t *testing.T) {
+	t.Parallel()
+
+	info, err := inspectSourceProvider(context.Background(), &stubSourceClient{
+		sourceInfo: sourcecap.Info{
+			Files:        []sourcecap.File{{ID: "file-id", Name: "file.txt", Size: 42}},
+			StorageTotal: 100,
+			StorageUsed:  42,
+			StorageFree:  58,
+		},
+	})
+	if err != nil {
+		t.Fatalf("inspect source provider: %v", err)
+	}
+	if len(info.Files) != 1 || info.Files[0].ID != "file-id" || info.Files[0].Name != "file.txt" || info.Files[0].Size != 42 {
+		t.Fatalf("unexpected files: %#v", info.Files)
+	}
+	if info.StorageTotal != 100 || info.StorageUsed != 42 || info.StorageFree != 58 {
+		t.Fatalf("unexpected storage info: %#v", info)
+	}
+}
+
+func TestInspectSourceProviderRejectsMissingInfoCapability(t *testing.T) {
+	t.Parallel()
+
+	_, err := inspectSourceProvider(context.Background(), bareSourceClient{})
+	if err != ErrUnsupportedSourceType {
+		t.Fatalf("expected ErrUnsupportedSourceType, got %v", err)
+	}
+}
+
+func TestProbeSourceHealthProviderRejectsMissingHealthCapability(t *testing.T) {
+	t.Parallel()
+
+	_, err := probeSourceHealthProvider(context.Background(), bareSourceClient{})
+	if err != sourcecap.ErrUnsupportedCapability {
+		t.Fatalf("expected ErrUnsupportedCapability, got %v", err)
+	}
+}
+
+func TestDownloadSourceProviderFilePrefersStreamCapability(t *testing.T) {
+	t.Parallel()
+
+	cli := &streamingSourceClient{}
+	body, err := downloadSourceProviderFile(context.Background(), cli, "file-id")
+	if err != nil {
+		t.Fatalf("download source provider file: %v", err)
+	}
+	defer func() { _ = body.Close() }()
+
+	data, err := io.ReadAll(body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if string(data) != "stream" {
+		t.Fatalf("expected stream body, got %q", data)
+	}
+	if cli.downloadCalls != 0 {
+		t.Fatalf("expected Download to be skipped, got %d calls", cli.downloadCalls)
+	}
+	if cli.downloadStreamCalls != 1 {
+		t.Fatalf("expected DownloadStream once, got %d calls", cli.downloadStreamCalls)
+	}
+}


### PR DESCRIPTION
## Summary
- split `api-go/internal/manager/source.go` into source-type policy helpers plus separate provider-capability helpers
- keep direct source download and source info semantics unchanged while removing provider capability plumbing from the handler-facing flow
- add focused manager tests for provider info mapping, unsupported capability handling, and stream-download preference

## Why
The source manager file still mixed handler semantics with provider capability resolution after the earlier source capability work. This isolates those concerns before the next source feature slice lands.

## Validation
- `go test ./internal/manager ./internal/handlers ./internal/resilience`
- `git diff --check`

## Notes
- no docs updates were needed because the public source API behavior is unchanged
