### PR TITLE
feat(webui): surface non-redundancy warnings in bucket setup and detail

### DIFF
--- a/webui/src/features/bucket/ui/create-bucket-dialog.tsx
+++ b/webui/src/features/bucket/ui/create-bucket-dialog.tsx
@@ -116,20 +116,27 @@ export function CreateBucketDialog({isOpen, onOpenChange, onCreated}: Props) {
                       </div>
                     ) : null}
                     {hasSources ? (
-                      <CheckboxGroup
-                        value={selectedSourceIds}
-                        onValueChange={(values) => setSelectedSourceIds(values as string[])}
-                        classNames={{wrapper: "gap-3"}}
-                      >
-                        {sources.map((source) => (
-                          <Checkbox key={source.id} value={source.id} classNames={{base: "max-w-full"}}>
-                            <div className="flex items-center gap-2">
-                              <span>{source.name}</span>
-                              <SourceTypeChip type={source.type} />
-                            </div>
-                          </Checkbox>
-                        ))}
-                      </CheckboxGroup>
+                      <>
+                        <CheckboxGroup
+                          value={selectedSourceIds}
+                          onValueChange={(values) => setSelectedSourceIds(values as string[])}
+                          classNames={{wrapper: "gap-3"}}
+                        >
+                          {sources.map((source) => (
+                            <Checkbox key={source.id} value={source.id} classNames={{base: "max-w-full"}}>
+                              <div className="flex items-center gap-2">
+                                <span>{source.name}</span>
+                                <SourceTypeChip type={source.type} />
+                              </div>
+                            </Checkbox>
+                          ))}
+                        </CheckboxGroup>
+                        <div className="rounded-lg border border-warning-200 bg-warning-50 p-3">
+                          <p className="text-sm text-warning-700">
+                            SFree distributes file chunks across your selected sources but does not replicate them. If an upstream source becomes unavailable, affected files may be unrecoverable.
+                          </p>
+                        </div>
+                      </>
                     ) : null}
                   </div>
 

--- a/webui/src/pages/bucket/ui/bucket-page.tsx
+++ b/webui/src/pages/bucket/ui/bucket-page.tsx
@@ -311,6 +311,11 @@ export function BucketPage() {
           </Chip>
         </div>
         <CredentialsPanel bucket={bucket} />
+        <div className="rounded-lg border border-warning-200 bg-warning-50 p-3">
+          <p className="text-sm text-warning-700">
+            Files in this bucket are distributed across sources, not replicated. Losing a source can make affected files unrecoverable.
+          </p>
+        </div>
       </div>
       <div className="flex flex-wrap justify-end gap-2">
         {canManage && (


### PR DESCRIPTION
## Summary
- Adds a warning callout to the **bucket creation dialog** (source selection area) reminding users that SFree distributes chunks across sources but does not replicate them.
- Adds a matching warning to the **bucket detail page** below the credentials panel, visible whenever users manage files.
- Copy aligns with existing project docs: losing an upstream source can make affected files unrecoverable.

Resolves THE-926

## Test plan
- [ ] Open the create bucket dialog — verify warning appears below the source checkboxes when sources are loaded
- [ ] Open any bucket detail page — verify warning appears below the S3 credentials panel
- [ ] Check mobile viewport — warning should wrap cleanly without layout breakage
- [ ] Verify warning uses the existing `border-warning-200 bg-warning-50` pattern consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)