### PR TITLE
THE-924 Add bounded virtual-hosted-style routing for the S3 endpoint

### DIFF
--- a/api-go/internal/app/router_routes.go
+++ b/api-go/internal/app/router_routes.go
@@ -129,19 +129,43 @@ func registerS3Routes(router *gin.Engine, cfg *config.Config, deps *routerDepend
 	}
 	s3Auth := handlers.AWS4Auth(deps.bucketRepo, routerAccessSecret(cfg))
 	uploadChunkSize := routerUploadChunkSize(cfg)
+	listBuckets := handlers.ListBucketsS3(deps.bucketRepo)
+	headBucket := handlers.HeadBucket(deps.bucketRepo)
+	headObject := handlers.HeadObject(deps.bucketRepo, deps.fileRepo)
+	getObjectOrParts := handlers.GetObjectOrPartsWithFactory(deps.bucketRepo, deps.sourceRepo, deps.fileRepo, deps.mpRepo, deps.sourceFactory)
+	listObjectsOrUploads := handlers.ListObjectsOrUploads(deps.bucketRepo, deps.fileRepo, deps.mpRepo)
+	putObjectOrPart := handlers.PutObjectOrPartWithFactory(deps.bucketRepo, deps.sourceRepo, deps.fileRepo, deps.mpRepo, uploadChunkSize, deps.sourceFactory)
+	postBucket := handlers.PostBucketWithFactory(deps.bucketRepo, deps.sourceRepo, deps.fileRepo, deps.sourceFactory)
+	postObject := handlers.PostObjectWithFactory(deps.bucketRepo, deps.sourceRepo, deps.fileRepo, deps.mpRepo, uploadChunkSize, deps.sourceFactory)
+	deleteObjectOrAbort := handlers.DeleteObjectOrAbortWithFactory(deps.bucketRepo, deps.sourceRepo, deps.fileRepo, deps.mpRepo, deps.sourceFactory)
+
+	getDispatch := s3GetDispatchHandler(listBuckets, listObjectsOrUploads, getObjectOrParts)
+	headDispatch := s3HeadDispatchHandler(headBucket, headObject)
+	putDispatch := s3PutDispatchHandler(putObjectOrPart)
+	postDispatch := s3PostDispatchHandler(postBucket, postObject)
+	deleteDispatch := s3DeleteDispatchHandler(deleteObjectOrAbort)
+
 	for _, root := range []string{"/", "/api/s3"} {
-		router.GET(root, protectedHandlers(limits, s3Auth, handlers.ListBucketsS3(deps.bucketRepo))...)
+		router.GET(root, protectedHandlers(limits, s3Auth, getDispatch)...)
+		if root == "/" {
+			router.HEAD(root, protectedHandlers(limits, s3Auth, headDispatch)...)
+			router.POST(root, protectedHandlers(limits, s3Auth, postDispatch)...)
+		}
 	}
 	for _, prefix := range []string{"", "/api/s3"} {
 		bucketPath, objectPath := s3RoutePaths(prefix)
-		router.HEAD(bucketPath, protectedHandlers(limits, s3Auth, handlers.HeadBucket(deps.bucketRepo))...)
-		router.HEAD(objectPath, protectedHandlers(limits, s3Auth, handlers.HeadObject(deps.bucketRepo, deps.fileRepo))...)
-		router.GET(objectPath, protectedHandlers(limits, s3Auth, handlers.GetObjectOrPartsWithFactory(deps.bucketRepo, deps.sourceRepo, deps.fileRepo, deps.mpRepo, deps.sourceFactory))...)
-		router.GET(bucketPath, protectedHandlers(limits, s3Auth, handlers.ListObjectsOrUploads(deps.bucketRepo, deps.fileRepo, deps.mpRepo))...)
-		router.PUT(objectPath, protectedHandlers(limits, s3Auth, handlers.PutObjectOrPartWithFactory(deps.bucketRepo, deps.sourceRepo, deps.fileRepo, deps.mpRepo, uploadChunkSize, deps.sourceFactory))...)
-		router.POST(bucketPath, protectedHandlers(limits, s3Auth, handlers.PostBucketWithFactory(deps.bucketRepo, deps.sourceRepo, deps.fileRepo, deps.sourceFactory))...)
-		router.POST(objectPath, protectedHandlers(limits, s3Auth, handlers.PostObjectWithFactory(deps.bucketRepo, deps.sourceRepo, deps.fileRepo, deps.mpRepo, uploadChunkSize, deps.sourceFactory))...)
-		router.DELETE(objectPath, protectedHandlers(limits, s3Auth, handlers.DeleteObjectOrAbortWithFactory(deps.bucketRepo, deps.sourceRepo, deps.fileRepo, deps.mpRepo, deps.sourceFactory))...)
+		router.HEAD(bucketPath, protectedHandlers(limits, s3Auth, headDispatch)...)
+		router.HEAD(objectPath, protectedHandlers(limits, s3Auth, headDispatch)...)
+		router.GET(objectPath, protectedHandlers(limits, s3Auth, getDispatch)...)
+		router.GET(bucketPath, protectedHandlers(limits, s3Auth, getDispatch)...)
+		router.PUT(objectPath, protectedHandlers(limits, s3Auth, putDispatch)...)
+		router.POST(bucketPath, protectedHandlers(limits, s3Auth, postDispatch)...)
+		router.POST(objectPath, protectedHandlers(limits, s3Auth, postDispatch)...)
+		router.DELETE(objectPath, protectedHandlers(limits, s3Auth, deleteDispatch)...)
+		if prefix == "" {
+			router.PUT(bucketPath, protectedHandlers(limits, s3Auth, putDispatch)...)
+			router.DELETE(bucketPath, protectedHandlers(limits, s3Auth, deleteDispatch)...)
+		}
 	}
 }
 

--- a/api-go/internal/app/router_test.go
+++ b/api-go/internal/app/router_test.go
@@ -151,9 +151,13 @@ func TestRegisterS3RoutesIncludesRootAndLegacyEndpoints(t *testing.T) {
 		path   string
 	}{
 		{http.MethodGet, "/"},
+		{http.MethodHead, "/"},
+		{http.MethodPost, "/"},
 		{http.MethodGet, "/api/s3"},
 		{http.MethodHead, "/:bucket"},
 		{http.MethodGet, "/:bucket"},
+		{http.MethodPut, "/:bucket"},
+		{http.MethodDelete, "/:bucket"},
 		{http.MethodHead, "/:bucket/*object"},
 		{http.MethodGet, "/:bucket/*object"},
 		{http.MethodPut, "/:bucket/*object"},

--- a/api-go/internal/app/s3_virtual_host.go
+++ b/api-go/internal/app/s3_virtual_host.go
@@ -1,0 +1,146 @@
+package app
+
+import (
+	"net"
+	"net/http"
+	"strings"
+
+	"github.com/example/sfree/api-go/internal/handlers"
+	"github.com/gin-gonic/gin"
+)
+
+func s3GetDispatchHandler(listBuckets, listObjectsOrUploads, getObjectOrParts gin.HandlerFunc) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		_, objectKey, hasBucket := applyS3DispatchTarget(c)
+		if !hasBucket {
+			listBuckets(c)
+			return
+		}
+		if objectKey == "" {
+			listObjectsOrUploads(c)
+			return
+		}
+		getObjectOrParts(c)
+	}
+}
+
+func s3HeadDispatchHandler(headBucket, headObject gin.HandlerFunc) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		_, objectKey, hasBucket := applyS3DispatchTarget(c)
+		if !hasBucket {
+			c.Status(http.StatusNotFound)
+			return
+		}
+		if objectKey == "" {
+			headBucket(c)
+			return
+		}
+		headObject(c)
+	}
+}
+
+func s3PutDispatchHandler(putObjectOrPart gin.HandlerFunc) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		_, objectKey, hasBucket := applyS3DispatchTarget(c)
+		if !hasBucket || objectKey == "" {
+			c.Status(http.StatusNotFound)
+			return
+		}
+		putObjectOrPart(c)
+	}
+}
+
+func s3PostDispatchHandler(postBucket, postObject gin.HandlerFunc) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		_, objectKey, hasBucket := applyS3DispatchTarget(c)
+		if !hasBucket {
+			c.Status(http.StatusNotFound)
+			return
+		}
+		if objectKey == "" {
+			postBucket(c)
+			return
+		}
+		postObject(c)
+	}
+}
+
+func s3DeleteDispatchHandler(deleteObjectOrAbort gin.HandlerFunc) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		_, objectKey, hasBucket := applyS3DispatchTarget(c)
+		if !hasBucket || objectKey == "" {
+			c.Status(http.StatusNotFound)
+			return
+		}
+		deleteObjectOrAbort(c)
+	}
+}
+
+func applyS3DispatchTarget(c *gin.Context) (string, string, bool) {
+	if bucketKey, objectKey, ok := s3VirtualHostedTarget(c.Request); ok {
+		handlers.SetS3BucketKey(c, bucketKey)
+		handlers.SetS3ObjectKey(c, objectKey)
+		return bucketKey, objectKey, true
+	}
+
+	bucketKey := handlers.S3BucketKey(c)
+	if bucketKey == "" {
+		return "", "", false
+	}
+
+	objectKey := strings.TrimPrefix(c.Param("object"), "/")
+	handlers.SetS3BucketKey(c, bucketKey)
+	handlers.SetS3ObjectKey(c, objectKey)
+	return bucketKey, objectKey, true
+}
+
+func s3VirtualHostedTarget(r *http.Request) (string, string, bool) {
+	bucketKey := s3VirtualHostedBucket(r)
+	if bucketKey == "" {
+		return "", "", false
+	}
+	objectKey := ""
+	if r != nil && r.URL != nil {
+		objectKey = strings.TrimPrefix(r.URL.Path, "/")
+	}
+	return bucketKey, objectKey, true
+}
+
+func s3VirtualHostedBucket(r *http.Request) string {
+	if r == nil || r.URL == nil || strings.HasPrefix(r.URL.Path, "/api/s3") {
+		return ""
+	}
+
+	host := s3RequestHost(r)
+	if host == "" || net.ParseIP(host) != nil {
+		return ""
+	}
+
+	labels := strings.Split(strings.ToLower(host), ".")
+	if len(labels) < 2 || labels[0] == "" {
+		return ""
+	}
+	return labels[0]
+}
+
+func s3RequestHost(r *http.Request) string {
+	if r == nil {
+		return ""
+	}
+
+	host := r.Host
+	if host == "" && r.URL != nil {
+		host = r.URL.Host
+	}
+	if host == "" {
+		host = r.Header.Get("Host")
+	}
+	if host == "" {
+		return ""
+	}
+
+	if parsedHost, _, err := net.SplitHostPort(host); err == nil {
+		return parsedHost
+	}
+	return strings.Trim(host, "[]")
+}

--- a/api-go/internal/app/s3_virtual_host_test.go
+++ b/api-go/internal/app/s3_virtual_host_test.go
@@ -1,0 +1,220 @@
+package app
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/example/sfree/api-go/internal/handlers"
+	"github.com/gin-gonic/gin"
+)
+
+func TestS3VirtualHostedBucket(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		target string
+		host   string
+		want   string
+	}{
+		{name: "bucket subdomain", target: "/", host: "bucket.localhost:9000", want: "bucket"},
+		{name: "legacy path ignored", target: "/api/s3/bucket/object.txt", host: "bucket.localhost:9000"},
+		{name: "localhost ignored", target: "/", host: "localhost:9000"},
+		{name: "ipv4 ignored", target: "/", host: "127.0.0.1:9000"},
+		{name: "ipv6 ignored", target: "/", host: "[::1]:9000"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			req := httptest.NewRequest(http.MethodGet, tt.target, nil)
+			req.Host = tt.host
+
+			if got := s3VirtualHostedBucket(req); got != tt.want {
+				t.Fatalf("expected bucket %q, got %q", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestS3GetDispatchHandlerListsBucketsAtBareRoot(t *testing.T) {
+	t.Parallel()
+
+	c, _ := newS3DispatchTestContext(t, http.MethodGet, "/", "", nil)
+	var listBucketsCalled bool
+	handler := s3GetDispatchHandler(
+		func(c *gin.Context) {
+			listBucketsCalled = true
+			c.Status(http.StatusOK)
+		},
+		func(c *gin.Context) {
+			t.Fatal("list objects handler should not run")
+		},
+		func(c *gin.Context) {
+			t.Fatal("get object handler should not run")
+		},
+	)
+
+	handler(c)
+
+	if !listBucketsCalled {
+		t.Fatal("expected list buckets handler to run")
+	}
+	if got := c.Writer.Status(); got != http.StatusOK {
+		t.Fatalf("expected 200, got %d", got)
+	}
+}
+
+func TestS3GetDispatchHandlerListsObjectsAtVirtualRoot(t *testing.T) {
+	t.Parallel()
+
+	c, _ := newS3DispatchTestContext(t, http.MethodGet, "/", "bucket.localhost:9000", nil)
+	var gotBucket string
+	handler := s3GetDispatchHandler(
+		func(c *gin.Context) {
+			t.Fatal("list buckets handler should not run")
+		},
+		func(c *gin.Context) {
+			gotBucket = handlers.S3BucketKey(c)
+			c.Status(http.StatusOK)
+		},
+		func(c *gin.Context) {
+			t.Fatal("get object handler should not run")
+		},
+	)
+
+	handler(c)
+
+	if gotBucket != "bucket" {
+		t.Fatalf("expected virtual bucket %q, got %q", "bucket", gotBucket)
+	}
+	if got := c.Param("object"); got != "" {
+		t.Fatalf("expected empty object param, got %q", got)
+	}
+	if got := c.Writer.Status(); got != http.StatusOK {
+		t.Fatalf("expected 200, got %d", got)
+	}
+}
+
+func TestS3GetDispatchHandlerGetsObjectForVirtualSingleSegmentPath(t *testing.T) {
+	t.Parallel()
+
+	c, _ := newS3DispatchTestContext(t, http.MethodGet, "/readme.txt", "bucket.localhost:9000", gin.Params{
+		{Key: "bucket", Value: "readme.txt"},
+	})
+	var gotBucket string
+	var gotObject string
+	handler := s3GetDispatchHandler(
+		func(c *gin.Context) {
+			t.Fatal("list buckets handler should not run")
+		},
+		func(c *gin.Context) {
+			t.Fatal("list objects handler should not run")
+		},
+		func(c *gin.Context) {
+			gotBucket = handlers.S3BucketKey(c)
+			gotObject = c.Param("object")
+			c.Status(http.StatusOK)
+		},
+	)
+
+	handler(c)
+
+	if gotBucket != "bucket" {
+		t.Fatalf("expected virtual bucket %q, got %q", "bucket", gotBucket)
+	}
+	if gotObject != "/readme.txt" {
+		t.Fatalf("expected object param %q, got %q", "/readme.txt", gotObject)
+	}
+	if got := c.Writer.Status(); got != http.StatusOK {
+		t.Fatalf("expected 200, got %d", got)
+	}
+}
+
+func TestS3HeadDispatchHandlerRejectsBareRoot(t *testing.T) {
+	t.Parallel()
+
+	c, _ := newS3DispatchTestContext(t, http.MethodHead, "/", "", nil)
+	handler := s3HeadDispatchHandler(
+		func(c *gin.Context) {
+			t.Fatal("head bucket handler should not run")
+		},
+		func(c *gin.Context) {
+			t.Fatal("head object handler should not run")
+		},
+	)
+
+	handler(c)
+
+	if got := c.Writer.Status(); got != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", got)
+	}
+}
+
+func TestS3PostDispatchHandlerUsesBucketOperationAtVirtualRoot(t *testing.T) {
+	t.Parallel()
+
+	c, _ := newS3DispatchTestContext(t, http.MethodPost, "/?delete", "bucket.localhost:9000", nil)
+	var gotBucket string
+	handler := s3PostDispatchHandler(
+		func(c *gin.Context) {
+			gotBucket = handlers.S3BucketKey(c)
+			c.Status(http.StatusNoContent)
+		},
+		func(c *gin.Context) {
+			t.Fatal("post object handler should not run")
+		},
+	)
+
+	handler(c)
+
+	if gotBucket != "bucket" {
+		t.Fatalf("expected virtual bucket %q, got %q", "bucket", gotBucket)
+	}
+	if got := c.Writer.Status(); got != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d", got)
+	}
+}
+
+func TestS3PutDispatchHandlerUsesVirtualSingleSegmentObject(t *testing.T) {
+	t.Parallel()
+
+	c, _ := newS3DispatchTestContext(t, http.MethodPut, "/upload.bin", "bucket.localhost:9000", gin.Params{
+		{Key: "bucket", Value: "upload.bin"},
+	})
+	var gotBucket string
+	var gotObject string
+	handler := s3PutDispatchHandler(func(c *gin.Context) {
+		gotBucket = handlers.S3BucketKey(c)
+		gotObject = c.Param("object")
+		c.Status(http.StatusOK)
+	})
+
+	handler(c)
+
+	if gotBucket != "bucket" {
+		t.Fatalf("expected virtual bucket %q, got %q", "bucket", gotBucket)
+	}
+	if gotObject != "/upload.bin" {
+		t.Fatalf("expected object param %q, got %q", "/upload.bin", gotObject)
+	}
+	if got := c.Writer.Status(); got != http.StatusOK {
+		t.Fatalf("expected 200, got %d", got)
+	}
+}
+
+func newS3DispatchTestContext(t *testing.T, method, target, host string, params gin.Params) (*gin.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	req := httptest.NewRequest(method, target, nil)
+	req.Host = host
+	c.Request = req
+	c.Params = params
+	return c, w
+}

--- a/api-go/internal/handlers/s3.go
+++ b/api-go/internal/handlers/s3.go
@@ -33,7 +33,7 @@ func isBucketSourceResolutionError(err error) bool {
 
 func lookupBucket(c *gin.Context, bucketRepo objectBucketReader) (*repository.Bucket, bool) {
 	ctx := c.Request.Context()
-	bucketDoc, err := bucketRepo.GetByKey(ctx, c.Param("bucket"))
+	bucketDoc, err := bucketRepo.GetByKey(ctx, S3BucketKey(c))
 	if err != nil {
 		if err == mongo.ErrNoDocuments {
 			writeS3Error(c, http.StatusNotFound, "NoSuchBucket", "")

--- a/api-go/internal/handlers/s3_list.go
+++ b/api-go/internal/handlers/s3_list.go
@@ -176,7 +176,7 @@ func ListObjects(bucketRepo *repository.BucketRepository, fileRepo *repository.F
 			c.Status(http.StatusServiceUnavailable)
 			return
 		}
-		bucketKey := c.Param("bucket")
+		bucketKey := S3BucketKey(c)
 		bucketDoc, ok := lookupBucket(c, bucketRepo)
 		if !ok {
 			return
@@ -218,7 +218,7 @@ func ListObjectsV2(bucketRepo *repository.BucketRepository, fileRepo *repository
 			c.Status(http.StatusServiceUnavailable)
 			return
 		}
-		bucketKey := c.Param("bucket")
+		bucketKey := S3BucketKey(c)
 		bucketDoc, ok := lookupBucket(c, bucketRepo)
 		if !ok {
 			return

--- a/api-go/internal/handlers/s3_multipart_complete.go
+++ b/api-go/internal/handlers/s3_multipart_complete.go
@@ -45,8 +45,8 @@ func completeMultipartUpload(c *gin.Context, bucketRepo *repository.BucketReposi
 	}
 	c.XML(http.StatusOK, completeMultipartUploadResult{
 		Xmlns:    "http://s3.amazonaws.com/doc/2006-03-01/",
-		Location: fmt.Sprintf("/%s/%s", c.Param("bucket"), result.Upload.ObjectKey),
-		Bucket:   c.Param("bucket"),
+		Location: fmt.Sprintf("/%s/%s", S3BucketKey(c), result.Upload.ObjectKey),
+		Bucket:   S3BucketKey(c),
 		Key:      result.Upload.ObjectKey,
 		ETag:     result.ETag,
 	})

--- a/api-go/internal/handlers/s3_multipart_create.go
+++ b/api-go/internal/handlers/s3_multipart_create.go
@@ -38,7 +38,7 @@ func createMultipartUpload(c *gin.Context, bucketRepo *repository.BucketReposito
 	}
 	c.XML(http.StatusOK, initiateMultipartUploadResult{
 		Xmlns:    "http://s3.amazonaws.com/doc/2006-03-01/",
-		Bucket:   c.Param("bucket"),
+		Bucket:   S3BucketKey(c),
 		Key:      objectKey,
 		UploadId: uploadID,
 	})

--- a/api-go/internal/handlers/s3_multipart_list.go
+++ b/api-go/internal/handlers/s3_multipart_list.go
@@ -157,7 +157,7 @@ func listMultipartUploads(c *gin.Context, bucketRepo objectBucketReader, mpRepo 
 
 	c.XML(http.StatusOK, listMultipartUploadsResult{
 		Xmlns:              "http://s3.amazonaws.com/doc/2006-03-01/",
-		Bucket:             c.Param("bucket"),
+		Bucket:             S3BucketKey(c),
 		KeyMarker:          keyMarker,
 		UploadIDMarker:     uploadIDMarker,
 		NextKeyMarker:      page.nextKeyMarker,
@@ -199,7 +199,7 @@ func listParts(c *gin.Context, bucketRepo objectBucketReader, mpRepo multipartUp
 
 	c.XML(http.StatusOK, listPartsResult{
 		Xmlns:                "http://s3.amazonaws.com/doc/2006-03-01/",
-		Bucket:               c.Param("bucket"),
+		Bucket:               S3BucketKey(c),
 		Key:                  mu.ObjectKey,
 		UploadId:             uploadID,
 		PartNumberMarker:     partNumberMarker,

--- a/api-go/internal/handlers/s3_object.go
+++ b/api-go/internal/handlers/s3_object.go
@@ -45,10 +45,6 @@ type objectFileReader interface {
 	GetByName(ctx context.Context, bucketID primitive.ObjectID, name string) (*repository.File, error)
 }
 
-func s3ObjectKey(c *gin.Context) string {
-	return strings.TrimPrefix(c.Param("object"), "/")
-}
-
 func parseCopySource(raw string) (string, string, bool) {
 	raw = strings.TrimSpace(raw)
 	raw = strings.TrimPrefix(raw, "/")

--- a/api-go/internal/handlers/s3_request_routing.go
+++ b/api-go/internal/handlers/s3_request_routing.go
@@ -1,0 +1,56 @@
+package handlers
+
+import "github.com/gin-gonic/gin"
+
+const (
+	s3BucketContextKey = "s3Bucket"
+	s3ObjectContextKey = "s3Object"
+)
+
+func S3BucketKey(c *gin.Context) string {
+	if bucketKey := c.GetString(s3BucketContextKey); bucketKey != "" {
+		return bucketKey
+	}
+	return c.Param("bucket")
+}
+
+func SetS3BucketKey(c *gin.Context, bucketKey string) {
+	c.Set(s3BucketContextKey, bucketKey)
+	upsertRouteParam(c, "bucket", bucketKey)
+}
+
+func s3ObjectKey(c *gin.Context) string {
+	if objectKey := c.GetString(s3ObjectContextKey); objectKey != "" {
+		return objectKey
+	}
+	return trimS3ObjectParam(c.Param("object"))
+}
+
+func SetS3ObjectKey(c *gin.Context, objectKey string) {
+	c.Set(s3ObjectContextKey, objectKey)
+	rawParam := ""
+	if objectKey != "" {
+		rawParam = "/" + objectKey
+	}
+	upsertRouteParam(c, "object", rawParam)
+}
+
+func trimS3ObjectParam(raw string) string {
+	if raw == "/" {
+		return ""
+	}
+	for len(raw) > 0 && raw[0] == '/' {
+		raw = raw[1:]
+	}
+	return raw
+}
+
+func upsertRouteParam(c *gin.Context, key, value string) {
+	for i := range c.Params {
+		if c.Params[i].Key == key {
+			c.Params[i].Value = value
+			return
+		}
+	}
+	c.Params = append(c.Params, gin.Param{Key: key, Value: value})
+}


### PR DESCRIPTION
## Summary
- add bounded virtual-hosted-style S3 request dispatch on the root endpoint without breaking existing path-style routes
- reuse the existing S3 auth/rate-limit chain while rewriting bucket/object params for qualifying host-based requests
- cover the new routing behavior with router and handler tests

## Testing
- `go test ./internal/app ./internal/handlers`
