### PR TITLE
[codex] Add cursor pagination to bucket workspace file list

### DIFF
--- a/api-go/internal/docs/docs.go
+++ b/api-go/internal/docs/docs.go
@@ -758,6 +758,18 @@ const docTemplate = `{
                         "description": "Filename search query",
                         "name": "q",
                         "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page size for bounded file listing",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Continuation cursor for bounded file listing",
+                        "name": "cursor",
+                        "in": "query"
                     }
                 ],
                 "responses": {

--- a/api-go/internal/handlers/bucket_files.go
+++ b/api-go/internal/handlers/bucket_files.go
@@ -3,8 +3,10 @@ package handlers
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -28,7 +30,15 @@ type fileResponse struct {
 	Size      int64     `json:"size"`
 }
 
-const maxBatchDeleteFiles = 100
+type paginatedFileResponse struct {
+	Items      []fileResponse `json:"items"`
+	NextCursor string         `json:"next_cursor,omitempty"`
+}
+
+const (
+	maxBatchDeleteFiles       = 100
+	maxBucketFileListPageSize = 200
+)
 
 type batchDeleteFilesRequest struct {
 	FileIDs []string `json:"file_ids"`
@@ -125,6 +135,8 @@ func UploadFileWithFactory(bucketRepo *repository.BucketRepository, sourceRepo *
 // @Produce json
 // @Param id path string true "Bucket ID"
 // @Param q query string false "Filename search query"
+// @Param limit query int false "Page size for bounded file listing"
+// @Param cursor query string false "Continuation cursor for bounded file listing"
 // @Success 200 {array} fileResponse
 // @Failure 400 {string} string ""
 // @Failure 401 {string} string ""
@@ -146,7 +158,34 @@ func ListFiles(bucketRepo *repository.BucketRepository, fileRepo *repository.Fil
 			return
 		}
 		bucketID := acc.Bucket.ID
-		files, err := fileRepo.ListByBucketByNameQuery(c.Request.Context(), bucketID, strings.TrimSpace(c.Query("q")))
+		query := strings.TrimSpace(c.Query("q"))
+		limitParam := strings.TrimSpace(c.Query("limit"))
+		if limitParam == "" {
+			files, err := fileRepo.ListByBucketByNameQuery(c.Request.Context(), bucketID, query)
+			if err != nil {
+				slog.ErrorContext(ctx, "list files: list files", slog.String("error", err.Error()))
+				c.Status(http.StatusInternalServerError)
+				return
+			}
+			resp := make([]fileResponse, 0, len(files))
+			for _, f := range files {
+				resp = append(resp, fileResponse{
+					ID:        f.ID.Hex(),
+					Name:      f.Name,
+					CreatedAt: f.CreatedAt,
+					Size:      manager.FileSize(f),
+				})
+			}
+			c.JSON(http.StatusOK, resp)
+			return
+		}
+
+		limit, err := strconv.Atoi(limitParam)
+		if err != nil || limit < 1 || limit > maxBucketFileListPageSize {
+			c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("limit must be between 1 and %d", maxBucketFileListPageSize)})
+			return
+		}
+		files, hasMore, err := fileRepo.ListByBucketByNameQueryPage(c.Request.Context(), bucketID, query, c.Query("cursor"), limit)
 		if err != nil {
 			slog.ErrorContext(ctx, "list files: list files", slog.String("error", err.Error()))
 			c.Status(http.StatusInternalServerError)
@@ -161,7 +200,11 @@ func ListFiles(bucketRepo *repository.BucketRepository, fileRepo *repository.Fil
 				Size:      manager.FileSize(f),
 			})
 		}
-		c.JSON(http.StatusOK, resp)
+		page := paginatedFileResponse{Items: resp}
+		if hasMore && len(files) > 0 {
+			page.NextCursor = files[len(files)-1].Name
+		}
+		c.JSON(http.StatusOK, page)
 	}
 }
 

--- a/api-go/internal/handlers/bucket_test.go
+++ b/api-go/internal/handlers/bucket_test.go
@@ -149,6 +149,81 @@ func TestListFilesSearchQueryWithGrantAccess(t *testing.T) {
 	}
 }
 
+func TestListFilesPagination(t *testing.T) {
+	bucketRepo, fileRepo, grantRepo := newBucketFileHandlerTestRepos(t)
+	ctx := context.Background()
+	ownerID := primitive.NewObjectID()
+	bucket := createBucketFileTestBucket(t, ctx, bucketRepo, ownerID)
+
+	now := time.Now().UTC()
+	for _, file := range []repository.File{
+		{BucketID: bucket.ID, Name: "alpha.txt", CreatedAt: now},
+		{BucketID: bucket.ID, Name: "report-final.txt", CreatedAt: now},
+		{BucketID: bucket.ID, Name: "report-notes.txt", CreatedAt: now},
+		{BucketID: bucket.ID, Name: "report-summary.txt", CreatedAt: now},
+	} {
+		if _, err := fileRepo.Create(ctx, file); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	router := gin.New()
+	router.GET("/buckets/:id/files", setUserID(ownerID.Hex()), ListFiles(bucketRepo, fileRepo, grantRepo))
+
+	firstReq, _ := http.NewRequest(http.MethodGet, "/buckets/"+bucket.ID.Hex()+"/files?q=report&limit=2", nil)
+	firstW := httptest.NewRecorder()
+	router.ServeHTTP(firstW, firstReq)
+	if firstW.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", firstW.Code)
+	}
+
+	var firstPage paginatedFileResponse
+	if err := json.Unmarshal(firstW.Body.Bytes(), &firstPage); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+	if firstPage.NextCursor != "report-notes.txt" {
+		t.Fatalf("unexpected next cursor: %+v", firstPage)
+	}
+	if len(firstPage.Items) != 2 || firstPage.Items[0].Name != "report-final.txt" || firstPage.Items[1].Name != "report-notes.txt" {
+		t.Fatalf("unexpected first page: %+v", firstPage)
+	}
+
+	secondReq, _ := http.NewRequest(http.MethodGet, "/buckets/"+bucket.ID.Hex()+"/files?q=report&limit=2&cursor="+firstPage.NextCursor, nil)
+	secondW := httptest.NewRecorder()
+	router.ServeHTTP(secondW, secondReq)
+	if secondW.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", secondW.Code)
+	}
+
+	var secondPage paginatedFileResponse
+	if err := json.Unmarshal(secondW.Body.Bytes(), &secondPage); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+	if secondPage.NextCursor != "" {
+		t.Fatalf("expected empty next cursor on last page, got %+v", secondPage)
+	}
+	if len(secondPage.Items) != 1 || secondPage.Items[0].Name != "report-summary.txt" {
+		t.Fatalf("unexpected second page: %+v", secondPage)
+	}
+}
+
+func TestListFilesRejectsInvalidLimit(t *testing.T) {
+	bucketRepo, fileRepo, grantRepo := newBucketFileHandlerTestRepos(t)
+	ctx := context.Background()
+	ownerID := primitive.NewObjectID()
+	bucket := createBucketFileTestBucket(t, ctx, bucketRepo, ownerID)
+
+	router := gin.New()
+	router.GET("/buckets/:id/files", setUserID(ownerID.Hex()), ListFiles(bucketRepo, fileRepo, grantRepo))
+
+	req, _ := http.NewRequest(http.MethodGet, "/buckets/"+bucket.ID.Hex()+"/files?limit=0", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
 func newBucketFileHandlerTestRepos(t *testing.T) (*repository.BucketRepository, *repository.FileRepository, *repository.BucketGrantRepository) {
 	t.Helper()
 	cfg, err := config.Load()

--- a/api-go/internal/repository/file.go
+++ b/api-go/internal/repository/file.go
@@ -196,6 +196,49 @@ func (r *FileRepository) ListByBucketByNameQuery(ctx context.Context, bucketID p
 	return r.listByBucketFilter(ctx, filter)
 }
 
+func (r *FileRepository) ListByBucketByNameQueryPage(ctx context.Context, bucketID primitive.ObjectID, query, after string, limit int) ([]File, bool, error) {
+	filter := bson.M{"bucket_id": bucketID}
+	nameFilter := bson.M{}
+	if query = strings.TrimSpace(query); query != "" {
+		nameFilter["$regex"] = regexp.QuoteMeta(query)
+		nameFilter["$options"] = "i"
+	}
+	if after = strings.TrimSpace(after); after != "" {
+		nameFilter["$gt"] = after
+	}
+	if len(nameFilter) > 0 {
+		filter["name"] = nameFilter
+	}
+
+	findOpts := options.Find().SetSort(bson.D{{Key: "name", Value: 1}})
+	if limit >= 0 {
+		findOpts.SetLimit(int64(limit + 1))
+	}
+	cursor, err := r.coll.Find(ctx, filter, findOpts)
+	if err != nil {
+		return nil, false, err
+	}
+	defer func() { _ = cursor.Close(ctx) }()
+
+	files := make([]File, 0, max(limit, 0))
+	for cursor.Next(ctx) {
+		var f File
+		if err := cursor.Decode(&f); err != nil {
+			return nil, false, err
+		}
+		files = append(files, f)
+	}
+	if err := cursor.Err(); err != nil {
+		return nil, false, err
+	}
+
+	hasMore := limit >= 0 && len(files) > limit
+	if hasMore {
+		files = files[:limit]
+	}
+	return files, hasMore, nil
+}
+
 func (r *FileRepository) ListByBucketWithPrefix(ctx context.Context, bucketID primitive.ObjectID, prefix string) ([]File, error) {
 	filter := bson.M{"bucket_id": bucketID}
 	if prefix != "" {

--- a/api-go/internal/repository/file_test.go
+++ b/api-go/internal/repository/file_test.go
@@ -178,6 +178,44 @@ func TestFileRepositoryListByBucketByNameQuery(t *testing.T) {
 	assertFileNames(t, blankMatches, fileNames(unfiltered))
 }
 
+func TestFileRepositoryListByBucketByNameQueryPage(t *testing.T) {
+	_, repo := newFileRepositoryTestDB(t)
+	ctx := context.Background()
+	bucketID := primitive.NewObjectID()
+	otherBucketID := primitive.NewObjectID()
+	now := time.Now().UTC()
+
+	for _, file := range []File{
+		{BucketID: bucketID, Name: "alpha.txt", CreatedAt: now},
+		{BucketID: bucketID, Name: "report-final.txt", CreatedAt: now},
+		{BucketID: bucketID, Name: "report-notes.txt", CreatedAt: now},
+		{BucketID: bucketID, Name: "report[1].txt", CreatedAt: now},
+		{BucketID: otherBucketID, Name: "report-zeta.txt", CreatedAt: now},
+	} {
+		if _, err := repo.Create(ctx, file); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	page, hasMore, err := repo.ListByBucketByNameQueryPage(ctx, bucketID, "report", "", 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasMore {
+		t.Fatal("expected more results on first page")
+	}
+	assertFileNames(t, page, []string{"report-final.txt", "report-notes.txt"})
+
+	nextPage, hasMore, err := repo.ListByBucketByNameQueryPage(ctx, bucketID, "report", page[len(page)-1].Name, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hasMore {
+		t.Fatal("expected last page")
+	}
+	assertFileNames(t, nextPage, []string{"report[1].txt"})
+}
+
 func newFileRepositoryTestDB(t *testing.T) (*mongo.Database, *FileRepository) {
 	t.Helper()
 	cfg, err := config.Load()

--- a/webui/e2e/buckets.spec.ts
+++ b/webui/e2e/buckets.spec.ts
@@ -8,7 +8,7 @@
  * - Upload File button is present on the bucket detail page
  */
 
-import { test, expect, type Route } from "@playwright/test";
+import { test, expect, type Page, type Route } from "@playwright/test";
 import { API_GLOB, injectAuth, mockGet, mockPost } from "./helpers";
 
 const MOCK_SOURCE = {

--- a/webui/e2e/buckets.spec.ts
+++ b/webui/e2e/buckets.spec.ts
@@ -51,6 +51,16 @@ const MOCK_GRANT = {
   created_at: "2024-01-15T12:00:00Z",
 };
 
+async function mockBucketFiles(page: Page, bucketId: string, items: unknown[]) {
+  await page.route(`**/api/v1/buckets/${bucketId}/files*`, async (route) => {
+    if (route.request().method() !== "GET") {
+      await route.continue();
+      return;
+    }
+    await route.fulfill({status: 200, json: {items}});
+  });
+}
+
 test.describe("Bucket creation flow", () => {
   test("buckets page shows empty state when no buckets exist", async ({
     page,
@@ -163,7 +173,7 @@ test.describe("Bucket creation flow", () => {
     await injectAuth(page);
     await mockGet(page, "/buckets", [MOCK_BUCKET]);
     await mockGet(page, "/buckets/bkt-1", MOCK_BUCKET);
-    await mockGet(page, "/buckets/bkt-1/files", []);
+    await mockBucketFiles(page, "bkt-1", []);
     await page.goto("/buckets/bkt-1");
 
     await expect(
@@ -185,7 +195,7 @@ test.describe("Bucket creation flow", () => {
     await injectAuth(page);
     await mockGet(page, "/buckets", [MOCK_BUCKET]);
     await mockGet(page, "/buckets/bkt-1", MOCK_BUCKET);
-    await mockGet(page, "/buckets/bkt-1/files", []);
+    await mockBucketFiles(page, "bkt-1", []);
 
     let fulfillGrants: (() => Promise<void>) | undefined;
     await page.route(`${API_GLOB}/buckets/bkt-1/grants`, async (route) => {
@@ -212,7 +222,7 @@ test.describe("Bucket creation flow", () => {
     await injectAuth(page);
     await mockGet(page, "/buckets", [MOCK_BUCKET]);
     await mockGet(page, "/buckets/bkt-1", MOCK_BUCKET);
-    await mockGet(page, "/buckets/bkt-1/files", []);
+    await mockBucketFiles(page, "bkt-1", []);
     await mockGet(
       page,
       "/buckets/bkt-1/grants",
@@ -236,7 +246,7 @@ test.describe("Bucket creation flow", () => {
     await injectAuth(page);
     await mockGet(page, "/buckets", [MOCK_BUCKET]);
     await mockGet(page, "/buckets/bkt-1", MOCK_BUCKET);
-    await mockGet(page, "/buckets/bkt-1/files", []);
+    await mockBucketFiles(page, "bkt-1", []);
 
     const grantRoutes: Route[] = [];
     await page.route(`${API_GLOB}/buckets/bkt-1/grants`, async (route) => {
@@ -273,7 +283,7 @@ test.describe("Bucket creation flow", () => {
     await injectAuth(page);
     await mockGet(page, "/buckets", [MOCK_VIEWER_BUCKET]);
     await mockGet(page, "/buckets/bkt-1", MOCK_VIEWER_BUCKET);
-    await mockGet(page, "/buckets/bkt-1/files", []);
+    await mockBucketFiles(page, "bkt-1", []);
     await page.goto("/buckets/bkt-1");
 
     await expect(page.getByRole("button", { name: "Upload File" })).not.toBeVisible();

--- a/webui/e2e/error-states.spec.ts
+++ b/webui/e2e/error-states.spec.ts
@@ -5,7 +5,7 @@
  * - "Bucket not found" when navigating to a non-existent bucket ID
  * - Landing page auth dialogs open and close without crashing
  * - Register flow shows password after API call
- * - Login flow closes dialog and starts a session
+ * - Login flow closes dialog and persists auth
  */
 
 import { test, expect } from "@playwright/test";
@@ -68,15 +68,10 @@ test.describe("Error states", () => {
     await expect(dialog).not.toBeVisible();
   });
 
-  test("Login dialog opens and closes, starting a session", async ({
+  test("Login dialog opens and closes, storing credentials", async ({
     page,
   }) => {
-    await page.route(`${API_GLOB}/auth/session`, (route) =>
-      route.fulfill({status: 204, body: ""}),
-    );
-    await page.route(`${API_GLOB}/auth/me`, (route) =>
-      route.fulfill({status: 200, json: {id: "u-1", username: "alice"}}),
-    );
+    await page.route(`${API_GLOB}/**`, (route) => route.abort());
 
     await page.goto("/");
     await page.getByRole("button", { name: "Log In" }).first().click();
@@ -89,7 +84,9 @@ test.describe("Error states", () => {
     await dialog.getByRole("button", { name: "Log In" }).click();
 
     await expect(dialog).not.toBeVisible();
-    await expect(page).toHaveURL("/dashboard");
+
+    const auth = await page.evaluate(() => localStorage.getItem("auth"));
+    expect(auth).toBe(btoa("alice:secret"));
   });
 
   test("sources page renders without crashing when API returns error", async ({

--- a/webui/e2e/error-states.spec.ts
+++ b/webui/e2e/error-states.spec.ts
@@ -5,7 +5,7 @@
  * - "Bucket not found" when navigating to a non-existent bucket ID
  * - Landing page auth dialogs open and close without crashing
  * - Register flow shows password after API call
- * - Login flow closes dialog and persists auth
+ * - Login flow closes dialog and starts a session
  */
 
 import { test, expect } from "@playwright/test";
@@ -55,19 +55,28 @@ test.describe("Error states", () => {
     await dialog.getByLabel("Username").fill("newuser");
     await dialog.getByRole("button", { name: "Create Account" }).click();
 
-    // Generated password is shown via Snippet
     await expect(dialog.getByText("generated-secret-pw")).toBeVisible();
 
-    // Confirmation button dismisses
+    await page.route(`${API_GLOB}/auth/session`, (route) =>
+      route.fulfill({status: 204, body: ""}),
+    );
+    await page.route(`${API_GLOB}/auth/me`, (route) =>
+      route.fulfill({status: 200, json: {id: "u-new", username: "newuser"}}),
+    );
+
     await dialog.getByRole("button", { name: "I saved my password" }).click();
     await expect(dialog).not.toBeVisible();
   });
 
-  test("Login dialog opens and closes, storing credentials", async ({
+  test("Login dialog opens and closes, starting a session", async ({
     page,
   }) => {
-    // Login is purely client-side — saves btoa(user:pass) to localStorage
-    await page.route(`${API_GLOB}/**`, (route) => route.abort());
+    await page.route(`${API_GLOB}/auth/session`, (route) =>
+      route.fulfill({status: 204, body: ""}),
+    );
+    await page.route(`${API_GLOB}/auth/me`, (route) =>
+      route.fulfill({status: 200, json: {id: "u-1", username: "alice"}}),
+    );
 
     await page.goto("/");
     await page.getByRole("button", { name: "Log In" }).first().click();
@@ -79,12 +88,8 @@ test.describe("Error states", () => {
     await dialog.getByLabel("Password").fill("secret");
     await dialog.getByRole("button", { name: "Log In" }).click();
 
-    // Dialog closes after login
     await expect(dialog).not.toBeVisible();
-
-    // localStorage should now have auth set
-    const auth = await page.evaluate(() => localStorage.getItem("auth"));
-    expect(auth).toBe(btoa("alice:secret"));
+    await expect(page).toHaveURL("/dashboard");
   });
 
   test("sources page renders without crashing when API returns error", async ({

--- a/webui/e2e/error-states.spec.ts
+++ b/webui/e2e/error-states.spec.ts
@@ -17,7 +17,13 @@ test.describe("Error states", () => {
   }) => {
     await injectAuth(page);
     await mockGet(page, "/buckets/does-not-exist", { error: "not found" }, 404);
-    await mockGet(page, "/buckets/does-not-exist/files", []);
+    await page.route("**/api/v1/buckets/does-not-exist/files*", async (route) => {
+      if (route.request().method() !== "GET") {
+        await route.continue();
+        return;
+      }
+      await route.fulfill({status: 200, json: {items: []}});
+    });
     await page.goto("/buckets/does-not-exist");
 
     await expect(page.getByText("Bucket not found")).toBeVisible();

--- a/webui/e2e/files.spec.ts
+++ b/webui/e2e/files.spec.ts
@@ -55,6 +55,24 @@ const LARGE_TEXT_FILE = {
   created_at: "2024-01-22T08:15:00Z",
 };
 
+function filePage(items: typeof MOCK_FILES, nextCursor?: string) {
+  return nextCursor ? {items, next_cursor: nextCursor} : {items};
+}
+
+async function mockBucketFiles(
+  page: Page,
+  items: typeof MOCK_FILES,
+  nextCursor?: string,
+) {
+  await page.route("**/api/v1/buckets/bkt-1/files*", async (route) => {
+    if (route.request().method() !== "GET") {
+      await route.continue();
+      return;
+    }
+    await route.fulfill({status: 200, json: filePage(items, nextCursor)});
+  });
+}
+
 test.describe("File listing and download", () => {
   async function revealCredentialsIfNeeded(
     page: Page,
@@ -75,7 +93,7 @@ test.describe("File listing and download", () => {
     await injectAuth(page);
     await mockGet(page, "/buckets", [MOCK_BUCKET]);
     await mockGet(page, "/buckets/bkt-1", MOCK_BUCKET);
-    await mockGet(page, "/buckets/bkt-1/files", []);
+    await mockBucketFiles(page, []);
     await page.goto("/buckets/bkt-1");
 
     await expect(page.getByRole("heading", { name: "my-bucket" })).toBeVisible();
@@ -87,7 +105,7 @@ test.describe("File listing and download", () => {
     await injectAuth(page);
     await mockGet(page, "/buckets", [MOCK_BUCKET]);
     await mockGet(page, "/buckets/bkt-1", MOCK_BUCKET);
-    await mockGet(page, "/buckets/bkt-1/files", []);
+    await mockBucketFiles(page, []);
     await page.goto("/buckets/bkt-1");
 
     await expect(
@@ -101,7 +119,7 @@ test.describe("File listing and download", () => {
     await injectAuth(page);
     await mockGet(page, "/buckets", [MOCK_BUCKET]);
     await mockGet(page, "/buckets/bkt-1", MOCK_BUCKET);
-    await mockGet(page, "/buckets/bkt-1/files", MOCK_FILES);
+    await mockBucketFiles(page, MOCK_FILES);
     await page.goto("/buckets/bkt-1");
 
     // Table headers
@@ -120,7 +138,7 @@ test.describe("File listing and download", () => {
     await injectAuth(page);
     await mockGet(page, "/buckets", [MOCK_BUCKET]);
     await mockGet(page, "/buckets/bkt-1", MOCK_BUCKET);
-    await mockGet(page, "/buckets/bkt-1/files", MOCK_FILES);
+    await mockBucketFiles(page, MOCK_FILES);
     await page.goto("/buckets/bkt-1");
 
     // There should be one download button per file row (icon buttons)
@@ -163,7 +181,7 @@ test.describe("File listing and download", () => {
             file.name.toLowerCase().includes(query.toLowerCase()),
           )
         : MOCK_FILES;
-      await route.fulfill({status: 200, json: body});
+      await route.fulfill({status: 200, json: filePage(body)});
     });
 
     await page.goto("/buckets/bkt-1");
@@ -193,7 +211,7 @@ test.describe("File listing and download", () => {
       }
       const query = new URL(route.request().url()).searchParams.get("q") ?? "";
       const body = query === "missing" ? [] : MOCK_FILES;
-      await route.fulfill({status: 200, json: body});
+      await route.fulfill({status: 200, json: filePage(body)});
     });
 
     await page.goto("/buckets/bkt-1");
@@ -209,11 +227,38 @@ test.describe("File listing and download", () => {
     await expect(page.getByRole("button", {name: "Upload File"})).toHaveCount(1);
   });
 
+  test("bucket detail loads additional file pages on demand", async ({ page }) => {
+    await injectAuth(page);
+    await mockGet(page, "/buckets", [MOCK_BUCKET]);
+    await mockGet(page, "/buckets/bkt-1", MOCK_BUCKET);
+
+    await page.route("**/api/v1/buckets/bkt-1/files*", async (route) => {
+      if (route.request().method() !== "GET") {
+        await route.continue();
+        return;
+      }
+      const cursor = new URL(route.request().url()).searchParams.get("cursor") ?? "";
+      const body = cursor
+        ? filePage([{id: "file-3", name: "zeta.txt", size: 512, created_at: "2024-01-23T10:00:00Z"}])
+        : filePage([MOCK_FILES[0]], MOCK_FILES[0].name);
+      await route.fulfill({status: 200, json: body});
+    });
+
+    await page.goto("/buckets/bkt-1");
+    await expect(page.getByText("report.pdf")).toBeVisible();
+    await expect(page.getByRole("button", {name: "Load More"})).toBeVisible();
+
+    await page.getByRole("button", {name: "Load More"}).click();
+
+    await expect(page.getByText("zeta.txt")).toBeVisible();
+    await expect(page.getByRole("button", {name: "Load More"})).toHaveCount(0);
+  });
+
   test("viewer file rows only expose download actions", async ({ page }) => {
     await injectAuth(page);
     await mockGet(page, "/buckets", [MOCK_VIEWER_BUCKET]);
     await mockGet(page, "/buckets/bkt-1", MOCK_VIEWER_BUCKET);
-    await mockGet(page, "/buckets/bkt-1/files", MOCK_FILES);
+    await mockBucketFiles(page, MOCK_FILES);
     await page.goto("/buckets/bkt-1");
 
     const firstRowActions = page.locator("tbody tr").first().locator("td").last();
@@ -240,7 +285,7 @@ test.describe("File listing and download", () => {
     await injectAuth(page);
     await mockGet(page, "/buckets", [MOCK_EDITOR_BUCKET]);
     await mockGet(page, "/buckets/bkt-1", MOCK_EDITOR_BUCKET);
-    await mockGet(page, "/buckets/bkt-1/files", [MOCK_FILES[0]]);
+    await mockBucketFiles(page, [MOCK_FILES[0]]);
     await page.goto("/buckets/bkt-1");
 
     await expect(
@@ -260,7 +305,7 @@ test.describe("File listing and download", () => {
     await injectAuth(page);
     await mockGet(page, "/buckets", [MOCK_BUCKET]);
     await mockGet(page, "/buckets/bkt-1", MOCK_BUCKET);
-    await mockGet(page, "/buckets/bkt-1/files", [MOCK_FILES[0]]);
+    await mockBucketFiles(page, [MOCK_FILES[0]]);
 
     // Intercept download call and fulfill with a blob
     let downloadCalled = false;
@@ -326,7 +371,7 @@ test.describe("File listing and download", () => {
     await injectAuth(page);
     await mockGet(page, "/buckets", [MOCK_BUCKET]);
     await mockGet(page, "/buckets/bkt-1", MOCK_BUCKET);
-    await mockGet(page, "/buckets/bkt-1/files", [MOCK_FILES[0]]);
+    await mockBucketFiles(page, [MOCK_FILES[0]]);
 
     await page.route("**/api/v1/buckets/bkt-1/files/file-1/download", async (route) => {
       await route.fulfill({
@@ -355,7 +400,7 @@ test.describe("File listing and download", () => {
     await injectAuth(page);
     await mockGet(page, "/buckets", [MOCK_BUCKET]);
     await mockGet(page, "/buckets/bkt-1", MOCK_BUCKET);
-    await mockGet(page, "/buckets/bkt-1/files", [LARGE_TEXT_FILE]);
+    await mockBucketFiles(page, [LARGE_TEXT_FILE]);
 
     let previewRequests = 0;
     await page.route("**/api/v1/buckets/bkt-1/files/file-3/download", async (route) => {
@@ -385,7 +430,7 @@ test.describe("File listing and download", () => {
     await injectAuth(page);
     await mockGet(page, "/buckets", [MOCK_BUCKET]);
     await mockGet(page, "/buckets/bkt-1", MOCK_BUCKET);
-    await mockGet(page, "/buckets/bkt-1/files", []);
+    await mockBucketFiles(page, []);
     await page.goto("/buckets");
     // Navigate to bucket detail
     await page.goto("/buckets/bkt-1");

--- a/webui/e2e/files.spec.ts
+++ b/webui/e2e/files.spec.ts
@@ -332,7 +332,7 @@ test.describe("File listing and download", () => {
     await injectAuth(page);
     await mockGet(page, "/buckets", [MOCK_VIEWER_BUCKET]);
     await mockGet(page, "/buckets/bkt-1", MOCK_VIEWER_BUCKET);
-    await mockGet(page, "/buckets/bkt-1/files", MOCK_FILES);
+    await mockBucketFiles(page, MOCK_FILES);
 
     let reportDownloaded = false;
     let dataDownloaded = false;

--- a/webui/src/pages/bucket/ui/bucket-page.tsx
+++ b/webui/src/pages/bucket/ui/bucket-page.tsx
@@ -16,7 +16,7 @@ import {
   downloadFile,
   downloadFiles,
   getBucket,
-  listFiles,
+  listFilesPage,
   MAX_MULTI_FILE_DOWNLOAD_COUNT,
   uploadFile,
 } from "../../../shared/api/buckets";
@@ -38,13 +38,17 @@ const ROLE_COLOR: Record<string, "default" | "primary" | "secondary" | "success"
 
 type SortField = "name" | "size" | "created_at";
 
+const FILE_PAGE_SIZE = 100;
+
 export function BucketPage() {
   const {id} = useParams<{id: string}>();
   const navigate = useNavigate();
   const [bucket, setBucket] = useState<Bucket | null>(null);
   const [files, setFiles] = useState<FileInfo[]>([]);
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [isRefreshingFiles, setIsRefreshingFiles] = useState(false);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
   const fileInput = useRef<HTMLInputElement>(null);
@@ -94,26 +98,36 @@ export function BucketPage() {
     });
   }, [files, sortBy, sortAsc]);
 
-  const load = useCallback(async (mode: "initial" | "refresh" = "initial") => {
+  const load = useCallback(async (mode: "initial" | "refresh" | "append" = "initial") => {
     if (!id) return;
+    if (mode === "append" && !nextCursor) return;
     const requestID = requestIDRef.current + 1;
     requestIDRef.current = requestID;
     if (mode === "initial") {
       setIsLoading(true);
+    } else if (mode === "append") {
+      setIsLoadingMore(true);
     } else {
       setIsRefreshingFiles(true);
     }
     setError(null);
     try {
-      const [loadedBucket, fs] = await Promise.all([
-        getBucket(id),
-        listFiles(id, activeSearchQuery),
+      const [loadedBucket, page] = await Promise.all([
+        mode === "append" ? Promise.resolve(bucket) : getBucket(id),
+        listFilesPage(id, {
+          query: activeSearchQuery,
+          limit: FILE_PAGE_SIZE,
+          cursor: mode === "append" ? nextCursor ?? undefined : undefined,
+        }),
       ]);
       if (requestID !== requestIDRef.current) {
         return;
       }
-      setBucket(loadedBucket);
-      setFiles(fs);
+      if (loadedBucket) {
+        setBucket(loadedBucket);
+      }
+      setFiles((prev) => mode === "append" ? [...prev, ...page.items] : page.items);
+      setNextCursor(page.next_cursor ?? null);
       hasLoadedRef.current = true;
     } catch (err) {
       if (requestID !== requestIDRef.current) {
@@ -129,16 +143,20 @@ export function BucketPage() {
       if (requestID === requestIDRef.current) {
         if (mode === "initial") {
           setIsLoading(false);
+        } else if (mode === "append") {
+          setIsLoadingMore(false);
         } else {
           setIsRefreshingFiles(false);
         }
       }
     }
-  }, [activeSearchQuery, id]);
+  }, [activeSearchQuery, bucket, id, nextCursor]);
 
   useEffect(() => {
     hasLoadedRef.current = false;
     setSearchQuery("");
+    setFiles([]);
+    setNextCursor(null);
     setSelectedFileIds([]);
     setPendingDeleteFiles([]);
   }, [id]);
@@ -226,6 +244,13 @@ export function BucketPage() {
   const canSelectFiles = sortedFiles.length > 0;
   const canDeleteSelected = bucket !== null && canWriteFiles(bucket);
   const selectedDownloadLimitExceeded = selectedCount > MAX_MULTI_FILE_DOWNLOAD_COUNT;
+  const searchStatus = activeSearchQuery
+    ? nextCursor
+      ? `Showing ${files.length}+ matching files`
+      : files.length === 1
+        ? "1 matching file"
+        : `${files.length} matching files`
+    : null;
 
   function setFileSelected(fileID: string, selected: boolean) {
     setSelectedFileIds((prev) => {
@@ -404,9 +429,9 @@ export function BucketPage() {
             onValueChange={setSearchQuery}
             endContent={isRefreshingFiles ? <Spinner size="sm" /> : null}
           />
-          {activeSearchQuery ? (
+          {searchStatus ? (
             <p className="text-sm text-default-500" aria-live="polite">
-              {files.length === 1 ? "1 matching file" : `${files.length} matching files`}
+              {searchStatus}
             </p>
           ) : null}
         </div>
@@ -555,6 +580,13 @@ export function BucketPage() {
             </table>
           </div>
         )}
+        {nextCursor ? (
+          <div className="mt-4 flex justify-center">
+            <Button variant="flat" isLoading={isLoadingMore} onPress={() => load("append")}>
+              Load More
+            </Button>
+          </div>
+        ) : null}
       </section>
       <ConfirmDialog
         isOpen={confirm.isOpen}

--- a/webui/src/shared/api/buckets.ts
+++ b/webui/src/shared/api/buckets.ts
@@ -16,6 +16,11 @@ export type FileInfo = {
   size: number;
 };
 
+export type FileListPage = {
+  items: FileInfo[];
+  next_cursor?: string;
+};
+
 export type BatchDeleteFileResult = {
   id: string;
   name: string;
@@ -70,11 +75,24 @@ export async function createBucket(
   });
 }
 
-function bucketFilesPath(bucketId: string, query?: string): string {
+type BucketFilesQuery = {
+  query?: string;
+  limit?: number;
+  cursor?: string;
+};
+
+function bucketFilesPath(bucketId: string, opts: BucketFilesQuery = {}): string {
   const params = new URLSearchParams();
-  const trimmedQuery = query?.trim();
+  const trimmedQuery = opts.query?.trim();
   if (trimmedQuery) {
     params.set("q", trimmedQuery);
+  }
+  if (opts.limit !== undefined) {
+    params.set("limit", String(opts.limit));
+  }
+  const trimmedCursor = opts.cursor?.trim();
+  if (trimmedCursor) {
+    params.set("cursor", trimmedCursor);
   }
   const encodedQuery = params.toString();
   return encodedQuery
@@ -87,7 +105,17 @@ export async function listFiles(
   query?: string,
 ): Promise<FileInfo[]> {
   return apiJson<FileInfo[]>(
-    bucketFilesPath(bucketId, query),
+    bucketFilesPath(bucketId, {query}),
+    "Failed to list files",
+  );
+}
+
+export async function listFilesPage(
+  bucketId: string,
+  opts: BucketFilesQuery = {},
+): Promise<FileListPage> {
+  return apiJson<FileListPage>(
+    bucketFilesPath(bucketId, opts),
     "Failed to list files",
   );
 }


### PR DESCRIPTION
## Summary
- add optional `limit` and `cursor` support to the bucket file list API while preserving the legacy full-array response for callers that do not request pagination
- add repository and handler coverage for paginated filename search and invalid page-size handling
- update the bucket workspace to load file pages incrementally and append additional results with a `Load More` flow
- update the bucket workspace e2e mocks to use the paginated response shape and cover the incremental load path

## Why
The bucket workspace currently fetches and renders the full file list on every interaction. This change introduces a bounded contract for workspace callers so larger buckets do not force a full refetch and rerender path.

## Impact
- workspace callers can page through large buckets without reloading the entire result set
- search continues to work with the bounded contract
- existing non-paginated callers of the REST endpoint remain compatible because the array response is preserved when `limit` is omitted

## Validation
- `cd api-go && go test ./internal/repository ./internal/handlers`
- integration-tag Go tests were not run to completion locally because the Mongo-backed environment timed out
- frontend lint was not run locally because `webui` dependencies are not installed in this workspace (`@eslint/js` missing from local `node_modules`)

## Tracking
- public tracking issue: #349