### PR TITLE
THE-933 Redesign source detail into storage health surface

### DIFF
--- a/webui/e2e/source-detail.spec.ts
+++ b/webui/e2e/source-detail.spec.ts
@@ -56,8 +56,8 @@ test.describe("Source detail", () => {
     await page.goto("/sources/src-1");
 
     await expect(page.getByRole("heading", {name: "My Drive"})).toBeVisible();
-    await expect(page.getByText("Native quota", {exact: true})).toBeVisible();
-    await expect(page.getByText("Stored In Source", {exact: true})).toBeVisible();
+    await expect(page.getByText("Quota", {exact: true})).toBeVisible();
+    await expect(page.getByText("Storage Used", {exact: true})).toBeVisible();
     await expect(page.getByText("Google Drive quota is nearly exhausted.")).toBeVisible();
   });
 
@@ -68,17 +68,42 @@ test.describe("Source detail", () => {
 
     await page.goto("/sources/src-2");
 
-    const capacitySignalCard = page
-      .locator("div.rounded-lg.border.border-default-200")
-      .filter({has: page.getByText("Capacity Signal", {exact: true})});
-
     await expect(page.getByRole("heading", {name: "Archive Bucket"})).toBeVisible();
-    await expect(capacitySignalCard.getByText("Quota unavailable", {exact: true})).toBeVisible();
+    await expect(page.getByText("Quota unavailable", {exact: true})).toBeVisible();
     await expect(
-      capacitySignalCard.getByText(
+      page.getByText(
         "S3-compatible sources are checked for reachability here, not provider-wide capacity limits.",
         {exact: true},
       ),
     ).toBeVisible();
+  });
+
+  test("shows provider capabilities section", async ({page}) => {
+    await injectAuth(page);
+    await mockGet(page, "/sources/src-1/info", GDRIVE_INFO);
+    await mockGet(page, "/sources/src-1/health", GDRIVE_HEALTH);
+
+    await page.goto("/sources/src-1");
+
+    await expect(page.getByText("Provider Capabilities", {exact: true})).toBeVisible();
+    await expect(page.getByText("Native quota reporting")).toBeVisible();
+    await expect(page.getByText("File listing")).toBeVisible();
+    await expect(page.getByText("Direct file download")).toBeVisible();
+  });
+
+  test("files section is collapsed by default and can be expanded", async ({page}) => {
+    await injectAuth(page);
+    await mockGet(page, "/sources/src-1/info", GDRIVE_INFO);
+    await mockGet(page, "/sources/src-1/health", GDRIVE_HEALTH);
+
+    await page.goto("/sources/src-1");
+
+    const toggle = page.getByRole("button", {name: /Source Files/});
+    await expect(toggle).toBeVisible();
+    // File table not visible initially
+    await expect(page.getByText("hello.txt")).not.toBeVisible();
+    // Expand
+    await toggle.click();
+    await expect(page.getByText("hello.txt")).toBeVisible();
   });
 });

--- a/webui/src/pages/source/ui/source-page.tsx
+++ b/webui/src/pages/source/ui/source-page.tsx
@@ -1,4 +1,4 @@
-import {Button, Card, CardBody, Chip, CircularProgress, Spinner} from "@heroui/react";
+import {Button, Card, CardBody, CardHeader, Chip, CircularProgress, Spinner} from "@heroui/react";
 import {useCallback, useEffect, useState} from "react";
 import {Link, useNavigate, useParams} from "react-router-dom";
 import {downloadFile, getSourceHealth, getSourceInfo} from "../../../shared/api/sources";
@@ -9,6 +9,255 @@ import {getSourceQuotaState, sourceHealthColor} from "../../../entities/source/l
 import {DownloadIcon} from "../../../shared/icons";
 import {EmptyState} from "../../../shared/ui";
 import {formatSize} from "../../../shared/lib/format";
+
+function formatLatency(ms: number): string {
+  if (ms < 1000) return `${ms} ms`;
+  return `${(ms / 1000).toFixed(1)} s`;
+}
+
+function formatCheckedAt(iso: string): string {
+  try {
+    const d = new Date(iso);
+    const now = Date.now();
+    const diffSec = Math.floor((now - d.getTime()) / 1000);
+    if (diffSec < 60) return "just now";
+    if (diffSec < 3600) return `${Math.floor(diffSec / 60)} min ago`;
+    return d.toLocaleString();
+  } catch {
+    return iso;
+  }
+}
+
+const PROVIDER_CAPABILITIES: Record<string, {quota: boolean; fileList: boolean; download: boolean; caveat: string}> = {
+  gdrive: {
+    quota: true,
+    fileList: true,
+    download: true,
+    caveat: "Quota comes from native Google Drive metadata. Shared-drive files count against the drive owner's quota, not yours.",
+  },
+  s3: {
+    quota: false,
+    fileList: true,
+    download: true,
+    caveat: "S3-compatible providers do not expose provider-wide capacity via API. SFree checks bucket reachability only.",
+  },
+  telegram: {
+    quota: false,
+    fileList: false,
+    download: false,
+    caveat: "Telegram does not expose storage metadata. SFree checks bot/chat accessibility only.",
+  },
+};
+
+function CapabilityDot({supported}: {supported: boolean}) {
+  return (
+    <span
+      className={`inline-block w-2 h-2 rounded-full ${supported ? "bg-success" : "bg-default-300"}`}
+      aria-hidden="true"
+    />
+  );
+}
+
+function HealthBanner({health}: {health: SourceHealth}) {
+  const color = sourceHealthColor[health.status];
+  return (
+    <Card>
+      <CardBody className="gap-3 py-5">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex items-center gap-3">
+            <span
+              className={`inline-block w-3 h-3 rounded-full ${color === "success" ? "bg-success" : color === "warning" ? "bg-warning" : "bg-danger"}`}
+              aria-hidden="true"
+            />
+            <span className="text-lg font-semibold capitalize">{health.status}</span>
+            <Chip size="sm" variant="flat" color={color}>
+              {health.reason_code}
+            </Chip>
+          </div>
+          <div className="flex items-center gap-4 text-sm text-default-500">
+            <span>Latency: {formatLatency(health.latency_ms)}</span>
+            <span>Checked {formatCheckedAt(health.checked_at)}</span>
+          </div>
+        </div>
+        {health.message && (
+          <p className="text-sm text-default-600">{health.message}</p>
+        )}
+      </CardBody>
+    </Card>
+  );
+}
+
+function QuotaCard({health, quota}: {health: SourceHealth | null; quota: ReturnType<typeof getSourceQuotaState>}) {
+  return (
+    <Card className="flex-1">
+      <CardHeader className="pb-0">
+        <p className="text-xs uppercase tracking-wide text-default-400">Quota</p>
+      </CardHeader>
+      <CardBody className="items-center justify-center gap-4 py-5 text-center">
+        {quota.kind === "available" ? (
+          <>
+            <CircularProgress
+              aria-label={`Quota usage: ${quota.percent.toFixed(0)}%`}
+              classNames={{
+                svg: "w-28 h-28",
+                indicator:
+                  health?.status === "healthy"
+                    ? "stroke-success"
+                    : health?.status === "degraded"
+                      ? "stroke-warning"
+                      : "stroke-danger",
+                track: "stroke-default-200",
+                value: "text-2xl font-semibold",
+              }}
+              showValueLabel
+              strokeWidth={4}
+              value={quota.percent}
+            />
+            <div className="flex flex-col gap-0.5">
+              <p className="text-sm text-default-600">
+                {formatSize(quota.usedBytes)} / {formatSize(quota.totalBytes)}
+              </p>
+              <p className="text-xs text-default-400">{formatSize(quota.freeBytes)} free</p>
+            </div>
+          </>
+        ) : (
+          <div className="flex flex-col items-center gap-1 py-2">
+            <p className="text-sm font-medium text-default-600">{quota.label}</p>
+            <p className="text-xs text-default-400 max-w-[200px]">{quota.description}</p>
+          </div>
+        )}
+      </CardBody>
+    </Card>
+  );
+}
+
+function StorageCard({info}: {info: SourceInfo}) {
+  const fileCount = info.files.length;
+  return (
+    <Card className="flex-1">
+      <CardHeader className="pb-0">
+        <p className="text-xs uppercase tracking-wide text-default-400">Storage Used</p>
+      </CardHeader>
+      <CardBody className="items-center justify-center gap-4 py-5 text-center">
+        <p className="text-3xl font-bold">{formatSize(info.storage_used)}</p>
+        <p className="text-sm text-default-500">
+          {fileCount} file{fileCount === 1 ? "" : "s"} stored
+        </p>
+      </CardBody>
+    </Card>
+  );
+}
+
+function CapabilitiesCard({sourceType}: {sourceType: string}) {
+  const caps = PROVIDER_CAPABILITIES[sourceType];
+  if (!caps) return null;
+
+  const rows: {label: string; supported: boolean}[] = [
+    {label: "Native quota reporting", supported: caps.quota},
+    {label: "File listing", supported: caps.fileList},
+    {label: "Direct file download", supported: caps.download},
+  ];
+
+  return (
+    <Card>
+      <CardHeader className="pb-0">
+        <p className="text-xs uppercase tracking-wide text-default-400">Provider Capabilities</p>
+      </CardHeader>
+      <CardBody className="gap-3 py-5">
+        <ul className="flex flex-col gap-2">
+          {rows.map((r) => (
+            <li key={r.label} className="flex items-center gap-2 text-sm">
+              <CapabilityDot supported={r.supported} />
+              <span className={r.supported ? "text-default-700" : "text-default-400"}>{r.label}</span>
+            </li>
+          ))}
+        </ul>
+        <p className="text-xs text-default-400 border-t border-default-100 pt-3">{caps.caveat}</p>
+      </CardBody>
+    </Card>
+  );
+}
+
+function FilesSection({
+  files,
+  onDownload,
+}: {
+  files: SourceFile[];
+  onDownload: (f: SourceFile) => void;
+}) {
+  const [expanded, setExpanded] = useState(false);
+
+  if (files.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <p className="text-xs uppercase tracking-wide text-default-400">Source Files</p>
+        </CardHeader>
+        <CardBody>
+          <EmptyState
+            title="No files in this source"
+            description="Files will appear here once synced from the connected service."
+          />
+        </CardBody>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardBody className="p-0">
+        <button
+          type="button"
+          className="w-full flex items-center justify-between px-4 py-3 text-left hover:bg-default-100 transition-colors rounded-t-large"
+          onClick={() => setExpanded(!expanded)}
+          aria-expanded={expanded}
+        >
+          <span className="text-xs uppercase tracking-wide text-default-400">
+            Source Files ({files.length})
+          </span>
+          <span
+            className={`text-default-400 transition-transform ${expanded ? "rotate-180" : ""}`}
+            aria-hidden="true"
+          >
+            &#9662;
+          </span>
+        </button>
+        {expanded && (
+          <div className="overflow-x-auto px-4 pb-4">
+            <table className="w-full text-left text-sm">
+              <thead>
+                <tr>
+                  <th scope="col" className="pb-2 font-medium text-default-500">Name</th>
+                  <th scope="col" className="pb-2 font-medium text-default-500 whitespace-nowrap">Size</th>
+                  <th scope="col" className="pb-2"><span className="sr-only">Actions</span></th>
+                </tr>
+              </thead>
+              <tbody>
+                {files.map((f) => (
+                  <tr key={f.id} className="border-t border-default-100">
+                    <td className="py-2 break-all text-default-700">{f.name}</td>
+                    <td className="py-2 whitespace-nowrap text-default-500">{formatSize(f.size)}</td>
+                    <td className="py-2">
+                      <Button
+                        isIconOnly
+                        size="sm"
+                        variant="light"
+                        aria-label={`Download ${f.name}`}
+                        onPress={() => onDownload(f)}
+                      >
+                        <DownloadIcon className="w-4 h-4" />
+                      </Button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </CardBody>
+    </Card>
+  );
+}
 
 export function SourcePage() {
   const {id} = useParams<{id: string}>();
@@ -95,137 +344,43 @@ export function SourcePage() {
   }
 
   const quota = getSourceQuotaState(health);
-  const fileCount = info.files.length;
 
   return (
-    <div className="p-6 sm:p-8 flex flex-col gap-6">
+    <div className="p-6 sm:p-8 flex flex-col gap-5">
       <Link to="/sources" className="text-sm text-default-500 hover:text-primary transition-colors">
         &larr; Sources
       </Link>
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <div className="flex flex-col gap-2">
-          <h1 className="text-3xl font-bold">{info.name}</h1>
-          <SourceTypeChip type={info.type} />
-        </div>
-        {health ? (
-          <Chip size="sm" variant="flat" color={sourceHealthColor[health.status]}>
-            {health.status}
-          </Chip>
-        ) : (
-          <Chip size="sm" variant="flat" color="default">
-            health unavailable
-          </Chip>
-        )}
+
+      {/* Header */}
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-3">
+        <h1 className="text-2xl font-bold">{info.name}</h1>
+        <SourceTypeChip type={info.type} />
       </div>
-      <div className="grid gap-4 lg:grid-cols-[220px,minmax(0,1fr)]">
+
+      {/* Health banner — primary surface */}
+      {health ? (
+        <HealthBanner health={health} />
+      ) : (
         <Card>
-          <CardBody className="items-center justify-center gap-4 py-6 text-center">
-            {quota.kind === "available" ? (
-              <>
-                <CircularProgress
-                  aria-label={`Quota usage: ${quota.percent}%`}
-                  classNames={{
-                    svg: "w-24 h-24 sm:w-36 sm:h-36",
-                    indicator:
-                      health?.status === "healthy"
-                        ? "stroke-success"
-                        : health?.status === "degraded"
-                          ? "stroke-warning"
-                          : "stroke-danger",
-                    track: "stroke-default-200",
-                    value: "text-3xl font-semibold",
-                  }}
-                  showValueLabel
-                  strokeWidth={4}
-                  value={quota.percent}
-                />
-                <div className="flex flex-col gap-1">
-                  <p className="text-sm font-medium">Native quota</p>
-                  <p className="text-sm text-default-500">
-                    {formatSize(quota.usedBytes)} of {formatSize(quota.totalBytes)}
-                  </p>
-                  <p className="text-xs text-default-400">
-                    {formatSize(quota.freeBytes)} free
-                  </p>
-                </div>
-              </>
-            ) : (
-              <div className="flex h-full flex-col items-center justify-center gap-2">
-                <p className="text-sm font-medium">{quota.label}</p>
-                <p className="text-sm text-default-500">{quota.description}</p>
-              </div>
-            )}
+          <CardBody className="py-4">
+            <p className="text-sm text-default-500">
+              Health data unavailable. SFree could not run a provider probe for this source.
+            </p>
           </CardBody>
         </Card>
-        <Card>
-          <CardBody className="gap-4 py-6">
-            <div className="grid gap-4 sm:grid-cols-2">
-              <div className="rounded-lg border border-default-200 px-4 py-3">
-                <p className="text-xs uppercase tracking-wide text-default-400">Stored In Source</p>
-                <p className="mt-2 text-2xl font-semibold">{formatSize(info.storage_used)}</p>
-                <p className="mt-1 text-sm text-default-500">
-                  {fileCount} listed file{fileCount === 1 ? "" : "s"}
-                </p>
-              </div>
-              <div className="rounded-lg border border-default-200 px-4 py-3">
-                <p className="text-xs uppercase tracking-wide text-default-400">Capacity Signal</p>
-                <p className="mt-2 text-base font-semibold">
-                  {quota.kind === "available" ? "Provider quota available" : quota.label}
-                </p>
-                <p className="mt-1 text-sm text-default-500">
-                  {quota.kind === "available"
-                    ? "This meter comes from native provider quota metadata."
-                    : quota.description}
-                </p>
-              </div>
-            </div>
-            {health && (
-              <div className="rounded-lg border border-default-200 bg-default-50 px-4 py-3">
-                <p className="text-xs uppercase tracking-wide text-default-400">Health Probe</p>
-                <p className="mt-2 text-sm text-default-700">{health.message}</p>
-              </div>
-            )}
-          </CardBody>
-        </Card>
+      )}
+
+      {/* Quota + Storage — side by side */}
+      <div className="grid gap-4 sm:grid-cols-2">
+        <QuotaCard health={health} quota={quota} />
+        <StorageCard info={info} />
       </div>
-      <div className="border-2 border-dashed rounded p-4">
-        {info.files.length === 0 ? (
-          <EmptyState
-            title="No files in this source"
-            description="Files will appear here once synced from the connected service."
-          />
-        ) : (
-          <div className="overflow-x-auto -mx-4 px-4">
-            <table className="w-full text-left">
-              <thead>
-                <tr>
-                  <th scope="col" className="pb-2">Name</th>
-                  <th scope="col" className="pb-2 whitespace-nowrap">Size</th>
-                  <th scope="col" className="pb-2"><span className="sr-only">Actions</span></th>
-                </tr>
-              </thead>
-              <tbody>
-                {info.files.map((f) => (
-                  <tr key={f.id} className="border-t">
-                    <td className="py-2 break-all">{f.name}</td>
-                    <td className="py-2 whitespace-nowrap">{formatSize(f.size)}</td>
-                    <td className="py-2">
-                      <Button
-                        isIconOnly
-                        variant="light"
-                        aria-label={`Download ${f.name}`}
-                        onPress={() => handleDownload(f)}
-                      >
-                        <DownloadIcon className="w-5 h-5" />
-                      </Button>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        )}
-      </div>
+
+      {/* Provider capabilities */}
+      <CapabilitiesCard sourceType={info.type} />
+
+      {/* Files — visually secondary, collapsed by default */}
+      <FilesSection files={info.files} onDownload={handleDownload} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Redesigns the source detail page so health status, quota/capacity, and provider capabilities are the primary visible surface
- Adds a **health banner** with status indicator, reason code, probe latency, and last-checked timestamp
- Adds **quota card** with circular gauge for providers that report native quota (Google Drive), honest "unavailable" messaging for others
- Adds **storage-used card** showing bytes stored and file count
- Adds **provider capabilities card** listing what the provider supports (quota, file listing, download) with per-provider caveats
- Moves file browsing into a **collapsible section** at the bottom — still accessible, but visually secondary
- Responsive layout across desktop and mobile

Closes #351

## Test plan

- [ ] Navigate to `/sources/:id` for each provider type (Google Drive, S3, Telegram)
- [ ] Verify health banner shows correct status, reason, latency
- [ ] Verify quota gauge renders for Google Drive; honest "unavailable" for S3/Telegram
- [ ] Verify capabilities card accurately reflects per-provider support
- [ ] Expand/collapse file section and verify download still works
- [ ] Test mobile viewport — cards stack vertically
- [ ] Test error and empty states (deleted source, unreachable source)
- [ ] Woodpecker web UI validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)