### PR TITLE
Add bounded S3 GetObject response header overrides

### DIFF
--- a/api-go/internal/e2e/s3_compat_auth_test.go
+++ b/api-go/internal/e2e/s3_compat_auth_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"testing"
 	"time"
 )
@@ -159,6 +160,84 @@ func TestS3CompatPresignedGetObject(t *testing.T) {
 	}
 
 	// Cleanup
+	s3Do(t, http.MethodDelete, s3URL, bucket.AccessKey, bucket.AccessSecret, env.Region, nil)
+}
+
+func TestS3CompatPresignedGetObjectResponseHeaderOverrides(t *testing.T) {
+	env, ok := loadS3E2EEnv()
+	if !ok {
+		t.Skip("E2E_S3_ENDPOINT not set; skipping S3 E2E tests")
+	}
+
+	ts, _ := newTestServer(t)
+	ensureMinIOBucket(t, env)
+
+	suffix := uniqueSuffix()
+	username, password := createTestUser(t, ts, suffix)
+	sourceID := createS3Source(t, ts, username, password, "src-"+suffix, env)
+	bucket := createBucket(t, ts, username, password, "bkt-"+suffix, sourceID)
+
+	t.Cleanup(func() {
+		apiDelete(t, ts, "/api/v1/buckets/"+bucket.ID, username, password)
+		apiDelete(t, ts, "/api/v1/sources/"+sourceID, username, password)
+	})
+
+	objectKey := "presign-overrides-" + suffix + ".txt"
+	objectContent := []byte("Presigned GET overrides content!")
+	s3URL := fmt.Sprintf("%s/api/s3/%s/%s", ts.URL, bucket.Key, objectKey)
+
+	status, _, body := s3DoWithHeaders(t, http.MethodPut, s3URL, bucket.AccessKey, bucket.AccessSecret, env.Region, objectContent, map[string]string{
+		"Content-Type": "text/plain",
+	})
+	if status != http.StatusOK {
+		t.Fatalf("PUT object: expected 200, got %d: %s", status, body)
+	}
+
+	overrideURL, err := url.Parse(s3URL)
+	if err != nil {
+		t.Fatalf("parse override URL: %v", err)
+	}
+	values := overrideURL.Query()
+	values.Set("response-content-disposition", `attachment; filename="download.txt"`)
+	values.Set("response-content-type", "application/octet-stream")
+	overrideURL.RawQuery = values.Encode()
+
+	presignedURL, err := presignS3URL(overrideURL.String(), "GET", bucket.AccessKey, bucket.AccessSecret, env.Region, 3600)
+	if err != nil {
+		t.Fatalf("presign URL: %v", err)
+	}
+
+	resp, err := http.Get(presignedURL)
+	if err != nil {
+		t.Fatalf("presigned GET: %v", err)
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("presigned GET: expected 200, got %d: %s", resp.StatusCode, respBody)
+	}
+	if !bytes.Equal(respBody, objectContent) {
+		t.Fatalf("presigned GET: content mismatch; want %q got %q", objectContent, respBody)
+	}
+	if got := resp.Header.Get("Content-Disposition"); got != `attachment; filename="download.txt"` {
+		t.Fatalf("presigned GET: expected Content-Disposition override, got %q", got)
+	}
+	if got := resp.Header.Get("Content-Type"); got != "application/octet-stream" {
+		t.Fatalf("presigned GET: expected Content-Type override, got %q", got)
+	}
+
+	status, headers, body := s3DoWithHeaders(t, http.MethodGet, s3URL, bucket.AccessKey, bucket.AccessSecret, env.Region, nil, nil)
+	if status != http.StatusOK {
+		t.Fatalf("plain GET: expected 200, got %d: %s", status, body)
+	}
+	if got := headers.Get("Content-Type"); got != "text/plain" {
+		t.Fatalf("plain GET: expected stored Content-Type, got %q", got)
+	}
+	if got := headers.Get("Content-Disposition"); got != "" {
+		t.Fatalf("plain GET: expected no stored Content-Disposition override, got %q", got)
+	}
+
 	s3Do(t, http.MethodDelete, s3URL, bucket.AccessKey, bucket.AccessSecret, env.Region, nil)
 }
 

--- a/api-go/internal/handlers/s3_get_test.go
+++ b/api-go/internal/handlers/s3_get_test.go
@@ -783,3 +783,42 @@ func TestHeadObjectIfUnmodifiedSinceReturnsPreconditionFailed(t *testing.T) {
 		t.Fatalf("expected persisted ETag header, got %q", got)
 	}
 }
+
+func TestHeadObjectIgnoresResponseHeaderOverrides(t *testing.T) {
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("accessKey", "access-key")
+		c.Next()
+	})
+	bucketID := primitive.NewObjectID()
+	r.HEAD("/api/s3/:bucket/*object", headObject(
+		fakeObjectBucketReader{
+			bucket: &repository.Bucket{
+				ID:        bucketID,
+				Key:       "bucket",
+				AccessKey: "access-key",
+			},
+		},
+		fakeObjectFileReader{
+			file: &repository.File{
+				ID:          primitive.NewObjectID(),
+				BucketID:    bucketID,
+				Name:        "object.txt",
+				ContentType: "application/json",
+				CreatedAt:   time.Unix(1700000000, 0).UTC(),
+				ETag:        `"persisted-etag"`,
+			},
+		},
+	))
+
+	req := httptest.NewRequest(http.MethodHead, "/api/s3/bucket/object.txt?response-content-type=text/plain", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if got := w.Header().Get("Content-Type"); got != "application/json" {
+		t.Fatalf("expected persisted content type, got %q", got)
+	}
+}

--- a/api-go/internal/handlers/s3_get_test.go
+++ b/api-go/internal/handlers/s3_get_test.go
@@ -279,6 +279,89 @@ func TestGetObjectStreamsBodyWithoutPreflight(t *testing.T) {
 	}
 }
 
+func TestGetObjectAppliesSupportedResponseHeaderOverrides(t *testing.T) {
+	origStream := streamS3Object
+	t.Cleanup(func() { streamS3Object = origStream })
+	streamS3Object = func(_ context.Context, _ *repository.SourceRepository, _ *repository.File, w io.Writer) error {
+		_, err := io.WriteString(w, "complete")
+		return err
+	}
+
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("accessKey", "access-key")
+		c.Next()
+	})
+	r.GET("/api/s3/:bucket/*object", getObjectFailureTestHandler(t))
+
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/s3/bucket/object.txt?response-cache-control=no-store&response-content-disposition=attachment%3B%20filename%3D%22download.txt%22&response-content-encoding=gzip&response-content-language=en-US&response-content-type=application%2Fpdf&response-expires=Mon%2C%2002%20Jan%202006%2015%3A04%3A05%20GMT",
+		nil,
+	)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if got := w.Header().Get("Cache-Control"); got != "no-store" {
+		t.Fatalf("expected override Cache-Control, got %q", got)
+	}
+	if got := w.Header().Get("Content-Disposition"); got != `attachment; filename="download.txt"` {
+		t.Fatalf("expected override Content-Disposition, got %q", got)
+	}
+	if got := w.Header().Get("Content-Encoding"); got != "gzip" {
+		t.Fatalf("expected override Content-Encoding, got %q", got)
+	}
+	if got := w.Header().Get("Content-Language"); got != "en-US" {
+		t.Fatalf("expected override Content-Language, got %q", got)
+	}
+	if got := w.Header().Get("Content-Type"); got != "application/pdf" {
+		t.Fatalf("expected override Content-Type, got %q", got)
+	}
+	if got := w.Header().Get("Expires"); got != "Mon, 02 Jan 2006 15:04:05 GMT" {
+		t.Fatalf("expected override Expires, got %q", got)
+	}
+	if got := w.Header().Get("x-amz-meta-owner"); got != "alice" {
+		t.Fatalf("expected stored metadata to remain, got %q", got)
+	}
+}
+
+func TestGetObjectIgnoresUnsafeAndUnsupportedResponseHeaderOverrides(t *testing.T) {
+	origStream := streamS3Object
+	t.Cleanup(func() { streamS3Object = origStream })
+	streamS3Object = func(_ context.Context, _ *repository.SourceRepository, _ *repository.File, w io.Writer) error {
+		_, err := io.WriteString(w, "complete")
+		return err
+	}
+
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("accessKey", "access-key")
+		c.Next()
+	})
+	r.GET("/api/s3/:bucket/*object", getObjectFailureTestHandler(t))
+
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/s3/bucket/object.txt?response-content-type=text%2Fhtml%0D%0AX-Injected%3A%20yes&response-content-length=1",
+		nil,
+	)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if got := w.Header().Get("Content-Type"); got != "text/plain" {
+		t.Fatalf("expected stored Content-Type after unsafe override, got %q", got)
+	}
+	if got := w.Header().Get("Content-Length"); got != "7" {
+		t.Fatalf("expected stored Content-Length after unsupported override, got %q", got)
+	}
+}
+
 func TestGetObjectRangeReturnsStoredMetadataHeaders(t *testing.T) {
 	origStreamRange := streamS3ObjectRange
 	t.Cleanup(func() { streamS3ObjectRange = origStreamRange })
@@ -318,6 +401,34 @@ func TestGetObjectRangeReturnsStoredMetadataHeaders(t *testing.T) {
 	}
 	if got := w.Header().Get("x-amz-meta-owner"); got != "alice" {
 		t.Fatalf("expected stored metadata, got %q", got)
+	}
+}
+
+func TestGetObjectRangeAppliesResponseHeaderOverrides(t *testing.T) {
+	origStreamRange := streamS3ObjectRange
+	t.Cleanup(func() { streamS3ObjectRange = origStreamRange })
+	streamS3ObjectRange = func(_ context.Context, _ *repository.SourceRepository, _ *repository.File, w io.Writer, start, end int64) error {
+		_, err := io.WriteString(w, "cde")
+		return err
+	}
+
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("accessKey", "access-key")
+		c.Next()
+	})
+	r.GET("/api/s3/:bucket/*object", getObjectFailureTestHandler(t))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/s3/bucket/object.txt?response-content-type=application%2Fjson", nil)
+	req.Header.Set("Range", "bytes=2-4")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusPartialContent {
+		t.Fatalf("expected 206, got %d", w.Code)
+	}
+	if got := w.Header().Get("Content-Type"); got != "application/json" {
+		t.Fatalf("expected override Content-Type on ranged response, got %q", got)
 	}
 }
 

--- a/api-go/internal/handlers/s3_object.go
+++ b/api-go/internal/handlers/s3_object.go
@@ -20,8 +20,9 @@ import (
 )
 
 const (
-	defaultObjectContentType = "application/octet-stream"
-	userMetadataHeaderPrefix = "x-amz-meta-"
+	defaultObjectContentType     = "application/octet-stream"
+	userMetadataHeaderPrefix     = "x-amz-meta-"
+	maxResponseHeaderOverrideLen = 1024
 )
 
 type copyObjectResult struct {
@@ -40,6 +41,18 @@ var (
 	streamS3Object      = manager.StreamFile
 	streamS3ObjectRange = manager.StreamFileRange
 )
+
+var responseHeaderOverrideSpecs = []struct {
+	queryKey string
+	header   string
+}{
+	{queryKey: "response-cache-control", header: "Cache-Control"},
+	{queryKey: "response-content-disposition", header: "Content-Disposition"},
+	{queryKey: "response-content-encoding", header: "Content-Encoding"},
+	{queryKey: "response-content-language", header: "Content-Language"},
+	{queryKey: "response-content-type", header: "Content-Type"},
+	{queryKey: "response-expires", header: "Expires"},
+}
 
 type objectFileReader interface {
 	GetByName(ctx context.Context, bucketID primitive.ObjectID, name string) (*repository.File, error)
@@ -155,6 +168,30 @@ func setObjectHeaders(c *gin.Context, fileDoc *repository.File, total int64) {
 	for key, value := range fileDoc.UserMetadata {
 		c.Header(userMetadataHeaderPrefix+key, value)
 	}
+	applyResponseHeaderOverrides(c)
+}
+
+func applyResponseHeaderOverrides(c *gin.Context) {
+	query := c.Request.URL.Query()
+	for _, spec := range responseHeaderOverrideSpecs {
+		value := query.Get(spec.queryKey)
+		if !validResponseHeaderOverrideValue(value) {
+			continue
+		}
+		c.Header(spec.header, value)
+	}
+}
+
+func validResponseHeaderOverrideValue(value string) bool {
+	if value == "" || len(value) > maxResponseHeaderOverrideLen {
+		return false
+	}
+	for i := 0; i < len(value); i++ {
+		if value[i] < 0x20 || value[i] == 0x7f {
+			return false
+		}
+	}
+	return true
 }
 
 func objectContentType(contentType string) string {

--- a/api-go/internal/handlers/s3_object.go
+++ b/api-go/internal/handlers/s3_object.go
@@ -168,7 +168,6 @@ func setObjectHeaders(c *gin.Context, fileDoc *repository.File, total int64) {
 	for key, value := range fileDoc.UserMetadata {
 		c.Header(userMetadataHeaderPrefix+key, value)
 	}
-	applyResponseHeaderOverrides(c)
 }
 
 func applyResponseHeaderOverrides(c *gin.Context) {
@@ -311,6 +310,7 @@ func getObject(bucketRepo objectBucketReader, sourceRepo *repository.SourceRepos
 		if rangeHeader == "" {
 			w := newDeferredResponseWriter(c, func() {
 				setObjectHeaders(c, fileDoc, total)
+				applyResponseHeaderOverrides(c)
 				c.Status(http.StatusOK)
 			})
 			if err := streamFile(c.Request.Context(), sourceRepo, fileDoc, w); err != nil {
@@ -335,6 +335,7 @@ func getObject(bucketRepo objectBucketReader, sourceRepo *repository.SourceRepos
 		}
 		w := newDeferredResponseWriter(c, func() {
 			setObjectHeaders(c, fileDoc, total)
+			applyResponseHeaderOverrides(c)
 			c.Header("Content-Length", strconv.FormatInt(objRange.end-objRange.start+1, 10))
 			c.Header("Content-Range", "bytes "+strconv.FormatInt(objRange.start, 10)+"-"+strconv.FormatInt(objRange.end, 10)+"/"+strconv.FormatInt(total, 10))
 			c.Status(http.StatusPartialContent)

--- a/docs/s3-compatibility.md
+++ b/docs/s3-compatibility.md
@@ -28,7 +28,7 @@ Bucket administration APIs, ACLs, versioning, lifecycle, object lock, tagging, a
 
 | S3 operation | Status | Notes |
 | --- | --- | --- |
-| GetObject | Partial | Basic full-object download and byte `Range` requests work. Stored Content-Type and user metadata are returned. `If-Match`, `If-None-Match`, `If-Modified-Since`, and `If-Unmodified-Since` now gate full-object and ranged reads with `304`/`412` responses before streaming. Response header overrides and checksum-related response semantics are still missing. |
+| GetObject | Partial | Basic full-object download and byte `Range` requests work. Stored Content-Type and user metadata are returned. `If-Match`, `If-None-Match`, `If-Modified-Since`, and `If-Unmodified-Since` now gate full-object and ranged reads with `304`/`412` responses before streaming. Signed requests can override `Cache-Control`, `Content-Disposition`, `Content-Encoding`, `Content-Language`, `Content-Type`, and `Expires` at response time via the matching S3 `response-*` query parameters when each value is a single-line ASCII string up to 1024 bytes. These overrides do not mutate stored object metadata. Checksum-related response semantics are still missing. |
 | PutObject | Partial | Basic upload and overwrite work. Content-Type and `x-amz-meta-*` user metadata are persisted. Object tags, storage class, checksum validation, and server-side encryption headers are ignored. |
 | DeleteObject | Implemented | Single-object delete is idempotent and returns no content for missing keys. |
 | HeadObject | Partial | Returns ETag, Last-Modified, Content-Length, Content-Type, and user metadata. `If-Match`, `If-None-Match`, `If-Modified-Since`, and `If-Unmodified-Since` are now honored with `304`/`412` responses. Range awareness and checksum headers remain missing. |
@@ -74,7 +74,7 @@ Bucket administration APIs, ACLs, versioning, lifecycle, object lock, tagging, a
 | Feature | Status | Notes |
 | --- | --- | --- |
 | AWS Signature V4 header auth | Implemented | Validates `AWS4-HMAC-SHA256` requests against bucket access credentials. Requests with bodies must send `X-Amz-Content-Sha256`; otherwise validation rejects the request without buffering the body. |
-| AWS Signature V4 presigned URLs | Implemented | Query-string presign validation supports default S3 unsigned payload behavior and a max TTL of seven days. Woodpecker-runnable Python SDK coverage now verifies aiobotocore-generated presigned `PUT` and `GET` URLs for simple object upload/download flows. |
+| AWS Signature V4 presigned URLs | Implemented | Query-string presign validation supports default S3 unsigned payload behavior and a max TTL of seven days. Presigned `GetObject` URLs now honor bounded `response-cache-control`, `response-content-disposition`, `response-content-encoding`, `response-content-language`, `response-content-type`, and `response-expires` overrides without mutating stored metadata. Woodpecker-runnable Python SDK coverage now verifies aiobotocore-generated presigned `PUT` and `GET` URLs for simple object upload/download flows. |
 | AWS Signature V2 | Missing | Legacy clients that require V2 are unsupported. |
 | Anonymous access | Missing | S3 API requests require signed bucket credentials. |
 | Virtual-hosted-style addressing | Missing | Path-style routing is supported on `/{bucket}` and the legacy `/api/s3/{bucket}` alias, but bucket-in-host virtual-hosted requests are still unsupported. |
@@ -174,3 +174,19 @@ Not automated in this PR:
 - AWS CLI, rclone, and s3cmd live binary smoke tests. They still need extra runtime installation and remain documented/manual in this PR.
 - MinIO `mc` live validation still needs Woodpecker or documented manual execution. The root-style endpoint removes the alias-configuration blocker, but this PR does not itself add fresh `mc` runtime evidence.
 - AWS SDK for Go/JavaScript client fixtures. The Go e2e suite already validates signed S3 endpoint behavior directly; this PR keeps SDK automation to one pinned SDK path to avoid widening CI dependencies.
+
+## Response Header Override Scope
+
+Shipped `GetObject` response override query parameters:
+- `response-cache-control` -> `Cache-Control`
+- `response-content-disposition` -> `Content-Disposition`
+- `response-content-encoding` -> `Content-Encoding`
+- `response-content-language` -> `Content-Language`
+- `response-content-type` -> `Content-Type`
+- `response-expires` -> `Expires`
+
+Deliberate limits in the current slice:
+- Overrides are applied on `GetObject` responses only, including byte-range reads.
+- Each override value must be a non-empty single-line ASCII string no longer than 1024 bytes.
+- Unsupported `response-*` parameters are ignored rather than mapped to arbitrary headers.
+- `HeadObject` does not currently mirror these overrides.


### PR DESCRIPTION
## Summary
- honor a bounded allowlist of S3 `response-*` query overrides on `GetObject` responses without mutating stored metadata
- add handler coverage for precedence, unsafe-value rejection, and ranged downloads plus a tagged e2e presigned GET check
- document the shipped override set and current limits in the S3 compatibility matrix

## Testing
- `go test ./internal/handlers`
- `go test -tags e2e ./internal/e2e -run TestS3CompatPresignedGetObjectResponseHeaderOverrides`