### PR TITLE
[codex] Make bucket setup honest about source health

### DIFF
--- a/api-go/cmd/sfree-cli/buckets.go
+++ b/api-go/cmd/sfree-cli/buckets.go
@@ -17,8 +17,9 @@ type bucketItem struct {
 }
 
 type createBucketReq struct {
-	Key       string   `json:"key"`
-	SourceIDs []string `json:"source_ids"`
+	Key              string   `json:"key"`
+	SourceIDs        []string `json:"source_ids"`
+	RiskAcknowledged bool     `json:"risk_acknowledged,omitempty"`
 }
 
 type createBucketResp struct {
@@ -59,8 +60,9 @@ var bucketsListCmd = &cobra.Command{
 }
 
 var (
-	bucketCreateKey     string
-	bucketCreateSources string
+	bucketCreateKey             string
+	bucketCreateSources         string
+	bucketCreateAcknowledgeRisk bool
 )
 
 var bucketsCreateCmd = &cobra.Command{
@@ -78,8 +80,9 @@ S3-compatible access credentials are generated automatically.`,
 		ids := strings.Split(bucketCreateSources, ",")
 		var resp createBucketResp
 		if err := apiPost("/api/v1/buckets", createBucketReq{
-			Key:       bucketCreateKey,
-			SourceIDs: ids,
+			Key:              bucketCreateKey,
+			SourceIDs:        ids,
+			RiskAcknowledged: bucketCreateAcknowledgeRisk,
 		}, &resp); err != nil {
 			return err
 		}
@@ -99,6 +102,7 @@ S3-compatible access credentials are generated automatically.`,
 func init() {
 	bucketsCreateCmd.Flags().StringVar(&bucketCreateKey, "key", "", "Bucket key (name)")
 	bucketsCreateCmd.Flags().StringVar(&bucketCreateSources, "sources", "", "Comma-separated source IDs")
+	bucketsCreateCmd.Flags().BoolVar(&bucketCreateAcknowledgeRisk, "acknowledge-source-risk", false, "Allow bucket creation when the API requires explicit confirmation for degraded or near-capacity sources")
 	bucketsCmd.AddCommand(bucketsListCmd, bucketsCreateCmd)
 	rootCmd.AddCommand(bucketsCmd)
 }

--- a/api-go/internal/app/router_routes.go
+++ b/api-go/internal/app/router_routes.go
@@ -52,7 +52,8 @@ func registerBucketRoutes(router *gin.Engine, cfg *config.Config, deps *routerDe
 	if deps.auth == nil || deps.bucketRepo == nil {
 		return
 	}
-	router.POST("/api/v1/buckets", protectedHandlers(limits, deps.auth, handlers.CreateBucket(deps.bucketRepo, deps.sourceRepo, routerAccessSecret(cfg)))...)
+	router.POST("/api/v1/buckets/preflight", protectedHandlers(limits, deps.auth, handlers.BucketPreflightWithFactory(deps.sourceRepo, deps.sourceFactory))...)
+	router.POST("/api/v1/buckets", protectedHandlers(limits, deps.auth, handlers.CreateBucketWithFactory(deps.bucketRepo, deps.sourceRepo, routerAccessSecret(cfg), deps.sourceFactory))...)
 	router.GET("/api/v1/buckets", protectedHandlers(limits, deps.auth, handlers.ListBuckets(deps.bucketRepo, deps.grantRepo))...)
 	router.GET("/api/v1/buckets/:id", protectedHandlers(limits, deps.auth, handlers.GetBucket(deps.bucketRepo, deps.grantRepo))...)
 	router.DELETE("/api/v1/buckets/:id", protectedHandlers(limits, deps.auth, handlers.DeleteBucketWithFactory(deps.bucketRepo, deps.sourceRepo, deps.fileRepo, deps.mpRepo, deps.shareLinkRepo, deps.grantRepo, deps.sourceFactory))...)

--- a/api-go/internal/app/router_test.go
+++ b/api-go/internal/app/router_test.go
@@ -108,10 +108,25 @@ func TestOpenAPIJSONRoute(t *testing.T) {
 	if doc.Swagger != "2.0" {
 		t.Fatalf("expected Swagger 2.0, got %q", doc.Swagger)
 	}
-	for _, path := range []string{"/api/v1/buckets", "/api/v1/sources/s3", "/api/v1/sources/{id}/download", "/{bucket}", "/{bucket}/{object}", "/api/s3/{bucket}", "/api/s3/{bucket}/{object}"} {
+	for _, path := range []string{"/api/v1/buckets", "/api/v1/buckets/preflight", "/api/v1/sources/s3", "/api/v1/sources/{id}/download", "/{bucket}", "/{bucket}/{object}", "/api/s3/{bucket}", "/api/s3/{bucket}/{object}"} {
 		if _, ok := doc.Paths[path]; !ok {
 			t.Fatalf("expected OpenAPI path %s", path)
 		}
+	}
+}
+
+func TestRegisterBucketRoutesIncludesPreflightRoute(t *testing.T) {
+	r := gin.New()
+	registerBucketRoutes(r, &config.Config{AccessSecretKey: "test-secret"}, &routerDependencies{
+		auth: func(c *gin.Context) {
+			c.Next()
+		},
+		bucketRepo: &repository.BucketRepository{},
+		sourceRepo: &repository.SourceRepository{},
+	}, nil)
+
+	if !hasRoute(r, http.MethodPost, "/api/v1/buckets/preflight") {
+		t.Fatalf("expected POST /api/v1/buckets/preflight to be registered")
 	}
 }
 

--- a/api-go/internal/docs/docs.go
+++ b/api-go/internal/docs/docs.go
@@ -553,6 +553,62 @@ const docTemplate = `{
                     "409": {
                         "description": "Conflict",
                         "schema": {
+                            "$ref": "#/definitions/handlers.bucketPreflightConflictResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/buckets/preflight": {
+            "post": {
+                "security": [
+                    {
+                        "BasicAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "buckets"
+                ],
+                "summary": "Preflight bucket creation",
+                "parameters": [
+                    {
+                        "description": "Bucket preflight request",
+                        "name": "bucket",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.bucketPreflightRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.bucketPreflightResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
                             "type": "string"
                         }
                     }
@@ -2476,6 +2532,126 @@ const docTemplate = `{
                 }
             }
         },
+        "handlers.bucketPreflightConflictResponse": {
+            "type": "object",
+            "properties": {
+                "decision": {
+                    "type": "string"
+                },
+                "degraded_source_count": {
+                    "type": "integer"
+                },
+                "error": {
+                    "type": "string"
+                },
+                "healthy_source_count": {
+                    "type": "integer"
+                },
+                "message": {
+                    "type": "string"
+                },
+                "near_capacity_source_count": {
+                    "type": "integer"
+                },
+                "sources": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/handlers.bucketPreflightSourceResponse"
+                    }
+                },
+                "unhealthy_source_count": {
+                    "type": "integer"
+                }
+            }
+        },
+        "handlers.bucketPreflightRequest": {
+            "type": "object",
+            "required": [
+                "source_ids"
+            ],
+            "properties": {
+                "source_ids": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "handlers.bucketPreflightResponse": {
+            "type": "object",
+            "properties": {
+                "decision": {
+                    "type": "string"
+                },
+                "degraded_source_count": {
+                    "type": "integer"
+                },
+                "healthy_source_count": {
+                    "type": "integer"
+                },
+                "message": {
+                    "type": "string"
+                },
+                "near_capacity_source_count": {
+                    "type": "integer"
+                },
+                "sources": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/handlers.bucketPreflightSourceResponse"
+                    }
+                },
+                "unhealthy_source_count": {
+                    "type": "integer"
+                }
+            }
+        },
+        "handlers.bucketPreflightSourceResponse": {
+            "type": "object",
+            "properties": {
+                "blocks_creation": {
+                    "type": "boolean"
+                },
+                "checked_at": {
+                    "type": "string"
+                },
+                "message": {
+                    "type": "string"
+                },
+                "quota_free_bytes": {
+                    "type": "integer",
+                    "x-nullable": true
+                },
+                "quota_total_bytes": {
+                    "type": "integer",
+                    "x-nullable": true
+                },
+                "quota_used_bytes": {
+                    "type": "integer",
+                    "x-nullable": true
+                },
+                "reason_code": {
+                    "type": "string"
+                },
+                "requires_confirmation": {
+                    "type": "boolean"
+                },
+                "source_id": {
+                    "type": "string"
+                },
+                "source_name": {
+                    "type": "string"
+                },
+                "source_type": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                }
+            }
+        },
         "handlers.bucketResponse": {
             "type": "object",
             "properties": {
@@ -2511,6 +2687,9 @@ const docTemplate = `{
                 },
                 "key": {
                     "type": "string"
+                },
+                "risk_acknowledged": {
+                    "type": "boolean"
                 },
                 "source_ids": {
                     "type": "array",

--- a/api-go/internal/handlers/bucket.go
+++ b/api-go/internal/handlers/bucket.go
@@ -19,6 +19,7 @@ import (
 type createBucketRequest struct {
 	Key                  string         `json:"key" binding:"required"`
 	SourceIDs            []string       `json:"source_ids" binding:"required,min=1"`
+	RiskAcknowledged     bool           `json:"risk_acknowledged,omitempty"`
 	DistributionStrategy string         `json:"distribution_strategy,omitempty"`
 	SourceWeights        map[string]int `json:"source_weights,omitempty"`
 }
@@ -115,10 +116,14 @@ func isNilDependency(dep any) bool {
 // @Success 200 {object} createBucketResponse
 // @Failure 400 {string} string ""
 // @Failure 401 {string} string ""
-// @Failure 409 {string} string ""
+// @Failure 409 {object} bucketPreflightConflictResponse
 // @Security BasicAuth
 // @Router /api/v1/buckets [post]
 func CreateBucket(repo bucketCreator, sourceRepo sourceGetter, secretKey string) gin.HandlerFunc {
+	return CreateBucketWithFactory(repo, sourceRepo, secretKey, nil)
+}
+
+func CreateBucketWithFactory(repo bucketCreator, sourceRepo sourceGetter, secretKey string, factory manager.SourceClientFactory) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		ctx := c.Request.Context()
 		var req createBucketRequest
@@ -154,34 +159,25 @@ func CreateBucket(repo bucketCreator, sourceRepo sourceGetter, secretKey string)
 			c.Status(http.StatusInternalServerError)
 			return
 		}
-		sourceIDs := make([]primitive.ObjectID, 0, len(req.SourceIDs))
-		seenSourceIDs := make(map[primitive.ObjectID]struct{}, len(req.SourceIDs))
-		for _, sourceIDHex := range req.SourceIDs {
-			sourceID, err := primitive.ObjectIDFromHex(sourceIDHex)
-			if err != nil {
-				c.Status(http.StatusBadRequest)
+		preflight, sourceIDs, err := bucketPreflightForSources(ctx, userID, sourceRepo, req.SourceIDs, factory)
+		if err != nil {
+			if inputErr, ok := err.(bucketPreflightInputError); ok {
+				c.JSON(inputErr.status, gin.H{"error": inputErr.message})
 				return
 			}
-			sourceDoc, err := sourceRepo.GetByID(c.Request.Context(), sourceID)
-			if err != nil {
-				if err == mongo.ErrNoDocuments {
-					c.Status(http.StatusBadRequest)
-					return
-				}
-				slog.ErrorContext(ctx, "create bucket: get source", slog.String("error", err.Error()))
-				c.Status(http.StatusInternalServerError)
+			slog.ErrorContext(ctx, "create bucket: preflight failed", slog.String("error", err.Error()))
+			c.Status(http.StatusInternalServerError)
+			return
+		}
+		switch bucketPreflightDecision(preflight.Decision) {
+		case bucketPreflightDecisionBlocked:
+			c.JSON(http.StatusConflict, bucketPreflightConflict(preflight))
+			return
+		case bucketPreflightDecisionConfirmRequired:
+			if !req.RiskAcknowledged {
+				c.JSON(http.StatusConflict, bucketPreflightConflict(preflight))
 				return
 			}
-			if sourceDoc.UserID != userID {
-				c.Status(http.StatusBadRequest)
-				return
-			}
-			if _, ok := seenSourceIDs[sourceID]; ok {
-				c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("source_ids contains duplicate source id %q", sourceIDHex)})
-				return
-			}
-			seenSourceIDs[sourceID] = struct{}{}
-			sourceIDs = append(sourceIDs, sourceID)
 		}
 		strategy := repository.DistributionStrategy(req.DistributionStrategy)
 		if strategy == "" {

--- a/api-go/internal/handlers/bucket_preflight.go
+++ b/api-go/internal/handlers/bucket_preflight.go
@@ -1,0 +1,223 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/example/sfree/api-go/internal/manager"
+	"github.com/example/sfree/api-go/internal/repository"
+	"github.com/gin-gonic/gin"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+type bucketPreflightDecision string
+
+const (
+	bucketPreflightDecisionReady           bucketPreflightDecision = "ready"
+	bucketPreflightDecisionConfirmRequired bucketPreflightDecision = "confirm_required"
+	bucketPreflightDecisionBlocked         bucketPreflightDecision = "blocked"
+)
+
+type bucketPreflightRequest struct {
+	SourceIDs []string `json:"source_ids" binding:"required,min=1"`
+}
+
+type bucketPreflightSourceResponse struct {
+	SourceID             string    `json:"source_id"`
+	SourceName           string    `json:"source_name"`
+	SourceType           string    `json:"source_type"`
+	Status               string    `json:"status"`
+	ReasonCode           string    `json:"reason_code"`
+	Message              string    `json:"message"`
+	QuotaTotalBytes      *int64    `json:"quota_total_bytes" extensions:"x-nullable"`
+	QuotaUsedBytes       *int64    `json:"quota_used_bytes" extensions:"x-nullable"`
+	QuotaFreeBytes       *int64    `json:"quota_free_bytes" extensions:"x-nullable"`
+	RequiresConfirmation bool      `json:"requires_confirmation"`
+	BlocksCreation       bool      `json:"blocks_creation"`
+	CheckedAt            time.Time `json:"checked_at"`
+}
+
+type bucketPreflightResponse struct {
+	Decision                string                          `json:"decision"`
+	Message                 string                          `json:"message"`
+	HealthySourceCount      int                             `json:"healthy_source_count"`
+	DegradedSourceCount     int                             `json:"degraded_source_count"`
+	UnhealthySourceCount    int                             `json:"unhealthy_source_count"`
+	NearCapacitySourceCount int                             `json:"near_capacity_source_count"`
+	Sources                 []bucketPreflightSourceResponse `json:"sources"`
+}
+
+type bucketPreflightConflictResponse struct {
+	Error string `json:"error"`
+	bucketPreflightResponse
+}
+
+type bucketPreflightInputError struct {
+	status  int
+	message string
+}
+
+func (e bucketPreflightInputError) Error() string {
+	return e.message
+}
+
+func bucketPreflightConflict(summary bucketPreflightResponse) bucketPreflightConflictResponse {
+	return bucketPreflightConflictResponse{
+		Error:                   summary.Message,
+		bucketPreflightResponse: summary,
+	}
+}
+
+func bucketPreflightForSources(ctx context.Context, userID primitive.ObjectID, sourceRepo sourceGetter, sourceIDHexes []string, factory manager.SourceClientFactory) (bucketPreflightResponse, []primitive.ObjectID, error) {
+	resolvedSources, sourceIDs, err := loadOwnedBucketSources(ctx, userID, sourceRepo, sourceIDHexes)
+	if err != nil {
+		return bucketPreflightResponse{}, nil, err
+	}
+
+	resp := bucketPreflightResponse{
+		Decision: string(bucketPreflightDecisionReady),
+		Sources:  make([]bucketPreflightSourceResponse, 0, len(resolvedSources)),
+	}
+
+	for _, src := range resolvedSources {
+		health, err := manager.CheckSourceHealth(ctx, &src, factory)
+		if err == manager.ErrUnsupportedSourceType {
+			health = manager.SourceHealth{
+				SourceID:   src.ID.Hex(),
+				SourceType: string(src.Type),
+				Status:     manager.SourceHealthDegraded,
+				CheckedAt:  time.Now().UTC(),
+				ReasonCode: "health_unsupported",
+				Message:    "SFree could not verify source health for this source type.",
+			}
+		} else if err != nil {
+			return bucketPreflightResponse{}, nil, err
+		}
+
+		item := bucketPreflightSourceResponse{
+			SourceID:        src.ID.Hex(),
+			SourceName:      src.Name,
+			SourceType:      string(src.Type),
+			Status:          string(health.Status),
+			ReasonCode:      health.ReasonCode,
+			Message:         health.Message,
+			QuotaTotalBytes: health.Quota.TotalBytes,
+			QuotaUsedBytes:  health.Quota.UsedBytes,
+			QuotaFreeBytes:  health.Quota.FreeBytes,
+			CheckedAt:       health.CheckedAt,
+		}
+
+		switch health.Status {
+		case manager.SourceHealthUnhealthy:
+			item.BlocksCreation = true
+			resp.UnhealthySourceCount++
+		case manager.SourceHealthDegraded:
+			item.RequiresConfirmation = true
+			resp.DegradedSourceCount++
+		default:
+			resp.HealthySourceCount++
+		}
+		if health.ReasonCode == "quota_low" {
+			item.RequiresConfirmation = true
+			resp.NearCapacitySourceCount++
+		}
+		if item.BlocksCreation {
+			resp.Decision = string(bucketPreflightDecisionBlocked)
+		} else if item.RequiresConfirmation && resp.Decision != string(bucketPreflightDecisionBlocked) {
+			resp.Decision = string(bucketPreflightDecisionConfirmRequired)
+		}
+
+		resp.Sources = append(resp.Sources, item)
+	}
+
+	switch bucketPreflightDecision(resp.Decision) {
+	case bucketPreflightDecisionBlocked:
+		resp.Message = "Remove unhealthy sources before creating this bucket."
+	case bucketPreflightDecisionConfirmRequired:
+		resp.Message = "Selected sources include degraded or near-capacity providers. Confirm the risk before creating this bucket."
+	default:
+		resp.Message = "Selected sources passed the current bucket preflight."
+	}
+
+	return resp, sourceIDs, nil
+}
+
+func loadOwnedBucketSources(ctx context.Context, userID primitive.ObjectID, sourceRepo sourceGetter, sourceIDHexes []string) ([]repository.Source, []primitive.ObjectID, error) {
+	if isNilDependency(sourceRepo) {
+		return nil, nil, bucketPreflightInputError{status: http.StatusServiceUnavailable, message: "source repository is unavailable"}
+	}
+	sourceIDs := make([]primitive.ObjectID, 0, len(sourceIDHexes))
+	seenSourceIDs := make(map[primitive.ObjectID]struct{}, len(sourceIDHexes))
+	sources := make([]repository.Source, 0, len(sourceIDHexes))
+
+	for _, sourceIDHex := range sourceIDHexes {
+		sourceID, err := primitive.ObjectIDFromHex(sourceIDHex)
+		if err != nil {
+			return nil, nil, bucketPreflightInputError{status: http.StatusBadRequest, message: fmt.Sprintf("source_ids contains invalid source id %q", sourceIDHex)}
+		}
+		if _, ok := seenSourceIDs[sourceID]; ok {
+			return nil, nil, bucketPreflightInputError{status: http.StatusBadRequest, message: fmt.Sprintf("source_ids contains duplicate source id %q", sourceIDHex)}
+		}
+		seenSourceIDs[sourceID] = struct{}{}
+
+		sourceDoc, err := sourceRepo.GetByID(ctx, sourceID)
+		if err != nil {
+			if err == mongo.ErrNoDocuments {
+				return nil, nil, bucketPreflightInputError{status: http.StatusBadRequest, message: fmt.Sprintf("source_ids contains unknown source id %q", sourceIDHex)}
+			}
+			return nil, nil, bucketPreflightInputError{status: http.StatusInternalServerError, message: "failed to load sources for bucket preflight"}
+		}
+		if sourceDoc.UserID != userID {
+			return nil, nil, bucketPreflightInputError{status: http.StatusBadRequest, message: fmt.Sprintf("source_ids contains source id %q that is not owned by the authenticated user", sourceIDHex)}
+		}
+
+		sources = append(sources, *sourceDoc)
+		sourceIDs = append(sourceIDs, sourceID)
+	}
+
+	return sources, sourceIDs, nil
+}
+
+// BucketPreflight godoc
+// @Summary Preflight bucket creation
+// @Tags buckets
+// @Accept json
+// @Produce json
+// @Param bucket body bucketPreflightRequest true "Bucket preflight request"
+// @Success 200 {object} bucketPreflightResponse
+// @Failure 400 {string} string ""
+// @Failure 401 {string} string ""
+// @Failure 500 {string} string ""
+// @Security BasicAuth
+// @Router /api/v1/buckets/preflight [post]
+func BucketPreflight(sourceRepo sourceGetter) gin.HandlerFunc {
+	return BucketPreflightWithFactory(sourceRepo, nil)
+}
+
+func BucketPreflightWithFactory(sourceRepo sourceGetter, factory manager.SourceClientFactory) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		ctx := c.Request.Context()
+		var req bucketPreflightRequest
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.Status(http.StatusBadRequest)
+			return
+		}
+		userID, ok := authenticatedUserID(c)
+		if !ok {
+			return
+		}
+		resp, _, err := bucketPreflightForSources(ctx, userID, sourceRepo, req.SourceIDs, factory)
+		if err != nil {
+			if inputErr, ok := err.(bucketPreflightInputError); ok {
+				c.JSON(inputErr.status, gin.H{"error": inputErr.message})
+				return
+			}
+			c.Status(http.StatusInternalServerError)
+			return
+		}
+		c.JSON(http.StatusOK, resp)
+	}
+}

--- a/api-go/internal/handlers/bucket_preflight_test.go
+++ b/api-go/internal/handlers/bucket_preflight_test.go
@@ -1,0 +1,214 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/example/sfree/api-go/internal/manager"
+	"github.com/example/sfree/api-go/internal/repository"
+	"github.com/example/sfree/api-go/internal/sourcecap"
+	"github.com/gin-gonic/gin"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+type bucketPreflightClient struct {
+	health sourcecap.Health
+}
+
+func (c bucketPreflightClient) Upload(context.Context, string, io.Reader) (string, error) {
+	return "", nil
+}
+
+func (c bucketPreflightClient) Download(context.Context, string) (io.ReadCloser, error) {
+	return io.NopCloser(strings.NewReader("")), nil
+}
+
+func (c bucketPreflightClient) Delete(context.Context, string) error {
+	return nil
+}
+
+func (c bucketPreflightClient) ProbeSourceHealth(context.Context) (sourcecap.Health, error) {
+	return c.health, nil
+}
+
+func TestBucketPreflightReturnsConfirmRequiredForDegradedSources(t *testing.T) {
+	t.Parallel()
+	userID := primitive.NewObjectID()
+	sourceID := primitive.NewObjectID()
+	sourceRepo := fakeBucketSourceGetter{sources: map[primitive.ObjectID]repository.Source{
+		sourceID: {
+			ID:     sourceID,
+			UserID: userID,
+			Type:   repository.SourceTypeGDrive,
+			Name:   "Crowded Drive",
+			Key:    "{}",
+		},
+	}}
+	r := gin.New()
+	r.POST("/buckets/preflight", setUserID(userID.Hex()), BucketPreflightWithFactory(sourceRepo, func(context.Context, *repository.Source) (manager.SourceClient, error) {
+		return bucketPreflightClient{health: sourcecap.Health{
+			Status:     sourcecap.HealthDegraded,
+			ReasonCode: "quota_low",
+			Message:    "Google Drive quota is nearly exhausted.",
+			Quota: sourcecap.Quota{
+				TotalBytes: ptrInt64(1024),
+				UsedBytes:  ptrInt64(1000),
+				FreeBytes:  ptrInt64(24),
+			},
+		}}, nil
+	}))
+
+	body, _ := json.Marshal(map[string]any{"source_ids": []string{sourceID.Hex()}})
+	req, _ := http.NewRequest(http.MethodPost, "/buckets/preflight", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp bucketPreflightResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Decision != string(bucketPreflightDecisionConfirmRequired) {
+		t.Fatalf("expected confirm_required, got %+v", resp)
+	}
+	if len(resp.Sources) != 1 || !resp.Sources[0].RequiresConfirmation || resp.Sources[0].BlocksCreation {
+		t.Fatalf("unexpected sources: %+v", resp.Sources)
+	}
+	if resp.NearCapacitySourceCount != 1 || resp.DegradedSourceCount != 1 {
+		t.Fatalf("unexpected counts: %+v", resp)
+	}
+}
+
+func TestBucketPreflightReturnsBlockedForUnhealthySources(t *testing.T) {
+	t.Parallel()
+	userID := primitive.NewObjectID()
+	sourceID := primitive.NewObjectID()
+	sourceRepo := fakeBucketSourceGetter{sources: map[primitive.ObjectID]repository.Source{
+		sourceID: {
+			ID:     sourceID,
+			UserID: userID,
+			Type:   repository.SourceTypeS3,
+			Name:   "Offline Bucket",
+			Key:    "{}",
+		},
+	}}
+	r := gin.New()
+	r.POST("/buckets/preflight", setUserID(userID.Hex()), BucketPreflightWithFactory(sourceRepo, func(context.Context, *repository.Source) (manager.SourceClient, error) {
+		return bucketPreflightClient{health: sourcecap.Health{
+			Status:     sourcecap.HealthUnhealthy,
+			ReasonCode: "probe_failed",
+			Message:    "Source health probe failed.",
+		}}, nil
+	}))
+
+	body, _ := json.Marshal(map[string]any{"source_ids": []string{sourceID.Hex()}})
+	req, _ := http.NewRequest(http.MethodPost, "/buckets/preflight", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp bucketPreflightResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Decision != string(bucketPreflightDecisionBlocked) {
+		t.Fatalf("expected blocked, got %+v", resp)
+	}
+	if len(resp.Sources) != 1 || !resp.Sources[0].BlocksCreation {
+		t.Fatalf("unexpected sources: %+v", resp.Sources)
+	}
+}
+
+func TestCreateBucketRejectsConfirmRequiredSourcesWithoutAcknowledgement(t *testing.T) {
+	t.Parallel()
+	userID := primitive.NewObjectID()
+	sourceID := primitive.NewObjectID()
+	bucketRepo := &fakeBucketCreator{}
+	sourceRepo := fakeBucketSourceGetter{sources: map[primitive.ObjectID]repository.Source{
+		sourceID: {
+			ID:     sourceID,
+			UserID: userID,
+			Type:   repository.SourceTypeGDrive,
+			Name:   "Crowded Drive",
+			Key:    "{}",
+		},
+	}}
+	r := gin.New()
+	r.POST("/buckets", setUserID(userID.Hex()), CreateBucketWithFactory(bucketRepo, sourceRepo, "secret", func(context.Context, *repository.Source) (manager.SourceClient, error) {
+		return bucketPreflightClient{health: sourcecap.Health{
+			Status:     sourcecap.HealthDegraded,
+			ReasonCode: "quota_low",
+			Message:    "Google Drive quota is nearly exhausted.",
+		}}, nil
+	}))
+
+	body, _ := json.Marshal(map[string]any{"key": "risk-bucket", "source_ids": []string{sourceID.Hex()}})
+	req, _ := http.NewRequest(http.MethodPost, "/buckets", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d: %s", w.Code, w.Body.String())
+	}
+	if bucketRepo.createCalls != 0 {
+		t.Fatalf("expected bucket not to be created, got %d create calls", bucketRepo.createCalls)
+	}
+}
+
+func TestCreateBucketAllowsConfirmRequiredSourcesWithAcknowledgement(t *testing.T) {
+	t.Parallel()
+	userID := primitive.NewObjectID()
+	sourceID := primitive.NewObjectID()
+	bucketRepo := &fakeBucketCreator{}
+	sourceRepo := fakeBucketSourceGetter{sources: map[primitive.ObjectID]repository.Source{
+		sourceID: {
+			ID:     sourceID,
+			UserID: userID,
+			Type:   repository.SourceTypeGDrive,
+			Name:   "Crowded Drive",
+			Key:    "{}",
+		},
+	}}
+	r := gin.New()
+	r.POST("/buckets", setUserID(userID.Hex()), CreateBucketWithFactory(bucketRepo, sourceRepo, "secret", func(context.Context, *repository.Source) (manager.SourceClient, error) {
+		return bucketPreflightClient{health: sourcecap.Health{
+			Status:     sourcecap.HealthDegraded,
+			ReasonCode: "quota_low",
+			Message:    "Google Drive quota is nearly exhausted.",
+		}}, nil
+	}))
+
+	body, _ := json.Marshal(map[string]any{
+		"key":               "risk-bucket",
+		"source_ids":        []string{sourceID.Hex()},
+		"risk_acknowledged": true,
+	})
+	req, _ := http.NewRequest(http.MethodPost, "/buckets", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if bucketRepo.createCalls != 1 {
+		t.Fatalf("expected bucket to be created once, got %d", bucketRepo.createCalls)
+	}
+}
+
+func ptrInt64(v int64) *int64 {
+	return &v
+}

--- a/api-go/internal/handlers/bucket_test.go
+++ b/api-go/internal/handlers/bucket_test.go
@@ -14,7 +14,9 @@ import (
 
 	"github.com/example/sfree/api-go/internal/config"
 	"github.com/example/sfree/api-go/internal/db"
+	"github.com/example/sfree/api-go/internal/manager"
 	"github.com/example/sfree/api-go/internal/repository"
+	"github.com/example/sfree/api-go/internal/sourcecap"
 	"github.com/gin-gonic/gin"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"golang.org/x/crypto/bcrypt"
@@ -62,7 +64,13 @@ func TestCreateBucket(t *testing.T) {
 	}
 	router := gin.New()
 	auth := BasicAuth(userRepo)
-	router.POST("/api/v1/buckets", auth, CreateBucket(repo, sourceRepo, "testkey"))
+	router.POST("/api/v1/buckets", auth, CreateBucketWithFactory(repo, sourceRepo, "testkey", func(context.Context, *repository.Source) (manager.SourceClient, error) {
+		return bucketPreflightClient{health: sourcecap.Health{
+			Status:     sourcecap.HealthHealthy,
+			ReasonCode: "ok",
+			Message:    "Source is reachable.",
+		}}, nil
+	}))
 	body, _ := json.Marshal(map[string]any{"key": "bucket-test", "source_ids": []string{source.ID.Hex()}})
 	req, _ := http.NewRequest(http.MethodPost, "/api/v1/buckets", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")

--- a/api-go/internal/handlers/unit_test.go
+++ b/api-go/internal/handlers/unit_test.go
@@ -8,7 +8,9 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/example/sfree/api-go/internal/manager"
 	"github.com/example/sfree/api-go/internal/repository"
+	"github.com/example/sfree/api-go/internal/sourcecap"
 	"github.com/gin-gonic/gin"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
@@ -406,7 +408,13 @@ func TestCreateBucketRejectsDuplicateSourceIDs(t *testing.T) {
 		},
 	}}
 	r := gin.New()
-	r.POST("/buckets", setUserID(userID.Hex()), CreateBucket(bucketRepo, sourceRepo, "secret"))
+	r.POST("/buckets", setUserID(userID.Hex()), CreateBucketWithFactory(bucketRepo, sourceRepo, "secret", func(context.Context, *repository.Source) (manager.SourceClient, error) {
+		return bucketPreflightClient{health: sourcecap.Health{
+			Status:     sourcecap.HealthHealthy,
+			ReasonCode: "ok",
+			Message:    "Source is reachable.",
+		}}, nil
+	}))
 
 	body, _ := json.Marshal(map[string]any{"key": "k", "source_ids": []string{sourceID.Hex(), sourceID.Hex()}})
 	req, _ := http.NewRequest(http.MethodPost, "/buckets", bytes.NewReader(body))
@@ -448,7 +456,13 @@ func TestCreateBucketAllowsMultipleDistinctSources(t *testing.T) {
 		},
 	}}
 	r := gin.New()
-	r.POST("/buckets", setUserID(userID.Hex()), CreateBucket(bucketRepo, sourceRepo, "secret"))
+	r.POST("/buckets", setUserID(userID.Hex()), CreateBucketWithFactory(bucketRepo, sourceRepo, "secret", func(context.Context, *repository.Source) (manager.SourceClient, error) {
+		return bucketPreflightClient{health: sourcecap.Health{
+			Status:     sourcecap.HealthHealthy,
+			ReasonCode: "ok",
+			Message:    "Source is reachable.",
+		}}, nil
+	}))
 
 	body, _ := json.Marshal(map[string]any{"key": "k", "source_ids": []string{firstSourceID.Hex(), secondSourceID.Hex()}})
 	req, _ := http.NewRequest(http.MethodPost, "/buckets", bytes.NewReader(body))

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -114,6 +114,49 @@ Save the `id` — you need it to create a bucket.
 
 A bucket groups one or more sources into a single storage namespace.
 
+Before creating the bucket, run the bounded preflight so SFree can tell
+you whether the selected sources are currently ready, require explicit
+confirmation, or are blocked because they are already unhealthy.
+
+```bash
+curl -s -X POST http://localhost:8080/api/v1/buckets/preflight \
+  -H 'Content-Type: application/json' \
+  -H "Authorization: Basic $AUTH" \
+  -d '{
+    "source_ids": ["SOURCE_ID"]
+  }'
+```
+
+**Expected output for a healthy source:**
+
+```json
+{
+  "decision": "ready",
+  "message": "Selected sources passed the current bucket preflight.",
+  "healthy_source_count": 1,
+  "degraded_source_count": 0,
+  "unhealthy_source_count": 0,
+  "near_capacity_source_count": 0,
+  "sources": [
+    {
+      "source_id": "SOURCE_ID",
+      "source_name": "local-minio",
+      "source_type": "s3",
+      "status": "healthy",
+      "reason_code": "ok",
+      "message": "S3 bucket metadata is reachable.",
+      "requires_confirmation": false,
+      "blocks_creation": false
+    }
+  ]
+}
+```
+
+If the preflight returns `"decision": "confirm_required"`, repeat the
+create request below with `"risk_acknowledged": true`. If the preflight
+returns `"decision": "blocked"`, remove or replace the unhealthy source
+before creating the bucket.
+
 ```bash
 curl -s -X POST http://localhost:8080/api/v1/buckets \
   -H 'Content-Type: application/json' \

--- a/webui/e2e/buckets.spec.ts
+++ b/webui/e2e/buckets.spec.ts
@@ -19,38 +19,12 @@ const MOCK_SOURCE = {
   created_at: "2024-01-15T10:00:00Z",
 };
 
-const MOCK_SOURCE_HEALTH = {
-  id: MOCK_SOURCE.id,
-  type: MOCK_SOURCE.type,
-  status: "healthy",
-  checked_at: "2024-01-15T10:05:00Z",
-  latency_ms: 25,
-  reason_code: "ok",
-  message: "Google Drive metadata is reachable.",
-  quota_total_bytes: 1024 * 1024,
-  quota_used_bytes: 512 * 1024,
-  quota_free_bytes: 512 * 1024,
-};
-
 const MOCK_DEGRADED_SOURCE = {
   id: "src-2",
   name: "Crowded Drive",
   type: "gdrive",
   key: "k-2",
   created_at: "2024-01-15T10:10:00Z",
-};
-
-const MOCK_DEGRADED_SOURCE_HEALTH = {
-  id: MOCK_DEGRADED_SOURCE.id,
-  type: MOCK_DEGRADED_SOURCE.type,
-  status: "degraded",
-  checked_at: "2024-01-15T10:11:00Z",
-  latency_ms: 31,
-  reason_code: "quota_low",
-  message: "Google Drive quota is nearly exhausted.",
-  quota_total_bytes: 1024 * 1024,
-  quota_used_bytes: 1000 * 1024,
-  quota_free_bytes: 24 * 1024,
 };
 
 const MOCK_UNHEALTHY_SOURCE = {
@@ -61,17 +35,93 @@ const MOCK_UNHEALTHY_SOURCE = {
   created_at: "2024-01-15T10:20:00Z",
 };
 
-const MOCK_UNHEALTHY_SOURCE_HEALTH = {
-  id: MOCK_UNHEALTHY_SOURCE.id,
-  type: MOCK_UNHEALTHY_SOURCE.type,
-  status: "unhealthy",
-  checked_at: "2024-01-15T10:21:00Z",
-  latency_ms: 200,
-  reason_code: "probe_failed",
-  message: "Source health probe failed.",
-  quota_total_bytes: null,
-  quota_used_bytes: null,
-  quota_free_bytes: null,
+const MOCK_READY_PREFLIGHT = {
+  decision: "ready",
+  message: "Selected sources passed the current bucket preflight.",
+  healthy_source_count: 1,
+  degraded_source_count: 0,
+  unhealthy_source_count: 0,
+  near_capacity_source_count: 0,
+  sources: [
+    {
+      source_id: MOCK_SOURCE.id,
+      source_name: MOCK_SOURCE.name,
+      source_type: MOCK_SOURCE.type,
+      status: "healthy",
+      reason_code: "ok",
+      message: "Google Drive metadata is reachable.",
+      quota_total_bytes: 1024 * 1024,
+      quota_used_bytes: 512 * 1024,
+      quota_free_bytes: 512 * 1024,
+      requires_confirmation: false,
+      blocks_creation: false,
+      checked_at: "2024-01-15T10:05:00Z",
+    },
+  ],
+};
+
+const MOCK_CONFIRM_PREFLIGHT = {
+  decision: "confirm_required",
+  message: "Selected sources include degraded or near-capacity providers. Confirm the risk before creating this bucket.",
+  healthy_source_count: 0,
+  degraded_source_count: 1,
+  unhealthy_source_count: 0,
+  near_capacity_source_count: 1,
+  sources: [
+    {
+      source_id: MOCK_DEGRADED_SOURCE.id,
+      source_name: MOCK_DEGRADED_SOURCE.name,
+      source_type: MOCK_DEGRADED_SOURCE.type,
+      status: "degraded",
+      reason_code: "quota_low",
+      message: "Google Drive quota is nearly exhausted.",
+      quota_total_bytes: 1024 * 1024,
+      quota_used_bytes: 1000 * 1024,
+      quota_free_bytes: 24 * 1024,
+      requires_confirmation: true,
+      blocks_creation: false,
+      checked_at: "2024-01-15T10:11:00Z",
+    },
+  ],
+};
+
+const MOCK_BLOCKED_PREFLIGHT = {
+  decision: "blocked",
+  message: "Remove unhealthy sources before creating this bucket.",
+  healthy_source_count: 0,
+  degraded_source_count: 1,
+  unhealthy_source_count: 1,
+  near_capacity_source_count: 1,
+  sources: [
+    {
+      source_id: MOCK_DEGRADED_SOURCE.id,
+      source_name: MOCK_DEGRADED_SOURCE.name,
+      source_type: MOCK_DEGRADED_SOURCE.type,
+      status: "degraded",
+      reason_code: "quota_low",
+      message: "Google Drive quota is nearly exhausted.",
+      quota_total_bytes: 1024 * 1024,
+      quota_used_bytes: 1000 * 1024,
+      quota_free_bytes: 24 * 1024,
+      requires_confirmation: true,
+      blocks_creation: false,
+      checked_at: "2024-01-15T10:11:00Z",
+    },
+    {
+      source_id: MOCK_UNHEALTHY_SOURCE.id,
+      source_name: MOCK_UNHEALTHY_SOURCE.name,
+      source_type: MOCK_UNHEALTHY_SOURCE.type,
+      status: "unhealthy",
+      reason_code: "probe_failed",
+      message: "Source health probe failed.",
+      quota_total_bytes: null,
+      quota_used_bytes: null,
+      quota_free_bytes: null,
+      requires_confirmation: false,
+      blocks_creation: true,
+      checked_at: "2024-01-15T10:21:00Z",
+    },
+  ],
 };
 
 const MOCK_BUCKET = {
@@ -127,7 +177,6 @@ test.describe("Bucket creation flow", () => {
     await injectAuth(page);
     await mockGet(page, "/buckets", []);
     await mockGet(page, "/sources", [MOCK_SOURCE]);
-    await mockGet(page, `/sources/${MOCK_SOURCE.id}/health`, MOCK_SOURCE_HEALTH);
     await page.goto("/buckets");
     const dialog = page.getByRole("dialog");
 
@@ -140,7 +189,6 @@ test.describe("Bucket creation flow", () => {
 
     // Source checkbox should appear after sources load
     await expect(dialog.getByText("My Drive", { exact: true })).toBeVisible();
-    await expect(dialog.getByText("Google Drive metadata is reachable.")).toBeVisible();
   });
 
   test("Create Bucket dialog surfaces source loading failures and retries", async ({ page }) => {
@@ -159,8 +207,6 @@ test.describe("Bucket creation flow", () => {
       }
       await route.fulfill({ status: 200, json: [MOCK_SOURCE] });
     });
-    await mockGet(page, `/sources/${MOCK_SOURCE.id}/health`, MOCK_SOURCE_HEALTH);
-
     await page.goto("/buckets");
     const dialog = page.getByRole("dialog");
 
@@ -172,14 +218,13 @@ test.describe("Bucket creation flow", () => {
 
     await dialog.getByRole("button", { name: "Retry" }).click();
     await expect(dialog.getByText("My Drive", { exact: true })).toBeVisible();
-    await expect(dialog.getByText("Google Drive metadata is reachable.")).toBeVisible();
   });
 
   test("creating a bucket shows S3 credentials", async ({ page }) => {
     await injectAuth(page);
     await mockGet(page, "/buckets", []);
     await mockGet(page, "/sources", [MOCK_SOURCE]);
-    await mockGet(page, `/sources/${MOCK_SOURCE.id}/health`, MOCK_SOURCE_HEALTH);
+    await mockPost(page, "/buckets/preflight", MOCK_READY_PREFLIGHT);
     await mockPost(page, "/buckets", MOCK_BUCKET_CREDS);
 
     await page.goto("/buckets");
@@ -217,12 +262,41 @@ test.describe("Bucket creation flow", () => {
     await expect(page.getByRole("dialog")).not.toBeVisible();
   });
 
-  test("Create Bucket dialog warns about near-capacity and unhealthy sources", async ({ page }) => {
+  test("Create Bucket dialog requires explicit confirmation for degraded sources", async ({ page }) => {
+    await injectAuth(page);
+    await mockGet(page, "/buckets", []);
+    await mockGet(page, "/sources", [MOCK_DEGRADED_SOURCE]);
+    await mockPost(page, "/buckets/preflight", MOCK_CONFIRM_PREFLIGHT);
+    await mockPost(page, "/buckets", {
+      key: "risk-bucket",
+      access_key: "AK999",
+      access_secret: "SK999",
+      created_at: "2024-01-15T11:10:00Z",
+    });
+
+    await page.goto("/buckets");
+    const dialog = page.getByRole("dialog");
+    await page.getByRole("button", { name: /^(Add|Create) Bucket$/ }).first().click();
+    await expect(dialog).toBeVisible();
+
+    await page.getByLabel("Key").fill("risk-bucket");
+    await page.getByLabel("Crowded Drive").check();
+
+    await expect(dialog.getByText("Selected sources include degraded or near-capacity providers. Confirm the risk before creating this bucket.")).toBeVisible();
+    await expect(dialog.getByText("Google Drive quota is nearly exhausted.")).toBeVisible();
+
+    const createButton = dialog.getByRole("button", { name: "Create" });
+    await expect(createButton).toBeDisabled();
+
+    await page.getByLabel("I understand this bucket starts on degraded or near-capacity sources.").check();
+    await expect(createButton).toBeEnabled();
+  });
+
+  test("Create Bucket dialog blocks unhealthy setups", async ({ page }) => {
     await injectAuth(page);
     await mockGet(page, "/buckets", []);
     await mockGet(page, "/sources", [MOCK_DEGRADED_SOURCE, MOCK_UNHEALTHY_SOURCE]);
-    await mockGet(page, `/sources/${MOCK_DEGRADED_SOURCE.id}/health`, MOCK_DEGRADED_SOURCE_HEALTH);
-    await mockGet(page, `/sources/${MOCK_UNHEALTHY_SOURCE.id}/health`, MOCK_UNHEALTHY_SOURCE_HEALTH);
+    await mockPost(page, "/buckets/preflight", MOCK_BLOCKED_PREFLIGHT);
 
     await page.goto("/buckets");
     const dialog = page.getByRole("dialog");
@@ -232,16 +306,14 @@ test.describe("Bucket creation flow", () => {
     await expect(dialog.getByText("Crowded Drive", { exact: true })).toBeVisible();
     await expect(dialog.getByText("Google Drive quota is nearly exhausted.")).toBeVisible();
     await expect(dialog.getByText("Source health probe failed.")).toBeVisible();
+    await expect(dialog.getByText("Remove unhealthy sources before creating this bucket.")).toBeVisible();
 
     await page.getByLabel("Key").fill("risk-bucket");
     await page.getByLabel("Crowded Drive").check();
     await page.getByLabel("Offline Bucket").check();
 
-    await expect(
-      dialog.getByText(
-        "1 selected source is unhealthy, 1 source is near capacity. SFree can create the bucket anyway, but uploads or later reads may fail while those providers remain impaired.",
-      ),
-    ).toBeVisible();
+    await expect(dialog.getByText("blocked")).toBeVisible();
+    await expect(dialog.getByRole("button", { name: "Create" })).toBeDisabled();
   });
 
   test("owner bucket detail shows owner actions", async ({

--- a/webui/e2e/buckets.spec.ts
+++ b/webui/e2e/buckets.spec.ts
@@ -19,6 +19,61 @@ const MOCK_SOURCE = {
   created_at: "2024-01-15T10:00:00Z",
 };
 
+const MOCK_SOURCE_HEALTH = {
+  id: MOCK_SOURCE.id,
+  type: MOCK_SOURCE.type,
+  status: "healthy",
+  checked_at: "2024-01-15T10:05:00Z",
+  latency_ms: 25,
+  reason_code: "ok",
+  message: "Google Drive metadata is reachable.",
+  quota_total_bytes: 1024 * 1024,
+  quota_used_bytes: 512 * 1024,
+  quota_free_bytes: 512 * 1024,
+};
+
+const MOCK_DEGRADED_SOURCE = {
+  id: "src-2",
+  name: "Crowded Drive",
+  type: "gdrive",
+  key: "k-2",
+  created_at: "2024-01-15T10:10:00Z",
+};
+
+const MOCK_DEGRADED_SOURCE_HEALTH = {
+  id: MOCK_DEGRADED_SOURCE.id,
+  type: MOCK_DEGRADED_SOURCE.type,
+  status: "degraded",
+  checked_at: "2024-01-15T10:11:00Z",
+  latency_ms: 31,
+  reason_code: "quota_low",
+  message: "Google Drive quota is nearly exhausted.",
+  quota_total_bytes: 1024 * 1024,
+  quota_used_bytes: 1000 * 1024,
+  quota_free_bytes: 24 * 1024,
+};
+
+const MOCK_UNHEALTHY_SOURCE = {
+  id: "src-3",
+  name: "Offline Bucket",
+  type: "s3",
+  key: "k-3",
+  created_at: "2024-01-15T10:20:00Z",
+};
+
+const MOCK_UNHEALTHY_SOURCE_HEALTH = {
+  id: MOCK_UNHEALTHY_SOURCE.id,
+  type: MOCK_UNHEALTHY_SOURCE.type,
+  status: "unhealthy",
+  checked_at: "2024-01-15T10:21:00Z",
+  latency_ms: 200,
+  reason_code: "probe_failed",
+  message: "Source health probe failed.",
+  quota_total_bytes: null,
+  quota_used_bytes: null,
+  quota_free_bytes: null,
+};
+
 const MOCK_BUCKET = {
   id: "bkt-1",
   key: "my-bucket",
@@ -72,6 +127,7 @@ test.describe("Bucket creation flow", () => {
     await injectAuth(page);
     await mockGet(page, "/buckets", []);
     await mockGet(page, "/sources", [MOCK_SOURCE]);
+    await mockGet(page, `/sources/${MOCK_SOURCE.id}/health`, MOCK_SOURCE_HEALTH);
     await page.goto("/buckets");
     const dialog = page.getByRole("dialog");
 
@@ -84,6 +140,7 @@ test.describe("Bucket creation flow", () => {
 
     // Source checkbox should appear after sources load
     await expect(dialog.getByText("My Drive", { exact: true })).toBeVisible();
+    await expect(dialog.getByText("Google Drive metadata is reachable.")).toBeVisible();
   });
 
   test("Create Bucket dialog surfaces source loading failures and retries", async ({ page }) => {
@@ -102,6 +159,7 @@ test.describe("Bucket creation flow", () => {
       }
       await route.fulfill({ status: 200, json: [MOCK_SOURCE] });
     });
+    await mockGet(page, `/sources/${MOCK_SOURCE.id}/health`, MOCK_SOURCE_HEALTH);
 
     await page.goto("/buckets");
     const dialog = page.getByRole("dialog");
@@ -114,12 +172,14 @@ test.describe("Bucket creation flow", () => {
 
     await dialog.getByRole("button", { name: "Retry" }).click();
     await expect(dialog.getByText("My Drive", { exact: true })).toBeVisible();
+    await expect(dialog.getByText("Google Drive metadata is reachable.")).toBeVisible();
   });
 
   test("creating a bucket shows S3 credentials", async ({ page }) => {
     await injectAuth(page);
     await mockGet(page, "/buckets", []);
     await mockGet(page, "/sources", [MOCK_SOURCE]);
+    await mockGet(page, `/sources/${MOCK_SOURCE.id}/health`, MOCK_SOURCE_HEALTH);
     await mockPost(page, "/buckets", MOCK_BUCKET_CREDS);
 
     await page.goto("/buckets");
@@ -155,6 +215,33 @@ test.describe("Bucket creation flow", () => {
       .last()
       .click();
     await expect(page.getByRole("dialog")).not.toBeVisible();
+  });
+
+  test("Create Bucket dialog warns about near-capacity and unhealthy sources", async ({ page }) => {
+    await injectAuth(page);
+    await mockGet(page, "/buckets", []);
+    await mockGet(page, "/sources", [MOCK_DEGRADED_SOURCE, MOCK_UNHEALTHY_SOURCE]);
+    await mockGet(page, `/sources/${MOCK_DEGRADED_SOURCE.id}/health`, MOCK_DEGRADED_SOURCE_HEALTH);
+    await mockGet(page, `/sources/${MOCK_UNHEALTHY_SOURCE.id}/health`, MOCK_UNHEALTHY_SOURCE_HEALTH);
+
+    await page.goto("/buckets");
+    const dialog = page.getByRole("dialog");
+    await page.getByRole("button", { name: /^(Add|Create) Bucket$/ }).first().click();
+    await expect(dialog).toBeVisible();
+
+    await expect(dialog.getByText("Crowded Drive", { exact: true })).toBeVisible();
+    await expect(dialog.getByText("Google Drive quota is nearly exhausted.")).toBeVisible();
+    await expect(dialog.getByText("Source health probe failed.")).toBeVisible();
+
+    await page.getByLabel("Key").fill("risk-bucket");
+    await page.getByLabel("Crowded Drive").check();
+    await page.getByLabel("Offline Bucket").check();
+
+    await expect(
+      dialog.getByText(
+        "1 selected source is unhealthy, 1 source is near capacity. SFree can create the bucket anyway, but uploads or later reads may fail while those providers remain impaired.",
+      ),
+    ).toBeVisible();
   });
 
   test("owner bucket detail shows owner actions", async ({

--- a/webui/src/features/bucket/ui/create-bucket-dialog.tsx
+++ b/webui/src/features/bucket/ui/create-bucket-dialog.tsx
@@ -1,17 +1,25 @@
-import {Button, Checkbox, CheckboxGroup, Divider, Input, Modal, ModalBody, ModalContent, ModalFooter, ModalHeader, Snippet, Spinner} from "@heroui/react";
+import {Button, Checkbox, CheckboxGroup, Chip, Divider, Input, Modal, ModalBody, ModalContent, ModalFooter, ModalHeader, Snippet, Spinner} from "@heroui/react";
 import {addToast} from "@heroui/toast";
 import {useCallback, useEffect, useMemo, useRef, useState} from "react";
 import {createBucket} from "../../../shared/api/buckets";
-import {listSources} from "../../../shared/api/sources";
-import type {Source} from "../../../shared/api/sources";
+import {getSourceHealth, listSources} from "../../../shared/api/sources";
+import type {Source, SourceHealth} from "../../../shared/api/sources";
 import {showErrorToast} from "../../../shared/api/error";
 import {SourceTypeChip} from "../../../entities/source";
+import {getSourceQuotaState, sourceHealthColor} from "../../../entities/source/lib/capacity";
+import {formatSize} from "../../../shared/lib/format";
 
 type Props = {isOpen: boolean; onOpenChange: (open: boolean) => void; onCreated: () => void};
+
+type HealthState =
+  | {state: "checking"}
+  | {state: "ready"; health: SourceHealth}
+  | {state: "error"; message: string};
 
 export function CreateBucketDialog({isOpen, onOpenChange, onCreated}: Props) {
   const [key, setKey] = useState("");
   const [sources, setSources] = useState<Source[]>([]);
+  const [healthBySource, setHealthBySource] = useState<Record<string, HealthState>>({});
   const [selectedSourceIds, setSelectedSourceIds] = useState<string[]>([]);
   const [creds, setCreds] = useState<{accessKey: string; accessSecret: string} | null>(null);
   const [isLoading, setIsLoading] = useState(false);
@@ -30,9 +38,30 @@ export function CreateBucketDialog({isOpen, onOpenChange, onCreated}: Props) {
       const nextSourceIds = new Set(nextSources.map((source) => source.id));
       setSources(nextSources);
       setSelectedSourceIds((current) => current.filter((id) => nextSourceIds.has(id)));
+      const checking = Object.fromEntries(nextSources.map((source) => [source.id, {state: "checking"} as HealthState]));
+      setHealthBySource(checking);
+      const healthEntries = await Promise.all(
+        nextSources.map(async (source) => {
+          try {
+            const health = await getSourceHealth(source.id);
+            return [source.id, {state: "ready", health} as HealthState] as const;
+          } catch (err) {
+            return [
+              source.id,
+              {
+                state: "error",
+                message: err instanceof Error ? err.message : "Health check failed",
+              } as HealthState,
+            ] as const;
+          }
+        }),
+      );
+      if (sourceLoadRequestId.current !== requestId) return;
+      setHealthBySource(Object.fromEntries(healthEntries));
     } catch (err) {
       if (sourceLoadRequestId.current !== requestId) return;
       setSources([]);
+      setHealthBySource({});
       setSelectedSourceIds([]);
       setSourceLoadError(err instanceof Error ? err.message : "Failed to load sources");
       showErrorToast(err);
@@ -49,18 +78,112 @@ export function CreateBucketDialog({isOpen, onOpenChange, onCreated}: Props) {
   }, [creds, isOpen, loadSources]);
 
   const hasSources = sources.length > 0;
-  const canCreate = key.trim() !== "" && selectedSourceIds.length > 0;
   const helperText = useMemo(() => {
     if (isSourcesLoading) return "Loading sources...";
     if (sourceLoadError) return "Sources could not be loaded. Retry to try again.";
     if (!hasSources) return "Create at least one source before creating a bucket.";
-    return "Choose which sources this bucket is allowed to use for uploads.";
+    return "Choose which sources this bucket is allowed to use for uploads. Each source shows its latest health signal before you create the bucket.";
   }, [hasSources, isSourcesLoading, sourceLoadError]);
 
   const selectedSourceNames = useMemo(
     () => sources.filter((s) => selectedSourceIds.includes(s.id)).map((s) => s.name),
     [sources, selectedSourceIds],
   );
+
+  const selectedHealthSummary = useMemo(() => {
+    const states = selectedSourceIds.map((id) => healthBySource[id]).filter(Boolean);
+    const checkingCount = states.filter((state) => state.state === "checking").length;
+    const errorCount = states.filter((state) => state.state === "error").length;
+    const readyStates = states.filter((state): state is Extract<HealthState, {state: "ready"}> => state.state === "ready");
+    const unhealthyCount = readyStates.filter((state) => state.health.status === "unhealthy").length;
+    const nearCapacityCount = readyStates.filter((state) => state.health.reason_code === "quota_low").length;
+    const degradedCount = readyStates.filter((state) => state.health.status === "degraded" && state.health.reason_code !== "quota_low").length;
+    const healthyCount = readyStates.filter((state) => state.health.status === "healthy").length;
+    return {
+      checkingCount,
+      errorCount,
+      unhealthyCount,
+      nearCapacityCount,
+      degradedCount,
+      healthyCount,
+    };
+  }, [healthBySource, selectedSourceIds]);
+
+  const canCreate = key.trim() !== "" && selectedSourceIds.length > 0 && selectedHealthSummary.checkingCount === 0;
+
+  const selectionStatus = useMemo(() => {
+    if (selectedSourceIds.length === 0) return null;
+    if (selectedHealthSummary.checkingCount > 0) {
+      return {
+        tone: "default" as const,
+        className: "border-default-200 bg-default-50 text-default-600",
+        message:
+          selectedHealthSummary.checkingCount === 1
+            ? "Checking the selected source before bucket creation."
+            : `Checking ${selectedHealthSummary.checkingCount} selected sources before bucket creation.`,
+      };
+    }
+    if (selectedHealthSummary.unhealthyCount > 0) {
+      const parts = [
+        selectedHealthSummary.unhealthyCount === 1
+          ? "1 selected source is unhealthy"
+          : `${selectedHealthSummary.unhealthyCount} selected sources are unhealthy`,
+      ];
+      if (selectedHealthSummary.nearCapacityCount > 0) {
+        parts.push(
+          selectedHealthSummary.nearCapacityCount === 1
+            ? "1 source is near capacity"
+            : `${selectedHealthSummary.nearCapacityCount} sources are near capacity`,
+        );
+      }
+      if (selectedHealthSummary.degradedCount > 0) {
+        parts.push(
+          selectedHealthSummary.degradedCount === 1
+            ? "1 source is degraded"
+            : `${selectedHealthSummary.degradedCount} sources are degraded`,
+        );
+      }
+      return {
+        tone: "danger" as const,
+        className: "border-danger-200 bg-danger-50 text-danger-700",
+        message: `${parts.join(", ")}. SFree can create the bucket anyway, but uploads or later reads may fail while those providers remain impaired.`,
+      };
+    }
+    if (selectedHealthSummary.nearCapacityCount > 0 || selectedHealthSummary.degradedCount > 0 || selectedHealthSummary.errorCount > 0) {
+      const parts: string[] = [];
+      if (selectedHealthSummary.nearCapacityCount > 0) {
+        parts.push(
+          selectedHealthSummary.nearCapacityCount === 1
+            ? "1 selected source is near capacity"
+            : `${selectedHealthSummary.nearCapacityCount} selected sources are near capacity`,
+        );
+      }
+      if (selectedHealthSummary.degradedCount > 0) {
+        parts.push(
+          selectedHealthSummary.degradedCount === 1
+            ? "1 selected source is degraded"
+            : `${selectedHealthSummary.degradedCount} selected sources are degraded`,
+        );
+      }
+      if (selectedHealthSummary.errorCount > 0) {
+        parts.push(
+          selectedHealthSummary.errorCount === 1
+            ? "1 selected source could not be checked"
+            : `${selectedHealthSummary.errorCount} selected sources could not be checked`,
+        );
+      }
+      return {
+        tone: "warning" as const,
+        className: "border-warning-200 bg-warning-50 text-warning-700",
+        message: `${parts.join(", ")}. Bucket creation is still allowed, but the current source signal is not fully healthy.`,
+      };
+    }
+    return {
+      tone: "success" as const,
+      className: "border-success-200 bg-success-50 text-success-700",
+      message: "Selected sources currently report healthy reachability. SFree still does not replicate chunks automatically across all sources.",
+    };
+  }, [selectedHealthSummary, selectedSourceIds.length]);
 
   return (
     <Modal
@@ -70,6 +193,7 @@ export function CreateBucketDialog({isOpen, onOpenChange, onCreated}: Props) {
           sourceLoadRequestId.current += 1;
           setKey("");
           setSources([]);
+          setHealthBySource({});
           setSelectedSourceIds([]);
           setCreds(null);
           setIsSourcesLoading(false);
@@ -124,18 +248,22 @@ export function CreateBucketDialog({isOpen, onOpenChange, onCreated}: Props) {
                         >
                           {sources.map((source) => (
                             <Checkbox key={source.id} value={source.id} classNames={{base: "max-w-full"}}>
-                              <div className="flex items-center gap-2">
-                                <span>{source.name}</span>
-                                <SourceTypeChip type={source.type} />
+                              <div className="flex flex-col gap-1 py-1">
+                                <div className="flex flex-wrap items-center gap-2">
+                                  <span>{source.name}</span>
+                                  <SourceTypeChip type={source.type} />
+                                  <SourceHealthChip state={healthBySource[source.id]} />
+                                </div>
+                                <SourceHealthDetail state={healthBySource[source.id]} />
                               </div>
                             </Checkbox>
                           ))}
                         </CheckboxGroup>
-                        <div className="rounded-lg border border-warning-200 bg-warning-50 p-3">
-                          <p className="text-sm text-warning-700">
-                            SFree distributes file chunks across your selected sources but does not replicate them. If an upstream source becomes unavailable, affected files may be unrecoverable.
-                          </p>
-                        </div>
+                        {selectionStatus ? (
+                          <div className={`rounded-lg border p-3 ${selectionStatus.className}`}>
+                            <p className="text-sm">{selectionStatus.message}</p>
+                          </div>
+                        ) : null}
                       </>
                     ) : null}
                   </div>
@@ -189,6 +317,39 @@ export function CreateBucketDialog({isOpen, onOpenChange, onCreated}: Props) {
       </ModalContent>
     </Modal>
   );
+}
+
+function SourceHealthChip({state}: {state: HealthState | undefined}) {
+  if (!state || state.state === "checking") {
+    return <Chip size="sm" variant="flat" color="default">Checking</Chip>;
+  }
+  if (state.state === "error") {
+    return <Chip size="sm" variant="flat" color="danger">Check failed</Chip>;
+  }
+  return (
+    <Chip size="sm" variant="flat" color={sourceHealthColor[state.health.status]}>
+      {state.health.status}
+    </Chip>
+  );
+}
+
+function SourceHealthDetail({state}: {state: HealthState | undefined}) {
+  if (!state || state.state === "checking") {
+    return <p className="text-xs text-default-400">Checking source health and capacity signal...</p>;
+  }
+  if (state.state === "error") {
+    return <p className="text-xs text-danger">{state.message}</p>;
+  }
+
+  const quota = getSourceQuotaState(state.health);
+  const detailParts = [state.health.message];
+  if (quota.kind === "available") {
+    detailParts.push(`${formatSize(quota.freeBytes)} free of ${formatSize(quota.totalBytes)}`);
+  } else if (state.health.type === "s3" || state.health.type === "telegram") {
+    detailParts.push(quota.description);
+  }
+
+  return <p className="text-xs text-default-500">{detailParts.join(" ")}</p>;
 }
 
 function CredentialsView({accessKey, accessSecret}: {accessKey: string; accessSecret: string}) {

--- a/webui/src/features/bucket/ui/create-bucket-dialog.tsx
+++ b/webui/src/features/bucket/ui/create-bucket-dialog.tsx
@@ -1,31 +1,31 @@
 import {Button, Checkbox, CheckboxGroup, Chip, Divider, Input, Modal, ModalBody, ModalContent, ModalFooter, ModalHeader, Snippet, Spinner} from "@heroui/react";
 import {addToast} from "@heroui/toast";
 import {useCallback, useEffect, useMemo, useRef, useState} from "react";
-import {createBucket} from "../../../shared/api/buckets";
-import {getSourceHealth, listSources} from "../../../shared/api/sources";
-import type {Source, SourceHealth} from "../../../shared/api/sources";
-import {showErrorToast} from "../../../shared/api/error";
+import {createBucket, preflightBucket} from "../../../shared/api/buckets";
+import type {BucketPreflight, BucketPreflightSource} from "../../../shared/api/buckets";
+import {listSources} from "../../../shared/api/sources";
+import type {Source} from "../../../shared/api/sources";
+import {ApiError, showErrorToast} from "../../../shared/api/error";
 import {SourceTypeChip} from "../../../entities/source";
-import {getSourceQuotaState, sourceHealthColor} from "../../../entities/source/lib/capacity";
+import {sourceHealthColor} from "../../../entities/source/lib/capacity";
 import {formatSize} from "../../../shared/lib/format";
 
 type Props = {isOpen: boolean; onOpenChange: (open: boolean) => void; onCreated: () => void};
 
-type HealthState =
-  | {state: "checking"}
-  | {state: "ready"; health: SourceHealth}
-  | {state: "error"; message: string};
-
 export function CreateBucketDialog({isOpen, onOpenChange, onCreated}: Props) {
   const [key, setKey] = useState("");
   const [sources, setSources] = useState<Source[]>([]);
-  const [healthBySource, setHealthBySource] = useState<Record<string, HealthState>>({});
   const [selectedSourceIds, setSelectedSourceIds] = useState<string[]>([]);
+  const [preflight, setPreflight] = useState<BucketPreflight | null>(null);
+  const [riskAcknowledged, setRiskAcknowledged] = useState(false);
   const [creds, setCreds] = useState<{accessKey: string; accessSecret: string} | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [isSourcesLoading, setIsSourcesLoading] = useState(false);
+  const [isPreflightLoading, setIsPreflightLoading] = useState(false);
   const [sourceLoadError, setSourceLoadError] = useState<string | null>(null);
+  const [preflightError, setPreflightError] = useState<string | null>(null);
   const sourceLoadRequestId = useRef(0);
+  const preflightRequestId = useRef(0);
 
   const loadSources = useCallback(async () => {
     const requestId = sourceLoadRequestId.current + 1;
@@ -38,30 +38,9 @@ export function CreateBucketDialog({isOpen, onOpenChange, onCreated}: Props) {
       const nextSourceIds = new Set(nextSources.map((source) => source.id));
       setSources(nextSources);
       setSelectedSourceIds((current) => current.filter((id) => nextSourceIds.has(id)));
-      const checking = Object.fromEntries(nextSources.map((source) => [source.id, {state: "checking"} as HealthState]));
-      setHealthBySource(checking);
-      const healthEntries = await Promise.all(
-        nextSources.map(async (source) => {
-          try {
-            const health = await getSourceHealth(source.id);
-            return [source.id, {state: "ready", health} as HealthState] as const;
-          } catch (err) {
-            return [
-              source.id,
-              {
-                state: "error",
-                message: err instanceof Error ? err.message : "Health check failed",
-              } as HealthState,
-            ] as const;
-          }
-        }),
-      );
-      if (sourceLoadRequestId.current !== requestId) return;
-      setHealthBySource(Object.fromEntries(healthEntries));
     } catch (err) {
       if (sourceLoadRequestId.current !== requestId) return;
       setSources([]);
-      setHealthBySource({});
       setSelectedSourceIds([]);
       setSourceLoadError(err instanceof Error ? err.message : "Failed to load sources");
       showErrorToast(err);
@@ -72,17 +51,50 @@ export function CreateBucketDialog({isOpen, onOpenChange, onCreated}: Props) {
     }
   }, []);
 
+  const loadPreflight = useCallback(async (sourceIds: string[]) => {
+    const requestId = preflightRequestId.current + 1;
+    preflightRequestId.current = requestId;
+    setIsPreflightLoading(true);
+    setPreflightError(null);
+    try {
+      const nextPreflight = await preflightBucket(sourceIds);
+      if (preflightRequestId.current !== requestId) return;
+      setPreflight(nextPreflight);
+    } catch (err) {
+      if (preflightRequestId.current !== requestId) return;
+      setPreflight(null);
+      setPreflightError(err instanceof Error ? err.message : "Failed to preflight bucket creation");
+    } finally {
+      if (preflightRequestId.current === requestId) {
+        setIsPreflightLoading(false);
+      }
+    }
+  }, []);
+
   useEffect(() => {
     if (!isOpen || creds) return;
     void loadSources();
   }, [creds, isOpen, loadSources]);
+
+  useEffect(() => {
+    if (!isOpen || creds) return;
+    setRiskAcknowledged(false);
+    if (selectedSourceIds.length === 0) {
+      preflightRequestId.current += 1;
+      setIsPreflightLoading(false);
+      setPreflight(null);
+      setPreflightError(null);
+      return;
+    }
+    void loadPreflight(selectedSourceIds);
+  }, [creds, isOpen, loadPreflight, selectedSourceIds]);
 
   const hasSources = sources.length > 0;
   const helperText = useMemo(() => {
     if (isSourcesLoading) return "Loading sources...";
     if (sourceLoadError) return "Sources could not be loaded. Retry to try again.";
     if (!hasSources) return "Create at least one source before creating a bucket.";
-    return "Choose which sources this bucket is allowed to use for uploads. Each source shows its latest health signal before you create the bucket.";
+    return "Choose which sources this bucket is allowed to use for uploads. SFree will preflight the selected sources before creation.";
   }, [hasSources, isSourcesLoading, sourceLoadError]);
 
   const selectedSourceNames = useMemo(
@@ -90,100 +102,46 @@ export function CreateBucketDialog({isOpen, onOpenChange, onCreated}: Props) {
     [sources, selectedSourceIds],
   );
 
-  const selectedHealthSummary = useMemo(() => {
-    const states = selectedSourceIds.map((id) => healthBySource[id]).filter(Boolean);
-    const checkingCount = states.filter((state) => state.state === "checking").length;
-    const errorCount = states.filter((state) => state.state === "error").length;
-    const readyStates = states.filter((state): state is Extract<HealthState, {state: "ready"}> => state.state === "ready");
-    const unhealthyCount = readyStates.filter((state) => state.health.status === "unhealthy").length;
-    const nearCapacityCount = readyStates.filter((state) => state.health.reason_code === "quota_low").length;
-    const degradedCount = readyStates.filter((state) => state.health.status === "degraded" && state.health.reason_code !== "quota_low").length;
-    const healthyCount = readyStates.filter((state) => state.health.status === "healthy").length;
-    return {
-      checkingCount,
-      errorCount,
-      unhealthyCount,
-      nearCapacityCount,
-      degradedCount,
-      healthyCount,
-    };
-  }, [healthBySource, selectedSourceIds]);
+  const canCreate = key.trim() !== ""
+    && selectedSourceIds.length > 0
+    && !isSourcesLoading
+    && !isPreflightLoading
+    && preflight !== null
+    && preflightError === null
+    && (preflight.decision === "ready" || (preflight.decision === "confirm_required" && riskAcknowledged));
 
-  const canCreate = key.trim() !== "" && selectedSourceIds.length > 0 && selectedHealthSummary.checkingCount === 0;
-
-  const selectionStatus = useMemo(() => {
+  const preflightState = useMemo(() => {
     if (selectedSourceIds.length === 0) return null;
-    if (selectedHealthSummary.checkingCount > 0) {
+    if (isPreflightLoading) {
       return {
-        tone: "default" as const,
         className: "border-default-200 bg-default-50 text-default-600",
-        message:
-          selectedHealthSummary.checkingCount === 1
-            ? "Checking the selected source before bucket creation."
-            : `Checking ${selectedHealthSummary.checkingCount} selected sources before bucket creation.`,
+        message: "Checking the selected sources before bucket creation.",
       };
     }
-    if (selectedHealthSummary.unhealthyCount > 0) {
-      const parts = [
-        selectedHealthSummary.unhealthyCount === 1
-          ? "1 selected source is unhealthy"
-          : `${selectedHealthSummary.unhealthyCount} selected sources are unhealthy`,
-      ];
-      if (selectedHealthSummary.nearCapacityCount > 0) {
-        parts.push(
-          selectedHealthSummary.nearCapacityCount === 1
-            ? "1 source is near capacity"
-            : `${selectedHealthSummary.nearCapacityCount} sources are near capacity`,
-        );
-      }
-      if (selectedHealthSummary.degradedCount > 0) {
-        parts.push(
-          selectedHealthSummary.degradedCount === 1
-            ? "1 source is degraded"
-            : `${selectedHealthSummary.degradedCount} sources are degraded`,
-        );
-      }
+    if (preflightError) {
       return {
-        tone: "danger" as const,
         className: "border-danger-200 bg-danger-50 text-danger-700",
-        message: `${parts.join(", ")}. SFree can create the bucket anyway, but uploads or later reads may fail while those providers remain impaired.`,
+        message: preflightError,
       };
     }
-    if (selectedHealthSummary.nearCapacityCount > 0 || selectedHealthSummary.degradedCount > 0 || selectedHealthSummary.errorCount > 0) {
-      const parts: string[] = [];
-      if (selectedHealthSummary.nearCapacityCount > 0) {
-        parts.push(
-          selectedHealthSummary.nearCapacityCount === 1
-            ? "1 selected source is near capacity"
-            : `${selectedHealthSummary.nearCapacityCount} selected sources are near capacity`,
-        );
-      }
-      if (selectedHealthSummary.degradedCount > 0) {
-        parts.push(
-          selectedHealthSummary.degradedCount === 1
-            ? "1 selected source is degraded"
-            : `${selectedHealthSummary.degradedCount} selected sources are degraded`,
-        );
-      }
-      if (selectedHealthSummary.errorCount > 0) {
-        parts.push(
-          selectedHealthSummary.errorCount === 1
-            ? "1 selected source could not be checked"
-            : `${selectedHealthSummary.errorCount} selected sources could not be checked`,
-        );
-      }
+    if (!preflight) return null;
+    if (preflight.decision === "blocked") {
       return {
-        tone: "warning" as const,
+        className: "border-danger-200 bg-danger-50 text-danger-700",
+        message: preflight.message,
+      };
+    }
+    if (preflight.decision === "confirm_required") {
+      return {
         className: "border-warning-200 bg-warning-50 text-warning-700",
-        message: `${parts.join(", ")}. Bucket creation is still allowed, but the current source signal is not fully healthy.`,
+        message: preflight.message,
       };
     }
     return {
-      tone: "success" as const,
       className: "border-success-200 bg-success-50 text-success-700",
-      message: "Selected sources currently report healthy reachability. SFree still does not replicate chunks automatically across all sources.",
+      message: preflight.message,
     };
-  }, [selectedHealthSummary, selectedSourceIds.length]);
+  }, [isPreflightLoading, preflight, preflightError, selectedSourceIds.length]);
 
   return (
     <Modal
@@ -191,13 +149,17 @@ export function CreateBucketDialog({isOpen, onOpenChange, onCreated}: Props) {
       onOpenChange={(open) => {
         if (!open) {
           sourceLoadRequestId.current += 1;
+          preflightRequestId.current += 1;
           setKey("");
           setSources([]);
-          setHealthBySource({});
           setSelectedSourceIds([]);
+          setPreflight(null);
+          setRiskAcknowledged(false);
           setCreds(null);
           setIsSourcesLoading(false);
+          setIsPreflightLoading(false);
           setSourceLoadError(null);
+          setPreflightError(null);
         }
         onOpenChange(open);
       }}
@@ -248,21 +210,30 @@ export function CreateBucketDialog({isOpen, onOpenChange, onCreated}: Props) {
                         >
                           {sources.map((source) => (
                             <Checkbox key={source.id} value={source.id} classNames={{base: "max-w-full"}}>
-                              <div className="flex flex-col gap-1 py-1">
-                                <div className="flex flex-wrap items-center gap-2">
-                                  <span>{source.name}</span>
-                                  <SourceTypeChip type={source.type} />
-                                  <SourceHealthChip state={healthBySource[source.id]} />
-                                </div>
-                                <SourceHealthDetail state={healthBySource[source.id]} />
+                              <div className="flex flex-wrap items-center gap-2 py-1">
+                                <span>{source.name}</span>
+                                <SourceTypeChip type={source.type} />
                               </div>
                             </Checkbox>
                           ))}
                         </CheckboxGroup>
-                        {selectionStatus ? (
-                          <div className={`rounded-lg border p-3 ${selectionStatus.className}`}>
-                            <p className="text-sm">{selectionStatus.message}</p>
+                        {preflightState ? (
+                          <div className={`rounded-lg border p-3 ${preflightState.className}`}>
+                            <p className="text-sm">{preflightState.message}</p>
                           </div>
+                        ) : null}
+                        {preflightError && selectedSourceIds.length > 0 ? (
+                          <Button size="sm" variant="flat" onPress={() => void loadPreflight(selectedSourceIds)}>
+                            Retry preflight
+                          </Button>
+                        ) : null}
+                        {preflight ? (
+                          <PreflightDetails preflight={preflight} />
+                        ) : null}
+                        {preflight?.decision === "confirm_required" ? (
+                          <Checkbox isSelected={riskAcknowledged} onValueChange={setRiskAcknowledged}>
+                            I understand this bucket starts on degraded or near-capacity sources.
+                          </Checkbox>
                         ) : null}
                       </>
                     ) : null}
@@ -291,17 +262,20 @@ export function CreateBucketDialog({isOpen, onOpenChange, onCreated}: Props) {
               ) : (
                 <Button
                   color="primary"
-                  isDisabled={!canCreate || isSourcesLoading}
+                  isDisabled={!canCreate}
                   isLoading={isLoading}
                   onPress={async () => {
                     setIsLoading(true);
                     try {
                       const trimmedKey = key.trim();
-                      const res = await createBucket(trimmedKey, selectedSourceIds);
+                      const res = await createBucket(trimmedKey, selectedSourceIds, riskAcknowledged);
                       setCreds({accessKey: res.access_key, accessSecret: res.access_secret});
                       addToast({title: "Bucket created", description: `${trimmedKey} is ready`, color: "success", timeout: 4000});
                       onCreated();
                     } catch (err) {
+                      if (err instanceof ApiError && err.status === 409) {
+                        void loadPreflight(selectedSourceIds);
+                      }
                       showErrorToast(err);
                     } finally {
                       setIsLoading(false);
@@ -319,37 +293,46 @@ export function CreateBucketDialog({isOpen, onOpenChange, onCreated}: Props) {
   );
 }
 
-function SourceHealthChip({state}: {state: HealthState | undefined}) {
-  if (!state || state.state === "checking") {
-    return <Chip size="sm" variant="flat" color="default">Checking</Chip>;
-  }
-  if (state.state === "error") {
-    return <Chip size="sm" variant="flat" color="danger">Check failed</Chip>;
-  }
+function PreflightDetails({preflight}: {preflight: BucketPreflight}) {
   return (
-    <Chip size="sm" variant="flat" color={sourceHealthColor[state.health.status]}>
-      {state.health.status}
-    </Chip>
+    <div className="flex flex-col gap-3 rounded-lg border border-default-200 bg-default-50 p-3">
+      <p className="text-sm font-medium">Selected source preflight</p>
+      <div className="flex flex-wrap gap-2 text-xs text-default-500">
+        <span>{preflight.healthy_source_count} healthy</span>
+        <span>{preflight.degraded_source_count} degraded</span>
+        <span>{preflight.near_capacity_source_count} near capacity</span>
+        <span>{preflight.unhealthy_source_count} unhealthy</span>
+      </div>
+      <div className="flex flex-col gap-2">
+        {preflight.sources.map((source) => (
+          <div key={source.source_id} className="rounded-md border border-default-200 bg-background px-3 py-2">
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="font-medium text-sm">{source.source_name}</span>
+              <SourceTypeChip type={source.source_type} />
+              <Chip size="sm" variant="flat" color={sourceHealthColor[source.status]}>
+                {source.status}
+              </Chip>
+              {source.blocks_creation ? <Chip size="sm" variant="flat" color="danger">blocked</Chip> : null}
+              {!source.blocks_creation && source.requires_confirmation ? <Chip size="sm" variant="flat" color="warning">confirm</Chip> : null}
+            </div>
+            <p className="mt-1 text-xs text-default-500">{sourceDetail(source)}</p>
+          </div>
+        ))}
+      </div>
+    </div>
   );
 }
 
-function SourceHealthDetail({state}: {state: HealthState | undefined}) {
-  if (!state || state.state === "checking") {
-    return <p className="text-xs text-default-400">Checking source health and capacity signal...</p>;
+function sourceDetail(source: BucketPreflightSource): string {
+  const parts = [source.message];
+  if (source.quota_total_bytes !== null && source.quota_free_bytes !== null) {
+    parts.push(`${formatSize(Math.max(0, source.quota_free_bytes))} free of ${formatSize(source.quota_total_bytes)}`);
+  } else if (source.source_type === "s3") {
+    parts.push("S3-compatible sources are checked for reachability here, not provider-wide capacity limits.");
+  } else if (source.source_type === "telegram") {
+    parts.push("Telegram sources do not expose native quota metadata to SFree.");
   }
-  if (state.state === "error") {
-    return <p className="text-xs text-danger">{state.message}</p>;
-  }
-
-  const quota = getSourceQuotaState(state.health);
-  const detailParts = [state.health.message];
-  if (quota.kind === "available") {
-    detailParts.push(`${formatSize(quota.freeBytes)} free of ${formatSize(quota.totalBytes)}`);
-  } else if (state.health.type === "s3" || state.health.type === "telegram") {
-    detailParts.push(quota.description);
-  }
-
-  return <p className="text-xs text-default-500">{detailParts.join(" ")}</p>;
+  return parts.join(" ");
 }
 
 function CredentialsView({accessKey, accessSecret}: {accessKey: string; accessSecret: string}) {

--- a/webui/src/shared/api/buckets.ts
+++ b/webui/src/shared/api/buckets.ts
@@ -52,6 +52,33 @@ type CreateBucketResponse = {
   created_at: string;
 };
 
+export type BucketPreflightDecision = "ready" | "confirm_required" | "blocked";
+
+export type BucketPreflightSource = {
+  source_id: string;
+  source_name: string;
+  source_type: string;
+  status: "healthy" | "degraded" | "unhealthy";
+  reason_code: string;
+  message: string;
+  quota_total_bytes: number | null;
+  quota_used_bytes: number | null;
+  quota_free_bytes: number | null;
+  requires_confirmation: boolean;
+  blocks_creation: boolean;
+  checked_at: string;
+};
+
+export type BucketPreflight = {
+  decision: BucketPreflightDecision;
+  message: string;
+  healthy_source_count: number;
+  degraded_source_count: number;
+  unhealthy_source_count: number;
+  near_capacity_source_count: number;
+  sources: BucketPreflightSource[];
+};
+
 export async function listBuckets(): Promise<Bucket[]> {
   return apiJson<Bucket[]>("/buckets", "Failed to list buckets");
 }
@@ -63,11 +90,25 @@ export async function getBucket(id: string): Promise<Bucket> {
 export async function createBucket(
   key: string,
   sourceIds: string[],
+  riskAcknowledged = false,
 ): Promise<CreateBucketResponse> {
   return apiJson<CreateBucketResponse>("/buckets", "Failed to create bucket", {
     method: "POST",
-    json: {key, source_ids: sourceIds},
+    json: {key, source_ids: sourceIds, risk_acknowledged: riskAcknowledged},
   });
+}
+
+export async function preflightBucket(
+  sourceIds: string[],
+): Promise<BucketPreflight> {
+  return apiJson<BucketPreflight>(
+    "/buckets/preflight",
+    "Failed to preflight bucket creation",
+    {
+      method: "POST",
+      json: {source_ids: sourceIds},
+    },
+  );
 }
 
 function bucketFilesPath(bucketId: string, query?: string): string {


### PR DESCRIPTION
## What changed
- added a server-backed `POST /api/v1/buckets/preflight` contract that evaluates the selected sources and returns `ready`, `confirm_required`, or `blocked`
- enforced the same preflight decision inside `POST /api/v1/buckets`, so unhealthy sources are blocked and degraded or near-capacity sources require explicit acknowledgement
- rewired the Create Bucket dialog to preflight only the selected sources instead of faning out health checks for every source in the account
- updated the tracked Playwright coverage, handler/router tests, generated OpenAPI docs, quickstart docs, and the CLI payload to support explicit risk acknowledgement

## Why
The original UI-only patch surfaced health signals, but it did not give the API and UI a shared contract for when bucket creation is allowed, confirmable, or blocked. The issue explicitly calls for a bounded health-aware bucket-creation model that the backend, browser UI, and docs all describe consistently.

## Impact
Bucket setup is now honest in both directions:
- clearly unsafe selections are blocked at the API and UI layers
- degraded or near-capacity selections require an explicit operator acknowledgement
- healthy selections still create normally
- the browser no longer blocks creation on unrelated slow health probes for unselected sources

## Validation
- `eslint src/features/bucket/ui/create-bucket-dialog.tsx e2e/buckets.spec.ts src/shared/api/buckets.ts`
- `tsc --noEmit -p tsconfig.app.json`
- `tsc --noEmit -p tsconfig.node.json`
- `go test ./internal/app ./internal/handlers ./cmd/sfree-cli`
- `go run github.com/swaggo/swag/cmd/swag@v1.16.4 init --generalInfo cmd/server/main.go --dir . --output internal/docs --outputTypes go --parseInternal --quiet`
