### PR TITLE
Align launch checklist with live GitHub repo presentation

### DIFF
--- a/docs/launch-campaign.md
+++ b/docs/launch-campaign.md
@@ -217,9 +217,13 @@ based on early reactions.
 - [ ] README Quick Start verified end-to-end (fresh clone to running)
 - [ ] API docs accessible and accurate
 - [ ] Docker Compose brings up a working instance
-- [ ] GitHub repo has: description, topics, license badge, social preview image
-- [ ] GitHub topics set: `storage`, `s3`, `self-hosted`, `google-drive`,
-      `telegram`, `homelab`, `object-storage`, `golang`
+- [x] GitHub repo description is live and matches the current prototype caveats
+- [x] GitHub topics are set intentionally for launch discovery (`storage`, `s3`,
+      `self-hosted`, `google-drive`, `telegram`, `homelab`,
+      `object-storage`, `golang`, plus closely related supporting topics)
+- [x] GitHub repo license badge is visible in README
+- [ ] GitHub social preview image is uploaded in repo Settings and matches the
+      README/launch visuals
 
 ---
 


### PR DESCRIPTION
## Summary
- align the launch checklist with the repo description, topics, and README license badge that are already live
- leave the social preview item explicitly unchecked because GitHub still requires a manual Settings upload

## Why
The public repo page changed, but the internal launch checklist still grouped repo presentation items together as incomplete. This PR makes the checklist honest about what is already done and what still needs manual GitHub UI work.

## Validation
- confirmed live repo description on GitHub
- confirmed live repo topics on GitHub
- confirmed README still shows the MIT license badge
- confirmed no social preview image is configured yet on GitHub